### PR TITLE
[CI] Pin Redis ref to hash-field expiry fix

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -32,7 +32,7 @@ on:
       redis_ref:
         type: string
         # Keep benchmarks independent of the Redis version preinstalled on the DB hosts.
-        default: "8.10.0"
+        default: "d3abc02fed6664cc0afaf9ffe4e172a99e274f44"
         description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
   workflow_call:
     inputs:
@@ -57,7 +57,7 @@ on:
       redis_ref:
         type: string
         # Keep benchmarks independent of the Redis version preinstalled on the DB hosts.
-        default: "8.10.0"
+        default: "d3abc02fed6664cc0afaf9ffe4e172a99e274f44"
         description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
 
 jobs:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,6 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-latest-redis-tag:
+    permissions: {}
+    runs-on: ubuntu-slim
+    outputs:
+      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+    steps:
+      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+
   lint:
     permissions:
       contents: read
@@ -31,6 +39,7 @@ jobs:
       advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
   build-unique-oses:
+    needs: get-latest-redis-tag
     permissions:
       contents: read
       packages: write
@@ -43,7 +52,7 @@ jobs:
       # test runners; keep macOS Intel (x86_64) here for build coverage.
       platform: 'macos-26,alpine:3.23,intel'
       architecture: all
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       options: skip-tests,fail-fast
       rejson-branch: master
 
@@ -68,6 +77,7 @@ jobs:
 
   test-ubuntu-master:
     # Always run tests for merge queue submissions, including text-only PRs.
+    needs: get-latest-redis-tag
     if: ${{ github.event.merge_group.base_ref == 'refs/heads/master' }}
     permissions:
       contents: read
@@ -80,7 +90,7 @@ jobs:
       job-type: basic-test
       platform: ubuntu:noble
       architecture: x86_64
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
       rejson-branch: master
       # This lane only runs tests, so the LTO link is dead weight on the queue's
@@ -90,6 +100,7 @@ jobs:
       enable-lto: '0'
 
   test-ubuntu-release-branch:
+    needs: get-latest-redis-tag
     if: ${{ github.event.merge_group.base_ref != 'refs/heads/master' }}
     permissions:
       contents: read
@@ -101,7 +112,7 @@ jobs:
     with:
       platform: ubuntu:noble
       architecture: x86_64
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1", "ubsan": "QUICK=1"}'
       options: unit-tests,coordinator,standalone,rejson,fail-fast,ubsan
       # Full alignment UBSan currently exposes unrelated pre-existing UB in the
@@ -114,6 +125,7 @@ jobs:
   pr-validation:
     permissions: {} # aggregation gate: inspects needs.* only
     needs:
+      - get-latest-redis-tag
       - lint
       - build-unique-oses
       - test-ubuntu-master

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -21,8 +21,6 @@ jobs:
   get-latest-redis-tag:
     permissions: {}
     uses: ./.github/workflows/task-get-redis-tag.yml
-    with:
-      repo: redis/redis
 
   lint:
     permissions:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,12 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-latest-redis-tag:
-    permissions: {}
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-
   lint:
     permissions:
       contents: read
@@ -37,7 +31,6 @@ jobs:
       advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
   build-unique-oses:
-    needs: get-latest-redis-tag
     permissions:
       contents: read
       packages: write
@@ -50,7 +43,7 @@ jobs:
       # test runners; keep macOS Intel (x86_64) here for build coverage.
       platform: 'macos-26,alpine:3.23,intel'
       architecture: all
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       options: skip-tests,fail-fast
       rejson-branch: master
 
@@ -75,7 +68,6 @@ jobs:
 
   test-ubuntu-master:
     # Always run tests for merge queue submissions, including text-only PRs.
-    needs: get-latest-redis-tag
     if: ${{ github.event.merge_group.base_ref == 'refs/heads/master' }}
     permissions:
       contents: read
@@ -88,7 +80,7 @@ jobs:
       job-type: basic-test
       platform: ubuntu:noble
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       test-config: QUICK=1
       rejson-branch: master
       # This lane only runs tests, so the LTO link is dead weight on the queue's
@@ -98,7 +90,6 @@ jobs:
       enable-lto: '0'
 
   test-ubuntu-release-branch:
-    needs: get-latest-redis-tag
     if: ${{ github.event.merge_group.base_ref != 'refs/heads/master' }}
     permissions:
       contents: read
@@ -110,7 +101,7 @@ jobs:
     with:
       platform: ubuntu:noble
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1", "ubsan": "QUICK=1"}'
       options: unit-tests,coordinator,standalone,rejson,fail-fast,ubsan
       # Full alignment UBSan currently exposes unrelated pre-existing UB in the
