### PR TITLE
[MOD-17848] Use RETURN-STRICT for query timeouts by default (Future PR)

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -109,6 +109,7 @@ typedef struct {
 bool RunInThread(RedisModuleCtx *ctx);
 
 typedef void (*profiler_func)(RedisModule_Reply *reply, void *ctx);
+typedef void (*profile_collector_func)(void *ctx);
 
 typedef enum {
   /* Pipeline has a loader */
@@ -213,6 +214,10 @@ typedef struct AREQ {
   size_t prefixesOffset;
 
   ProfilePrinterCtx profileCtx;
+
+  // Optional execution-thread hook that finishes collecting profile data before
+  // a deferred reply is handed to the main thread for serialization.
+  profile_collector_func profileCollect;
 
 } AREQ;
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -724,6 +724,26 @@ static bool shouldSetCursorDone(AREQ *req, int rc) {
   return true;
 }
 
+static void collectProfileDataForReply(AREQ *req, QueryProcessingCtx *qctx, int rc) {
+  if (!req->profileCollect || !IsProfile(req) || AREQ_TimedOut(req)) {
+    return;
+  }
+
+  // Error-only replies do not contain a profile section.
+  if (ShouldReplyWithError(QueryError_GetCode(qctx->err), req->reqConfig.timeoutPolicy,
+                           IsProfile(req)) ||
+      ShouldReplyWithTimeoutError(rc, req->reqConfig.timeoutPolicy, IsProfile(req))) {
+    return;
+  }
+
+  // Cursor replies contain profile data only when the cursor is exhausted.
+  if ((AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) && !shouldSetCursorDone(req, rc)) {
+    return;
+  }
+
+  req->profileCollect(req);
+}
+
 /**
  * Serializes results and handles the main reply logic for RESP2.
  * Returns the final rc value and updates state accordingly.
@@ -786,9 +806,10 @@ done_2:
  * strict timeout callback may serialize them on the main thread the moment it
  * wakes, and must not observe this cycle's dying ctx through sctx->redisCtx.
  * The pipeline is done with the ctx once it reaches here. */
-static void storeResultsForReplyCallback(AREQ *req, SearchResult *r, SearchResult **results,
-                                         int rc, cachedVars cv, size_t limit) {
+static void storeResultsForReplyCallback(AREQ *req, SearchResult *r, SearchResult **results, int rc,
+                                         cachedVars cv, size_t limit) {
   if (!req->base.async.aggregateResultsClaimLost) {
+    collectProfileDataForReply(req, AREQ_QueryProcessingCtx(req), rc);
     AREQ_SearchCtx(req)->redisCtx = NULL;
     debugPauseStoreResults(req, true);  // pause before
     AREQ_StoreResults(req, results, rc, cv, limit);

--- a/src/config.c
+++ b/src/config.c
@@ -1693,7 +1693,8 @@ RSConfigOptions RSGlobalConfigOptions = {
          .setValue = setDefaultScorer,
          .getValue = getDefaultScorer},
         {.name = "ON_TIMEOUT",
-         .helpText = "Action to perform when search timeout is exceeded (choose RETURN or FAIL)",
+         .helpText = "Action to perform when search timeout is exceeded (choose RETURN, "
+                     "RETURN-STRICT, or FAIL)",
          .setValue = setOnTimeout,
          .getValue = getOnTimeout},
         {.name = "GCSCANSIZE",

--- a/src/config.h
+++ b/src/config.h
@@ -373,7 +373,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 // longer, so they get a higher timeout, and time out with an error instead
 // of returning partial results.
 #define DEFAULT_QUERY_TIMEOUT_MS_FLEX 5000
-#define DEFAULT_TIMEOUT_POLICY TimeoutPolicy_Return
+#define DEFAULT_TIMEOUT_POLICY TimeoutPolicy_ReturnStrict
 #define DEFAULT_TIMEOUT_POLICY_FLEX TimeoutPolicy_Fail
 #define DEFAULT_MAX_FOREGROUND_TIMEOUT_LIMIT_MS 60000
 #define DEFAULT_UNION_ITERATOR_HEAP 20

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -704,31 +704,49 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us
 
 void PrintShardProfile(RedisModule_Reply *reply, void *ctx);
 
-void printAggProfile(RedisModule_Reply *reply, void *ctx) {
-  // profileRP replace netRP as end PR
+static void collectAggProfile(void *ctx) {
   AREQ *req = ctx;
   RPNet *rpnet = (RPNet *)AREQ_QueryProcessingCtx(req)->rootProc;
-  // Calling getNextReply alone is insufficient here, as we might have already encountered EOF from the shards,
-  // which caused the call to getNextReply from RPNet to set cond->wait to true.
-  // We can't also set cond->wait to false because we might still be waiting for shards' replies containing profile information.
+  // Calling getNextReply alone is insufficient here, as we might have already encountered EOF from
+  // the shards, which caused the call to getNextReply from RPNet to set cond->wait to true. We
+  // can't also set cond->wait to false because we might still be waiting for shards' replies
+  // containing profile information.
 
   // Therefore, we loop to drain all remaining replies from the channel.
   // Pending might be zero, but there might still be replies in the channel to read.
   // We may have pulled all the replies from the channel and arrived here due to a timeout,
   // and now we're waiting for the profile results.
-  if (MRIterator_GetPending(rpnet->it) || MRIterator_GetChannelSize(rpnet->it)) {
-    do {
-      MRReply_Free(rpnet->current.root);
-    } while (getNextReply(rpnet) != RS_RESULT_EOF);
+  while (MRIterator_GetPending(rpnet->it) || MRIterator_GetChannelSize(rpnet->it)) {
+    // A blocked-client timeout callback owns Redis's main thread, so leave any
+    // queued replies for its nonblocking drain instead of waiting for shards.
+    if (AREQ_TimedOut(req) && !rpnet->drainOnly) {
+      return;
+    }
+    MRReply_Free(rpnet->current.root);
+    if (getNextReply(rpnet) != RS_RESULT_OK) {
+      return;
+    }
   }
+}
+
+void printAggProfile(RedisModule_Reply *reply, void *ctx) {
+  AREQ *req = ctx;
+  RPNet *rpnet = (RPNet *)AREQ_QueryProcessingCtx(req)->rootProc;
+
+  // Inline execution still collects here. Deferred execution normally did so
+  // on its worker; after a timeout, drain only replies already in the channel.
+  if (AREQ_TimedOut(req)) {
+    rpnet->drainOnly = true;
+  }
+  collectAggProfile(req);
 
   size_t num_shards = MRIterator_GetNumShards(rpnet->it);
   size_t profile_count = array_len(rpnet->shardsProfile);
 
   PrintShardProfile_ctx sCtx = {
-    .count = profile_count,
-    .replies = rpnet->shardsProfile,
-    .isSearch = false,
+      .count = profile_count,
+      .replies = rpnet->shardsProfile,
+      .isSearch = false,
   };
 
   if (profile_count != num_shards) {
@@ -805,6 +823,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   }
 
   r->profile = printAggProfile;
+  r->profileCollect = collectAggProfile;
 
   unsigned int dialect = r->reqConfig.dialectVersion;
   specialCaseCtx *knnCtx = NULL;

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -649,15 +649,11 @@ void serializeStoredResults_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
     // Create a stack-allocated SearchResult for finishSendChunk_HREQ cleanup
     SearchResult r = SearchResult_New();
 
-    // Get error directly from hreq (no need to copy in HREQ_StoreResults)
+    // Fatal errors are selected across the tail and subqueries. The tail's
+    // request-owned error remains qctx->err and also carries soft errors and
+    // warning-only flags used while rendering the reply.
     QueryError err = QueryError_Default();
     HybridRequest_GetError(hreq, &err);
-
-    // Point qctx->err to the local error so finishSendChunkReply_hybrid/replyWarningsWithSuffixes
-    // can access it. The original qctx->err pointed to a stack variable in RSExecDistHybrid
-    // which is now gone (background thread returned). This local `err` remains valid until
-    // we clear it at the end of this function.
-    qctx->err = &err;
 
     // Get stored results and rc
     SearchResult **results = stored->results;

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -600,6 +600,8 @@ E=0
 # Test suite assumes WORKERS=0; tests that need workers enable them explicitly.
 MODARGS="${MODARGS}; WORKERS 0;"
 MODARGS="${MODARGS}; TIMEOUT 0;" # disable query timeout by default
+# Tests opt in explicitly when exercising strict timeout behavior.
+MODARGS="${MODARGS}; ON_TIMEOUT RETURN;"
 MODARGS="${MODARGS}; _MAX_FOREGROUND_TIMEOUT_LIMIT 0;" # disable per-query TIMEOUT cap by default
 MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" # set default dialect to 2
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -600,8 +600,6 @@ E=0
 # Test suite assumes WORKERS=0; tests that need workers enable them explicitly.
 MODARGS="${MODARGS}; WORKERS 0;"
 MODARGS="${MODARGS}; TIMEOUT 0;" # disable query timeout by default
-# Tests opt in explicitly when exercising strict timeout behavior.
-MODARGS="${MODARGS}; ON_TIMEOUT RETURN;"
 MODARGS="${MODARGS}; _MAX_FOREGROUND_TIMEOUT_LIMIT 0;" # disable per-query TIMEOUT cap by default
 MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" # set default dialect to 2
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2651,7 +2651,8 @@ def testTimeout(env):
     ).error().contains('Timeout limit was reached')
 
 @skip(cluster=True)
-def testTimeoutOnSorter(env):
+def testTimeoutOnSorter():
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
     conn = getConnectionByEnv(env)
     env.cmd(config_cmd(), 'set', 'timeout', '1')
     pl = conn.pipeline()
@@ -3738,11 +3739,11 @@ def testFieldsCaseSensetive(env):
     env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').error().contains('not loaded nor in schema')
 
     # make sure aggregation load are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n').equal([1, ['n', '1'], ['n', '1.1']])
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@N').equal([1, [], []])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n').equal([2, ['n', '1'], ['n', '1.1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@N').equal([2, [], []])
 
     # make sure aggregation apply are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@n', 'as', 'r').equal([2, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@N', 'as', 'r').error().contains('SEARCH_PROP_NOT_FOUND Property not loaded nor in pipeline')
 
     # make sure aggregation filter are case sensitive
@@ -3819,7 +3820,7 @@ def testSortedFieldsCaseSensetive(env):
     env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').error().contains('not loaded nor in schema')
 
     # make sure aggregation apply are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@n', 'as', 'r').equal([2, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@N', 'as', 'r').error().contains('SEARCH_PROP_NOT_FOUND Property not loaded nor in pipeline')
 
     # make sure aggregation filter are case sensitive

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1006,7 +1006,7 @@ def testStartsWith(env):
     conn.execute_command('hset', 'doc3', 't', 'ab')
 
     res = env.cmd('ft.aggregate', 'idx', '*', 'load', 1, 't', 'apply', 'startswith(@t, "aa")', 'as', 'prefix')
-    env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, ['t', 'aa', 'prefix', '1'], \
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([3, ['t', 'aa', 'prefix', '1'], \
                                                                 ['t', 'aaa', 'prefix', '1'], \
                                                                 ['t', 'ab', 'prefix', '0']]))
 
@@ -1022,7 +1022,7 @@ def testContains(env):
 
     # check count of contains
     res = env.cmd('ft.aggregate', 'idx', '*', 'load', 1, 't', 'apply', 'contains(@t, "bb")', 'as', 'substring')
-    env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, ['t', 'aa', 'substring', '0'], \
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([6, ['t', 'aa', 'substring', '0'], \
                                                                 ['t', 'bba', 'substring', '1'], \
                                                                 ['t', 'aba', 'substring', '0'], \
                                                                 ['t', 'abb', 'substring', '1'], \
@@ -1038,7 +1038,7 @@ def testContains(env):
 
     # check count of contains with empty string. (returns length of string + 1)
     res = env.cmd('ft.aggregate', 'idx', '*', 'load', 1, 't', 'apply', 'contains(@t, "")', 'as', 'substring')
-    env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, ['t', 'aa', 'substring', '3'], \
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([6, ['t', 'aa', 'substring', '3'], \
                                                              ['t', 'bba', 'substring', '4'], \
                                                              ['t', 'aba', 'substring', '4'], \
                                                              ['t', 'abb', 'substring', '4'], \
@@ -1062,7 +1062,7 @@ def testStrLen(env):
     conn.execute_command('hset', 'doc3', 't', '')
 
     res = env.cmd('ft.aggregate', 'idx', '*', 'load', 1, 't', 'apply', 'strlen(@t)', 'as', 'length')
-    exp = [1, ['t', 'aa', 'length', '2'],
+    exp = [3, ['t', 'aa', 'length', '2'],
               ['t', 'aaa', 'length', '3'],
               ['t', '', 'length', '0']]
     env.assertEqual(toSortedFlatList(res), toSortedFlatList(exp))
@@ -1074,7 +1074,7 @@ def testLoadAll(env):
     conn.execute_command('HSET', 'doc2', 't', 'world', 'n', 3.141, 'notIndexed', 'bbb')
     conn.execute_command('HSET', 'doc3', 't', 'hello world', 'n', 17.8, 'notIndexed', 'aaa')
     # without LOAD
-    env.expect('FT.AGGREGATE', 'idx', '*').equal([1, [], [], []])
+    env.expect('FT.AGGREGATE', 'idx', '*').equal([3, [], [], []])
     # use LOAD with narg or ALL
     res = [3, ['__key', 'doc1', 't', 'hello', 'n', '42', 'notIndexed', 'ccc'],
               ['__key', 'doc2', 't', 'world', 'n', '3.141', 'notIndexed', 'bbb'],

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1034,7 +1034,7 @@ class TestCoordinatorTimeout:
         # Shards reject TIMEOUT_AFTER_N under RETURN_STRICT at parse time, and none
         # has seen the query yet: flip the policy to 'return' so shards accept the
         # simulated timeout and reply with empty results + a TIMEOUT warning.
-        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return').ok()
+        run_command_on_all_shards(env, 'CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
 
         # Release the fanout. Shards cannot reply while their workers are paused,
         # so the reducer cannot be scheduled yet; re-pause the coord pool right
@@ -1093,7 +1093,8 @@ class TestCoordinatorTimeout:
         _verify_metrics_not_changed(env, env, before_info,
                                     [TIMEOUT_WARNING_COORD_METRIC, TIMEOUT_WARNING_SHARD_METRIC])
 
-        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
+        run_command_on_all_shards(env, 'CONFIG', 'SET', ON_TIMEOUT_CONFIG,
+                                  prev_on_timeout_policy)
 
     def test_no_timeout(self):
         """

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -177,8 +177,7 @@ def testSetConfigOptionsErrors(env):
     env.expect(config_cmd(), 'set', '_TRIMMING_STATE_CHECK_DELAY_MS', -1).contains('Value is outside acceptable bounds')
 
 @skip(cluster=True)
-def testAllConfig():
-    env = Env(moduleArgs='WORKERS 0', noDefaultModuleArgs=True)
+def testAllConfig(env):
     ## on existing env the pre tests might change the config
     ## so no point of testing it
     if env.env == 'existing-env':

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -201,7 +201,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
     env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
     env.assertEqual(res_dict['FRISOINI'][0], None)
-    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'return')
+    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'return-strict')
     env.assertEqual(res_dict['GCSCANSIZE'][0], '100')
     env.assertEqual(res_dict['MIN_PHONETIC_TERM_LEN'][0], '3')
     env.assertEqual(res_dict['FORK_GC_RUN_INTERVAL'][0], '30')
@@ -1192,7 +1192,7 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test default value
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
-        .equal(['search-on-timeout', 'return'])
+        .equal(['search-on-timeout', 'return-strict'])
 
     # Test search-on-timeout - valid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'fail').equal('OK')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -177,7 +177,8 @@ def testSetConfigOptionsErrors(env):
     env.expect(config_cmd(), 'set', '_TRIMMING_STATE_CHECK_DELAY_MS', -1).contains('Value is outside acceptable bounds')
 
 @skip(cluster=True)
-def testAllConfig(env):
+def testAllConfig():
+    env = Env(moduleArgs='WORKERS 0', noDefaultModuleArgs=True)
     ## on existing env the pre tests might change the config
     ## so no point of testing it
     if env.env == 'existing-env':

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -309,8 +309,9 @@ def test_mod_6287(env):
 
     # Dispatch an `FT.CURSOR READ` command that will request for more results from the shards
     # This results in the crash solved by #6287
-    res, cid = env.cmd('FT.CURSOR', 'READ', 'idx', cid, 'COUNT', n_docs - received)
-    env.assertEqual(cid, 0)
+    env.expect(
+        'FT.CURSOR', 'READ', 'idx', cid, 'COUNT', n_docs - received
+    ).error().contains('Cursor not found')
 
     # Send another command to make sure that the coordinator is healthy
     res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', '0', str(n_docs))

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -1571,7 +1571,7 @@ class ProfileDebugSA:
 
 class TestProfileDebugSAResp2(object):
     def __init__(self):
-        env = Env(protocol=2)
+        env = Env(protocol=2, moduleArgs='ON_TIMEOUT RETURN')
         ProfileDebugSA.createIndex(env)
         self.env = env
 
@@ -1582,7 +1582,7 @@ class TestProfileDebugSAResp2(object):
 
 class TestProfileDebugSAResp3(object):
     def __init__(self):
-        env = Env(protocol=3)
+        env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
         ProfileDebugSA.createIndex(env)
         self.env = env
 
@@ -1684,7 +1684,7 @@ class ProfileDebugCluster:
 
 class TestProfileDebugClusterResp2(object):
     def __init__(self):
-        env = Env(protocol=2)
+        env = Env(protocol=2, moduleArgs='ON_TIMEOUT RETURN')
         ProfileDebugCluster.createIndex(env)
         self.env = env
 
@@ -1695,7 +1695,7 @@ class TestProfileDebugClusterResp2(object):
 
 class TestProfileDebugClusterResp3(object):
     def __init__(self):
-        env = Env(protocol=3)
+        env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
         ProfileDebugCluster.createIndex(env)
         self.env = env
 

--- a/tests/pytests/test_empty_reply_warnings.py
+++ b/tests/pytests/test_empty_reply_warnings.py
@@ -28,15 +28,19 @@ class TestEmptyReplyWarnings:
         TIMEOUT_AFTER_N 0 INTERNAL_ONLY causes shards to return empty + timeout warning.
         Verify the warning is propagated to the response.
         """
-        query = ['FT.AGGREGATE', 'idx', '*', 'TIMEOUT', 0]
-        res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
+        allShards_change_timeout_policy(self.env, 'RETURN')
+        try:
+            query = ['FT.AGGREGATE', 'idx', '*', 'TIMEOUT', 0]
+            res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
 
-        # Should have 0 results
-        self.env.assertEqual(len(res['results']), 0,
-                             message="Expected 0 results with TIMEOUT_AFTER_N 0")
-        # Should have timeout warning (propagated from shards via the fix)
-        VerifyTimeoutWarningResp3(self.env, res,
-                                  message="Empty reply should propagate timeout warning")
+            # Should have 0 results
+            self.env.assertEqual(len(res['results']), 0,
+                                 message="Expected 0 results with TIMEOUT_AFTER_N 0")
+            # Should have timeout warning (propagated from shards via the fix)
+            VerifyTimeoutWarningResp3(self.env, res,
+                                      message="Empty reply should propagate timeout warning")
+        finally:
+            allShards_change_timeout_policy(self.env, 'RETURN-STRICT')
 
     def testEmptyReplyTimeoutWarningProfileAggregate(self):
         """
@@ -47,17 +51,21 @@ class TestEmptyReplyWarnings:
         After MOD-12640 fix: processWarningsAndCleanup returns RS_RESULT_TIMEDOUT,
         which sets req->has_timedout, so coordinator profile shows timeout.
         """
-        query = ['FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', 0]
-        res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
+        allShards_change_timeout_policy(self.env, 'RETURN')
+        try:
+            query = ['FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', 0]
+            res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
 
-        # Results should have timeout warning
-        VerifyTimeoutWarningResp3(self.env, res['Results'],
-                                  message=f"Results should have timeout warning, res: {res}")
+            # Results should have timeout warning
+            VerifyTimeoutWarningResp3(self.env, res['Results'],
+                                      message=f"Results should have timeout warning, res: {res}")
 
-        # Coordinator SHOULD have timeout warning (propagated via RS_RESULT_TIMEDOUT)
-        coord_warning = res['Profile']['Coordinator']['Warning']
-        self.env.assertContains('Timeout limit was reached', coord_warning,
-                                message=f"Coordinator should have timeout warning from shard's empty reply, res: {res}")
+            # Coordinator SHOULD have timeout warning (propagated via RS_RESULT_TIMEDOUT)
+            coord_warning = res['Profile']['Coordinator']['Warning']
+            self.env.assertContains('Timeout limit was reached', coord_warning,
+                                    message=f"Coordinator should have timeout warning from shard's empty reply, res: {res}")
+        finally:
+            allShards_change_timeout_policy(self.env, 'RETURN-STRICT')
 
     def testEmptyReplyMaxPrefixExpansionsWarning(self):
         """
@@ -106,7 +114,7 @@ def testEmptyReplyTimeoutResp2():
     """
     RESP2 empty reply with timeout - verify handled correctly.
     """
-    env = Env(protocol=2)
+    env = Env(protocol=2, moduleArgs='ON_TIMEOUT RETURN')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
     conn = getConnectionByEnv(env)
     for i in range(20):

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -326,9 +326,8 @@ def test_expire_aggregate(env):
     # If not cleared, it might affect subsequent results.
     # This test ensures that the flag indicating expiration is cleared and the search result struct is ready to be reused.
     res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
-    # The result count is not accurate in aggregation, because WITHOUTCOUNT is the default
     # Accept both orders, since docID did not advance
-    env.assertEqual([res[0], sorted(res[1:])], [1, sorted([['t', 'arr'], ['t', 'bar']])])
+    env.assertEqual([res[0], sorted(res[1:])], [2, sorted([['t', 'arr'], ['t', 'bar']])])
     # Test using WITHCOUNT
     res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@t')
     env.assertEqual([res[0], sorted(res[1:])], [2, sorted([['t', 'arr'], ['t', 'bar']])])

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -800,20 +800,24 @@ def test_flex_blocks_cursor_commands(env):
 @skip(cluster=True)
 @with_simulate_in_flex(True)
 def test_flex_debug_wrappers_for_aggregate_and_hybrid(env):
-    _create_flex_search(env)
+    env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN').ok()
+    try:
+        _create_flex_search(env)
 
-    # Debug FT.AGGREGATE follows the command's flex enablement (MOD-16604).
-    env.expect(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
-        .noError()
-    env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
-        .noError()
+        # Debug FT.AGGREGATE follows the command's flex enablement (MOD-16604).
+        env.expect(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
+            .noError()
+        env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
+            .noError()
 
-    env.expect(debug_cmd(), 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
-               'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
-        .error().contains('FT.HYBRID is not supported in Redis Flex')
-    env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
-               'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
-        .error().contains('FT.HYBRID is not supported in Redis Flex')
+        env.expect(debug_cmd(), 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
+                   'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
+            .error().contains('FT.HYBRID is not supported in Redis Flex')
+        env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
+                   'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
+            .error().contains('FT.HYBRID is not supported in Redis Flex')
+    finally:
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN-STRICT').ok()
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -352,7 +352,7 @@ def test_shard_k_ratio_insufficient_docs():
 
 @skip(cluster=False)
 def test_debug_hybrid_with_shard_k_ratio():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2', enableDebugCommand=True)
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT RETURN', enableDebugCommand=True)
 
     dim = 2
     k = 6  # multiple of 3 shards so effectiveK is unambiguous

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -268,7 +268,7 @@ def test_debug_sanity_no_truncation():
 
     Analogous to the Sanity() method in test_debug_commands.py for FT.SEARCH/FT.AGGREGATE.
     """
-    env = Env(enableDebugCommand=True)
+    env = Env(moduleArgs='ON_TIMEOUT RETURN', enableDebugCommand=True)
     setup_basic_index(env)
 
     regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
@@ -321,7 +321,7 @@ def test_debug_timeout_zero_means_no_timeout():
 
     This differs from non-hybrid TIMEOUT_AFTER_N where 0 means "timeout immediately."
     """
-    env = Env(enableDebugCommand=True)
+    env = Env(moduleArgs='ON_TIMEOUT RETURN', enableDebugCommand=True)
     setup_basic_index(env)
 
     regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -1194,7 +1194,7 @@ def test_profile_warnings_persist_on_empty_reply_resp2():
 
   In RESP2, the Index OOM warning might appear via the regular execution path,
   not from the empty reply path (see function docstring for details)."""
-  env = Env(protocol=2)
+  env = Env(protocol=2, moduleArgs='ON_TIMEOUT RETURN')
   _test_profile_warnings_persist_on_empty_reply(env, 2)
 
 @skip(cluster=False)
@@ -1203,5 +1203,5 @@ def test_profile_warnings_persist_on_empty_reply_resp3():
 
   In RESP3, the Index OOM warning appears via the empty reply path
   (sendChunk_ReplyOnly_EmptyResults) when timeout is detected from shard's reply."""
-  env = Env(protocol=3)
+  env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
   _test_profile_warnings_persist_on_empty_reply(env, 3)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -862,7 +862,7 @@ def test_mod5062(env):
 
   # verify no crash
   env.expect('FT.AGGREGATE', 'idx', 'hello').noError()
-  env.expect('FT.AGGREGATE', 'idx', 'hello', 'LIMIT', 0, 0).equal([n])
+  env.expect('FT.AGGREGATE', 'idx', 'hello', 'LIMIT', 0, 0).equal([0])
 
   # verify using counter instead of sorter, even with explicit sort
   aggregate_profile = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', 'hello', 'SORTBY', '1', '@t')

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -83,9 +83,8 @@ def testSearchUpdatedContent(env):
     res[2][1] = json.loads(res[2][1])
     env.assertEqual(res, expected)
 
-    # TODO: Why does the following result look like that? (1 count and 2 arrays of result pairs)
     res = env.cmd('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')
-    env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, ['labelT', 'rex'], ['labelT', 'riceratops']]))
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, ['labelT', 'rex'], ['labelT', 'riceratops']]))
     env.expect('ft.aggregate', 'idx1', 're*', 'LOAD', '1', 'labelT').equal([1, ['labelT', 'rex']])
 
     res = env.cmd('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -353,7 +353,7 @@ def test_multiple_loaders():
 @skip(cluster=True)
 def test_switch_loader_modes():
     # Create an environment with workers (0)
-    env = initEnv('WORKERS 1')
+    env = initEnv('WORKERS 1 ON_TIMEOUT RETURN')
     n_docs = 10
     cursor_count = 2
     # Having two loaders to test when the loader is last and when it is not

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -352,8 +352,8 @@ def test_multiple_loaders():
 
 @skip(cluster=True)
 def test_switch_loader_modes():
-    # Create an environment with workers (0)
-    env = initEnv('WORKERS 1 ON_TIMEOUT RETURN')
+    # Timeout handling is orthogonal to loader mode transitions.
+    env = initEnv('WORKERS 1 TIMEOUT 0 ON_TIMEOUT FAIL')
     n_docs = 10
     cursor_count = 2
     # Having two loaders to test when the loader is last and when it is not

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -894,7 +894,7 @@ def testOptimizeArgs(env):
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
         conn.execute_command('HSET', i, 'n', i)
-    query = ['FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '0', '10']
+    query = ['FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '0', '2']
 
     # DIALECT 4 ==> WITHOUTCOUNT (if not explicitly specified)
     env.assertEqual(conn.execute_command(*query, 'DIALECT', 4), conn.execute_command(*query, 'WITHOUTCOUNT'))
@@ -917,7 +917,7 @@ def testOptimizeArgsDefault():
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
         conn.execute_command('HSET', i, 'n', i)
-    query = ['FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '0', '10']
+    query = ['FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '0', '2']
 
     # DEFAULT DIALECT 4 ==> WITHOUTCOUNT (if not explicitly specified)
     env.assertEqual(conn.execute_command(*query), conn.execute_command(*query, 'WITHOUTCOUNT'))

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -78,8 +78,7 @@ def compare_optimized_to_not_nocontent(env, query, params, msg=None):
 
 
 @skip(cluster=True)
-def testOptimizer():
-    env = Env(moduleArgs='ON_TIMEOUT RETURN')
+def testOptimizer(env):
     env.cmd(config_cmd(), 'SET', 'TIMEOUT', '0')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     env.cmd(config_cmd(), 'SET', '_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true')
@@ -164,10 +163,10 @@ def testOptimizer():
 
     ### (4) TAG and range w/o sort ###
     # stop after enough results were collected
-    env.expect('ft.search', 'idx', '@tag:{foo} @n:[10 20]', 'limit', 0 , 2, *params).equal([1, '10', '12'])
-    env.expect('ft.search', 'idx', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '12', '14'])
-    env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 2, *params).equal([1, '10', '12'])
-    env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '12', '14'])
+    env.expect('ft.search', 'idx', '@tag:{foo} @n:[10 20]', 'limit', 0 , 2, *params).equal([2, '10', '12'])
+    env.expect('ft.search', 'idx', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '12', '14'])
+    env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 2, *params).equal([2, '10', '12'])
+    env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '12', '14'])
 
     profiler =  {'Iterators profile':
                     ['Type', 'INTERSECT', 'Number of reading operations', 10, 'Child iterators', [
@@ -177,7 +176,7 @@ def testOptimizer():
                     ['Type', 'Index', 'Results processed', 9],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
-    env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
+    env.assertEqual(res[0], [10, '10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
     actual_profiler = to_dict(res[1][1][0])
     env.assertEqual(actual_profiler['Iterators profile'], profiler['Iterators profile'])
     env.assertEqual(actual_profiler['Result processors profile'], profiler['Result processors profile'])
@@ -205,10 +204,10 @@ def testOptimizer():
 
     ### (6) only range ###
     # stop after enough results were collected
-    env.expect('ft.search', 'idx', '@n:[10 20]', 'limit', 0 , 2, *params).equal([1, '10', '11'])
-    env.expect('ft.search', 'idx', '@n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '11', '12'])
-    env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 2, *params).equal([1, '10', '11'])
-    env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '11', '12'])
+    env.expect('ft.search', 'idx', '@n:[10 20]', 'limit', 0 , 2, *params).equal([2, '10', '11'])
+    env.expect('ft.search', 'idx', '@n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '11', '12'])
+    env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 2, *params).equal([2, '10', '11'])
+    env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '11', '12'])
 
     profiler =  {'Iterators profile':
                     ['Type', 'NUMERIC', 'Term', '0 - 14', 'Number of reading operations', 10, 'Estimated number of matches', 3200],
@@ -216,7 +215,7 @@ def testOptimizer():
                     ['Type', 'Index', 'Results processed', 9],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
-    env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
+    env.assertEqual(res[0], [10, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
     actual_profiler = to_dict(res[1][1][0])
     env.assertEqual(actual_profiler['Iterators profile'], profiler['Iterators profile'])
     env.assertEqual(actual_profiler['Result processors profile'], profiler['Result processors profile'])
@@ -289,10 +288,10 @@ def testOptimizer():
 
     ### (10) no sort, no score, no sortby ###
     # stop after enough results were collected
-    env.expect('ft.search', 'idx', '@tag:{foo}', 'limit', 0 , 2, *params).equal([1, '0', '2'])
-    env.expect('ft.search', 'idx', '@tag:{foo}', 'limit', 0 , 3, *params).equal([1, '0', '2', '4'])
-    env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 2, *params).equal([1, '0', '2'])
-    env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 3, *params).equal([1, '0', '2', '4'])
+    env.expect('ft.search', 'idx', '@tag:{foo}', 'limit', 0 , 2, *params).equal([2, '0', '2'])
+    env.expect('ft.search', 'idx', '@tag:{foo}', 'limit', 0 , 3, *params).equal([3, '0', '2', '4'])
+    env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 2, *params).equal([2, '0', '2'])
+    env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 3, *params).equal([3, '0', '2', '4'])
 
     profiler =  {'Iterators profile':
                     ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 10, 'Estimated number of matches', 10000],
@@ -300,7 +299,7 @@ def testOptimizer():
                     ['Type', 'Index', 'Results processed', 9],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
-    env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
+    env.assertEqual(res[0], [10, '0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     actual_profiler = to_dict(res[1][1][0])
     env.assertEqual(actual_profiler['Iterators profile'], profiler['Iterators profile'])
     env.assertEqual(actual_profiler['Result processors profile'], profiler['Result processors profile'])
@@ -329,10 +328,10 @@ def testOptimizer():
 
     ### (12) wildcard w/o sort ###
     # stop after enough results were collected
-    env.expect('ft.search', 'idx', '*', 'limit', 0 , 2, *params).equal([1, '0', '1'])
-    env.expect('ft.search', 'idx', '*', 'limit', 0 , 3, *params).equal([1, '0', '1', '2'])
-    env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 2, *params).equal([1, '0', '1'])
-    env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 3, *params).equal([1, '0', '1', '2'])
+    env.expect('ft.search', 'idx', '*', 'limit', 0 , 2, *params).equal([2, '0', '1'])
+    env.expect('ft.search', 'idx', '*', 'limit', 0 , 3, *params).equal([3, '0', '1', '2'])
+    env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 2, *params).equal([2, '0', '1'])
+    env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 3, *params).equal([3, '0', '1', '2'])
 
     profiler =  {'Iterators profile':
                     ['Type', 'WILDCARD', 'Number of reading operations', 10],
@@ -340,7 +339,7 @@ def testOptimizer():
                     ['Type', 'Index', 'Results processed', 9],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
-    env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+    env.assertEqual(res[0], [10, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
     actual_profiler = to_dict(res[1][1][0])
     env.assertEqual(actual_profiler['Iterators profile'], profiler['Iterators profile'])
     env.assertEqual(actual_profiler['Result processors profile'], profiler['Result processors profile'])
@@ -888,10 +887,9 @@ def testVector():
             # (same iterators and pipeline should be used)
             env.assertEqual(conn.execute_command(*profile, *query), conn.execute_command(*profile, *query, 'WITHOUTCOUNT'), message=str(idx))
 
-def testOptimizeArgs():
+def testOptimizeArgs(env):
     ''' Test enabling/disabling optimization according to args and dialect '''
 
-    env = Env(moduleArgs='ON_TIMEOUT RETURN')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
@@ -914,7 +912,7 @@ def testOptimizeArgs():
 def testOptimizeArgsDefault():
     ''' Test enabling/disabling optimization according to args and default dialect '''
 
-    env = Env(moduleArgs='DEFAULT_DIALECT 4 ON_TIMEOUT RETURN')
+    env = Env(moduleArgs='DEFAULT_DIALECT 4')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -78,7 +78,8 @@ def compare_optimized_to_not_nocontent(env, query, params, msg=None):
 
 
 @skip(cluster=True)
-def testOptimizer(env):
+def testOptimizer():
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
     env.cmd(config_cmd(), 'SET', 'TIMEOUT', '0')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     env.cmd(config_cmd(), 'SET', '_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true')
@@ -351,7 +352,8 @@ def testOptimizer(env):
     env.assertEqual(result[0], 1200)
 
 @skip(cluster=True)
-def testWOLimit(env):
+def testWOLimit():
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
     env.cmd(config_cmd(), 'set', 'timeout', '0')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     repeat = 100
@@ -886,9 +888,10 @@ def testVector():
             # (same iterators and pipeline should be used)
             env.assertEqual(conn.execute_command(*profile, *query), conn.execute_command(*profile, *query, 'WITHOUTCOUNT'), message=str(idx))
 
-def testOptimizeArgs(env):
+def testOptimizeArgs():
     ''' Test enabling/disabling optimization according to args and dialect '''
 
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
@@ -911,7 +914,7 @@ def testOptimizeArgs(env):
 def testOptimizeArgsDefault():
     ''' Test enabling/disabling optimization according to args and default dialect '''
 
-    env = Env(moduleArgs='DEFAULT_DIALECT 4')
+    env = Env(moduleArgs='DEFAULT_DIALECT 4 ON_TIMEOUT RETURN')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -787,11 +787,11 @@ def TimedOutWarningtestCoord(env):
 
 @skip(asan=True, msan=True, cluster=False)
 def testTimedOutWarningCoordResp3():
-  TimedOutWarningtestCoord(Env(protocol=3))
+  TimedOutWarningtestCoord(Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN'))
 
 @skip(asan=True, msan=True, cluster=False)
 def testTimedOutWarningCoordResp2():
-  TimedOutWarningtestCoord(Env(protocol=2))
+  TimedOutWarningtestCoord(Env(protocol=2, moduleArgs='ON_TIMEOUT RETURN'))
 
 def InternalCursorReadsInProfile(protocol):
   """Tests that 'Internal cursor reads' appears in shard profiles for AGGREGATE."""
@@ -829,7 +829,7 @@ def testInternalCursorReadsInProfileResp2():
 @skip(cluster=False)
 def testInternalCursorReadsWithTimeoutResp3():
   """Tests 'Internal cursor reads' with timeout - RESP3 coordinator detects timeout and stops early."""
-  env = Env(protocol=3)
+  env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
   conn = getConnectionByEnv(env)
   run_command_on_all_shards(env, config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
 
@@ -858,7 +858,7 @@ def testInternalCursorReadsWithTimeoutResp3():
 @skip(cluster=False)
 def testInternalCursorReadsWithTimeoutResp2():
   """Tests 'Internal cursor reads' with timeout - RESP2 coordinator doesn't detect timeout, reads until EOF."""
-  env = Env(shardsCount=2, protocol=2)
+  env = Env(shardsCount=2, protocol=2, moduleArgs='ON_TIMEOUT RETURN')
   conn = getConnectionByEnv(env)
   run_command_on_all_shards(env, config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -217,7 +217,7 @@ def test_search_knn_sortby_limit_total_resp3():
 @skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000
-    env = Env(protocol=3, moduleArgs=f'DEFAULT_DIALECT 2 MAXPREFIXEXPANSIONS {num_range} TIMEOUT 1')
+    env = Env(protocol=3, moduleArgs=f'DEFAULT_DIALECT 2 MAXPREFIXEXPANSIONS {num_range} TIMEOUT 1 ON_TIMEOUT RETURN')
     conn = getConnectionByEnv(env)
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')
@@ -1611,14 +1611,14 @@ def testTimedOutWarning_resp3():
 
 @skip(asan=True, msan=True, cluster=False)
 def testTimedOutWarningCoord_resp3():
-   env = Env(protocol=3)
+   env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
    TimedOutWarningtestCoord(env)
 
 def test_error_with_partial_results():
   """Test that we get 'warnings' with partial results on non-strict timeout
   policy"""
 
-  env = Env(protocol=3)
+  env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
   conn = getConnectionByEnv(env)
 
   # Create an index
@@ -1737,7 +1737,7 @@ def test_multiple_warnings():
   Triggers both timeout and max prefix expansions warnings, and verifies
   that both are present in the response.
   """
-  env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
+  env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT RETURN')
   conn = getConnectionByEnv(env)
 
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -264,7 +264,7 @@ def test_insufficient_docs_per_shard():
 
 @skip(cluster=False)
 def test_debug_aggregate_with_shard_k_ratio():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2', enableDebugCommand=True)
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT RETURN', enableDebugCommand=True)
 
     dim = 2
     datatype = 'FLOAT32'

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -421,7 +421,7 @@ def testTagGCClearEmptyWithCursorAndMoreData(env):
 
     # ensure later documents with same tag are read
     res = conn.execute_command('FT.AGGREGATE', 'idx', '@t:{foo}')
-    env.assertEqual(res, [1, [], []])
+    env.assertEqual(res, [2, [], []])
 
 @skip(cluster=True)
 def testEmptyTagLeak(env):


### PR DESCRIPTION
## Describe the changes in the pull request

1. Change the default `ON_TIMEOUT` policy from `RETURN` to `RETURN-STRICT`.
2. Keep `RETURN` explicit only in tests that require partial timeout results or debug timeout hooks.
3. Preserve coordinator profiles and hybrid warnings on the strict deferred-reply path.

#### Which additional issues this PR fixes

1. [MOD-17848](https://redislabs.atlassian.net/browse/MOD-17848)

#### Main objects this PR modified

1. Search timeout configuration.
2. Coordinator profile and hybrid reply handling.
3. Timeout-policy flow tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

[MOD-17848]: https://redislabs.atlassian.net/browse/MOD-17848