@@ -123,7 +114,6 @@ jobs:
   pr-validation:
     permissions: {} # aggregation gate: inspects needs.* only
     needs:
-      - get-latest-redis-tag
       - lint
       - build-unique-oses
       - test-ubuntu-master

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -20,11 +20,9 @@ concurrency:
 jobs:
   get-latest-redis-tag:
     permissions: {}
-    runs-on: ubuntu-slim
-    outputs:
-      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
-    steps:
-      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+    uses: ./.github/workflows/task-get-redis-tag.yml
+    with:
+      repo: redis/redis
 
   lint:
     permissions:

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -161,8 +161,6 @@ jobs:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
     uses: ./.github/workflows/task-get-redis-tag.yml
-    with:
-      repo: redis/redis
 
   test-selected-platforms:
     needs: [should-run, get-latest-redis-tag]

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -160,11 +160,9 @@ jobs:
     permissions: {}
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
-    runs-on: ubuntu-slim
-    outputs:
-      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
-    steps:
-      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+    uses: ./.github/workflows/task-get-redis-tag.yml
+    with:
+      repo: redis/redis
 
   test-selected-platforms:
     needs: [should-run, get-latest-redis-tag]

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -156,8 +156,18 @@ jobs:
         run: |
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
-  test-selected-platforms:
+  get-latest-redis-tag:
+    permissions: {}
     needs: should-run
+    if: ${{ needs.should-run.outputs.run-validation == 'true' }}
+    runs-on: ubuntu-slim
+    outputs:
+      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+    steps:
+      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+
+  test-selected-platforms:
+    needs: [should-run, get-latest-redis-tag]
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
     permissions:
       contents: read
@@ -171,7 +181,7 @@ jobs:
       # problem is mitigated; macOS ARM still runs.
       platform: 'ubuntu:noble,macos-26,!macos-26~x86_64,alpine:3.23,intel'
       architecture: all
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": "", "ubsan": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize,ubsan' || 'unit-tests,coordinator,standalone,rejson,sanitize,ubsan' }}
       # Full alignment UBSan currently exposes unrelated pre-existing UB in the
@@ -181,7 +191,7 @@ jobs:
       rejson-branch: master
 
   notify-cie-failure:
-    needs: [should-run, test-selected-platforms]
+    needs: [should-run, get-latest-redis-tag, test-selected-platforms]
     if: failure()
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -156,16 +156,8 @@ jobs:
         run: |
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
-  get-latest-redis-tag:
-    permissions: {}
-    needs: should-run
-    if: ${{ needs.should-run.outputs.run-validation == 'true' }}
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-
   test-selected-platforms:
-    needs: [should-run, get-latest-redis-tag]
+    needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
     permissions:
       contents: read
@@ -179,7 +171,7 @@ jobs:
       # problem is mitigated; macOS ARM still runs.
       platform: 'ubuntu:noble,macos-26,!macos-26~x86_64,alpine:3.23,intel'
       architecture: all
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       job-test-config: '{"test": "", "coverage": "", "sanitize": "", "ubsan": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize,ubsan' || 'unit-tests,coordinator,standalone,rejson,sanitize,ubsan' }}
       # Full alignment UBSan currently exposes unrelated pre-existing UB in the
@@ -189,7 +181,7 @@ jobs:
       rejson-branch: master
 
   notify-cie-failure:
-    needs: [should-run, get-latest-redis-tag, test-selected-platforms]
+    needs: [should-run, test-selected-platforms]
     if: failure()
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -21,6 +21,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-latest-redis-tag:
+    permissions: {}
+    runs-on: ubuntu-slim
+    outputs:
+      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+    steps:
+      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+
   check-what-changed:
     permissions: # actions/checkout
       contents: read
@@ -59,7 +67,7 @@ jobs:
   # ------------------------------------------------------------------
 
   basic-test:
-    needs: [check-what-changed, spellcheck]
+    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -72,12 +80,12 @@ jobs:
       job-type: basic-test
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
       rejson-branch: master
 
   coverage:
-    needs: [check-what-changed, spellcheck]
+    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -90,12 +98,12 @@ jobs:
       job-type: coverage
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
       rejson-branch: master
 
   sanitize:
-    needs: [check-what-changed, spellcheck]
+    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -108,7 +116,7 @@ jobs:
       job-type: sanitize
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
       rejson-branch: master
 
@@ -143,6 +151,7 @@ jobs:
   pr-validation:
     permissions: {} # aggregation gate: inspects needs.* only
     needs:
+      - get-latest-redis-tag
       - check-what-changed
       - spellcheck
       - zizmor

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -23,11 +23,9 @@ concurrency:
 jobs:
   get-latest-redis-tag:
     permissions: {}
-    runs-on: ubuntu-slim
-    outputs:
-      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
-    steps:
-      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+    uses: ./.github/workflows/task-get-redis-tag.yml
+    with:
+      repo: redis/redis
 
   check-what-changed:
     permissions: # actions/checkout

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -21,12 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-latest-redis-tag:
-    permissions: {}
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-
   check-what-changed:
     permissions: # actions/checkout
       contents: read
@@ -65,7 +59,7 @@ jobs:
   # ------------------------------------------------------------------
 
   basic-test:
-    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
+    needs: [check-what-changed, spellcheck]
     if: ${{ (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -78,12 +72,12 @@ jobs:
       job-type: basic-test
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       test-config: QUICK=1
       rejson-branch: master
 
   coverage:
-    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
+    needs: [check-what-changed, spellcheck]
     if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -96,12 +90,12 @@ jobs:
       job-type: coverage
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       test-config: QUICK=1
       rejson-branch: master
 
   sanitize:
-    needs: [check-what-changed, get-latest-redis-tag, spellcheck]
+    needs: [check-what-changed, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
@@ -114,7 +108,7 @@ jobs:
       job-type: sanitize
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
       test-config: QUICK=1
       rejson-branch: master
 
@@ -149,7 +143,6 @@ jobs:
   pr-validation:
     permissions: {} # aggregation gate: inspects needs.* only
     needs:
-      - get-latest-redis-tag
       - check-what-changed
       - spellcheck
       - zizmor

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -24,8 +24,6 @@ jobs:
   get-latest-redis-tag:
     permissions: {}
     uses: ./.github/workflows/task-get-redis-tag.yml
-    with:
-      repo: redis/redis
 
   check-what-changed:
     permissions: # actions/checkout

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -55,8 +55,6 @@ on:
 jobs:
   get-latest-redis-tag:
     uses: ./.github/workflows/task-get-redis-tag.yml
-    with:
-      repo: redis/redis
 
   setup:
     needs: [get-latest-redis-tag]

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -54,11 +54,9 @@ on:
 
 jobs:
   get-latest-redis-tag:
-    runs-on: ubuntu-slim
-    outputs:
-      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
-    steps:
-      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+    uses: ./.github/workflows/task-get-redis-tag.yml
+    with:
+      repo: redis/redis
 
   setup:
     needs: [get-latest-redis-tag]

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -53,14 +53,22 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    runs-on: ubuntu-slim
+    outputs:
+      tag: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+    steps:
+      - run: echo "Using pinned redis/redis commit with the hash-field expiration notification fix"
+
   setup:
+    needs: [get-latest-redis-tag]
     permissions: # actions/checkout
       contents: read
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.redis-ref.outputs.ref }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -68,8 +76,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: redis-ref
-        run: echo "ref=d3abc02fed6664cc0afaf9ffe4e172a99e274f44" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         # Expanded through env rather than into the script body: a ref name is

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -53,20 +53,14 @@ on:
         default: false
 
 jobs:
-  get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-
   setup:
-    needs: [get-latest-redis-tag]
     permissions: # actions/checkout
       contents: read
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ steps.redis-ref.outputs.ref }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -74,6 +68,8 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - id: redis-ref
+        run: echo "ref=d3abc02fed6664cc0afaf9ffe4e172a99e274f44" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         # Expanded through env rather than into the script body: a ref name is

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -85,9 +85,9 @@ on:
         type: string
         default: ''
       redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
+        description: 'Redis git ref to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: '8.10.0'
+        default: 'd3abc02fed6664cc0afaf9ffe4e172a99e274f44'
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -20,9 +20,9 @@ on:
   workflow_call:
     inputs:
       redis-ref:
-        description: 'Redis version to build (e.g. "7.2.3", "unstable", or a commit sha)'
+        description: 'Redis git ref to build (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: '8.10.0'
+        default: 'd3abc02fed6664cc0afaf9ffe4e172a99e274f44'
       san:
         type: string
       coverage:

--- a/.github/workflows/task-get-redis-tag.yml
+++ b/.github/workflows/task-get-redis-tag.yml
@@ -10,6 +10,7 @@ on:
       pinned-ref:
         description: "Redis ref to use instead of the latest release tag. Empty uses the latest release tag."
         type: string
+        # TODO: Replace with a released Redis version once one includes the hexpired notification fix.
         default: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
     outputs:
       tag:

--- a/.github/workflows/task-get-redis-tag.yml
+++ b/.github/workflows/task-get-redis-tag.yml
@@ -3,10 +3,6 @@ name: Get Redis Tag
 on:
   workflow_call:
     inputs:
-      repo:
-        description: "Repository name in the format of owner/repo"
-        type: string
-        default: redis/redis
       prefix:
         description: "Prefix to filter tags, for getting latest release of a specific version"
         type: string
@@ -39,7 +35,7 @@ jobs:
     permissions: {}
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
-      repo: ${{ inputs.repo }}
+      repo: redis/redis
       prefix: ${{ inputs.prefix }}
 
   resolve:

--- a/.github/workflows/task-get-redis-tag.yml
+++ b/.github/workflows/task-get-redis-tag.yml
@@ -1,0 +1,62 @@
+name: Get Redis Tag
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "Repository name in the format of owner/repo"
+        type: string
+        default: redis/redis
+      prefix:
+        description: "Prefix to filter tags, for getting latest release of a specific version"
+        type: string
+        default: ''
+      pinned-ref:
+        description: "Redis ref to use instead of the latest release tag. Empty uses the latest release tag."
+        type: string
+        default: d3abc02fed6664cc0afaf9ffe4e172a99e274f44
+    outputs:
+      tag:
+        description: "Redis tag or pinned ref"
+        value: ${{ jobs.resolve.outputs.tag }}
+
+jobs:
+  pinned-ref:
+    if: ${{ inputs.pinned-ref != '' }}
+    runs-on: ubuntu-slim
+    outputs:
+      tag: ${{ steps.redis-ref.outputs.tag }}
+    steps:
+      - id: redis-ref
+        env:
+          PINNED_REDIS_REF: ${{ inputs.pinned-ref }}
+        run: |
+          echo "Using pinned Redis ref: $PINNED_REDIS_REF"
+          echo "tag=$PINNED_REDIS_REF" >> "$GITHUB_OUTPUT"
+
+  latest-release-tag:
+    if: ${{ inputs.pinned-ref == '' }}
+    permissions: {}
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: ${{ inputs.repo }}
+      prefix: ${{ inputs.prefix }}
+
+  resolve:
+    needs: [pinned-ref, latest-release-tag]
+    if: ${{ always() && !cancelled() && !failure() }}
+    runs-on: ubuntu-slim
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - id: resolve
+        env:
+          PINNED_TAG: ${{ needs.pinned-ref.outputs.tag }}
+          LATEST_TAG: ${{ needs.latest-release-tag.outputs.tag }}
+        run: |
+          TAG="${PINNED_TAG:-$LATEST_TAG}"
+          if [[ -z "$TAG" ]]; then
+            echo "Failed to resolve Redis ref" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -26,9 +26,9 @@ on:
         type: boolean
         default: false
       redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable")'
+        description: 'Redis git ref to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: '8.10.0'
+        default: 'd3abc02fed6664cc0afaf9ffe4e172a99e274f44'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -27,7 +27,7 @@ on:
       redis-ref:
         description: 'Redis version to use (only consumed by setup steps that key caches on it).'
         type: string
-        default: '8.10.0'
+        default: 'd3abc02fed6664cc0afaf9ffe4e172a99e274f44'
       test-timeout:
         type: number
         default: 120

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -19,9 +19,9 @@ on:
         type: boolean
         default: false
       redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable")'
+        description: 'Redis git ref to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: '8.10.0'
+        default: 'd3abc02fed6664cc0afaf9ffe4e172a99e274f44'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true


### PR DESCRIPTION
## Summary
- Add `task-get-redis-tag.yml`, a Redis-specific wrapper that returns a pinned Redis ref when `pinned-ref` is set and delegates to `task-get-latest-tag.yml` when it is empty.
- Route PR, merge queue, periodic validation, and artifact workflows through that wrapper instead of calling `task-get-latest-tag.yml` directly.
- Pin benchmark and reusable test/build workflow defaults to redis/redis commit d3abc02fed6664cc0afaf9ffe4e172a99e274f44 instead of 8.10.0.
- Keep package Redis-version metadata unchanged; this PR only changes CI Redis selection.

## Background
redis/redis#15623 was merged on 2026-08-19 and contains the hash-field expiration post-notification drain needed by RediSearch/RediSearch#10561. Redis 8.10.0 does not include that fix.

## Release notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Verification
- git diff --check public/master..HEAD
- python3 YAML parse over the 11 changed workflow files
- rg found no remaining `.github` references to `8.10`
