### PR TITLE
[MOD-16400] Trie - add RDB crate

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3320,6 +3320,7 @@ dependencies = [
 name = "trie_rdb"
 version = "0.0.1"
 dependencies = [
+ "lending-iterator",
  "rdb_io",
  "thiserror",
  "trie_rdb",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3317,6 +3317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trie_rdb"
+version = "0.0.1"
+dependencies = [
+ "rdb_io",
+ "thiserror",
+ "trie_rdb",
+ "trie_rs",
+ "workspace_hack",
+]
+
+[[package]]
 name = "trie_rs"
 version = "0.0.1"
 dependencies = [

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "numeric_score_source",
     "numeric_score_source_bencher",
     "trie_rs",
+    "trie_rdb",
     "ttl_table",
     "utf8parse",
     "ttl_table_bencher",
@@ -172,6 +173,7 @@ vecsim = { path = "./c_wrappers/vecsim" }
 vector_score_source = { path = "./vector_score_source" }
 tracing_redismodule = { path = "./tracing_redismodule" }
 trie_rs = { path = "./trie_rs" }
+trie_rdb = { path = "./trie_rdb" }
 rdb_io = { path = "./rdb_io" }
 ttl_table = { path = "./ttl_table" }
 value = { path = "./value" }

--- a/src/redisearch_rs/trie_rdb/Cargo.toml
+++ b/src/redisearch_rs/trie_rdb/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 test-utils = []
 
 [dependencies]
+lending-iterator.workspace = true
 rdb_io.workspace = true
 thiserror.workspace = true
 trie_rs.workspace = true

--- a/src/redisearch_rs/trie_rdb/Cargo.toml
+++ b/src/redisearch_rs/trie_rdb/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "trie_rdb"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[features]
+test-utils = []
+
+[dependencies]
+rdb_io.workspace = true
+thiserror.workspace = true
+trie_rs.workspace = true
+workspace_hack.workspace = true
+
+[dev-dependencies]
+trie_rdb = { workspace = true, features = ["test-utils"] }

--- a/src/redisearch_rs/trie_rdb/src/entry.rs
+++ b/src/redisearch_rs/trie_rdb/src/entry.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! The value type stored in a trie map.
+
+/// Borrowed view of the wire fields of one entry, handed to the generic
+/// save path.
+///
+/// The payload-generic serializers ([`crate::trie_map::save_with`],
+/// [`crate::str_trie_map::save_with`]) ask the caller to produce one of these per
+/// entry, so any payload type can be persisted without first materializing
+/// a [`TrieEntry`] (and cloning its payload bytes). Which of these fields
+/// actually reach the wire is governed by [`crate::RdbOpts`], same as for
+/// [`TrieEntry`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WireFields<'a> {
+    /// See [`TrieEntry::score`].
+    pub score: f64,
+    /// See [`TrieEntry::payload`].
+    pub payload: Option<&'a [u8]>,
+    /// See [`TrieEntry::num_docs`].
+    pub num_docs: u64,
+}
+
+impl<'a> From<&'a TrieEntry> for WireFields<'a> {
+    /// Project an owned [`TrieEntry`] into its borrowed wire fields — the
+    /// identity field mapping the save shorthands pass to the payload-generic
+    /// serializers for maps that store [`TrieEntry`] itself.
+    fn from(entry: &'a TrieEntry) -> Self {
+        WireFields {
+            score: entry.score,
+            payload: entry.payload.as_deref(),
+            num_docs: entry.num_docs,
+        }
+    }
+}
+
+/// One trie entry: score, optional opaque payload, and a per-entry counter.
+///
+/// This is the payload a [`trie_rs::TrieMap`] / [`trie_rs::str_trie_map::StrTrieMap`]
+/// holds for each key. Its persistence behavior is governed by
+/// [`crate::RdbOpts`]; the type itself carries no IO concern.
+///
+/// Empty and absent payloads are wire-indistinguishable; see
+/// [empty-payload normalization](crate#empty-payload-normalization).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrieEntry {
+    /// Score associated with the entry. Semantics are caller-defined (e.g.
+    /// suggestion weight, or a constant for index-term tries) and may be
+    /// mutated by callers after the initial insert. The C trie stores this
+    /// as `float`; the RDB wire format widens it to `f64`.
+    pub score: f64,
+    /// Optional opaque payload bytes.
+    pub payload: Option<Vec<u8>>,
+    /// Per-entry counter, persisted only when [`crate::RdbOpts::num_docs`]
+    /// is set. Semantics are caller-defined (e.g. document frequency for an
+    /// index's term trie); this type does not enforce a meaning. Loads with
+    /// [`crate::RdbOpts::num_docs`] unset materialize this as `0`.
+    pub num_docs: u64,
+}

--- a/src/redisearch_rs/trie_rdb/src/lib.rs
+++ b/src/redisearch_rs/trie_rdb/src/lib.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! RDB serialization for the [`trie_rs`] trie maps.
+//!
+//! Mirrors the wire format produced by the C functions `TrieType_GenericSave`
+//! and `TrieType_GenericLoad`. This crate owns the shared substrate —
+//! [`RdbOpts`], [`RdbError`], the
+//! NUL-framing helpers, and the [`read_entries`] entry-stream reader — plus
+//! the [`TrieEntry`] value type the wire fields are modeled on. The two
+//! serializer flavors live alongside it:
+//!
+//! - [`trie_map`] — for the byte-keyed [`trie_rs::TrieMap`].
+//! - [`str_trie_map`] — for the UTF-8-keyed [`trie_rs::str_trie_map::StrTrieMap`],
+//!   a thin wrapper that delegates to [`trie_map`].
+//!
+//! Each flavor is generic over the map's payload type ([`trie_map::save_with`] /
+//! [`trie_map::load_with`] and their [`str_trie_map`] counterparts, with a per-entry
+//! mapping to and from the wire fields) and offers [`trie_map::save`] /
+//! [`trie_map::load`] shorthands for maps that store [`TrieEntry`] itself.
+//!
+//! IO is abstracted behind the [`RdbIO`] trait, so this crate makes no direct
+//! use of the Redis module API: [`rdb_io`] implements the trait over
+//! `RedisModuleIO`, and pure-Rust callers can implement it over any buffer.
+//!
+//! # Wire format
+//!
+//! ```text
+//! u64  count                            // map.n_unique_keys()
+//! [ bytes(key + '\0')
+//!   f64  score
+//!   bytes(payload + '\0')               // only if RdbOpts::payloads
+//!   u64  num_docs                       // only if RdbOpts::num_docs
+//! ] * count
+//! ```
+//!
+//! The diagram lists the framed primitives passed to [`RdbIO`]; the actual
+//! on-wire bytes include length prefixes added by `RedisModule_Save*`, which
+//! are opaque to this layer.
+//!
+//! # Trailing-NUL framing
+//!
+//! Both keys and payloads are written with a trailing NUL byte, so a saved
+//! buffer is one byte longer than the value it carries — matching C's
+//! `SaveStringBuffer(..., len + 1)` — and the loader strips that byte. Framing
+//! is applied in the algorithm body via [`save_nul_terminated`],
+//! [`load_nul_terminated`] and [`load_payload`]; the [`RdbIO`] trait surface
+//! stays neutral — it just writes and reads raw length-prefixed buffers.
+//!
+//! The two field kinds differ in how much of that framing the loader trusts.
+//! A key's terminator is verified to be NUL. A payload's is not: RDB files and
+//! replication streams written earlier by C carry whatever heap byte occupied
+//! that slot, and they must stay loadable. Only the byte's presence is guaranteed,
+//! so [`load_payload`] discards it unread and rejects nothing but the zero-length buffer.
+//!
+//! # Empty-payload normalization
+//!
+//! When [`RdbOpts::payloads`] is `true`, both `payload: None` and
+//! `payload: Some(vec![])` emit a single-NUL buffer (`"\0"`) and load back as
+//! `None`.
+//!
+//! # IO model
+//!
+//! Save is infallible at the Rust API level, matching the void-returning C
+//! `RedisModule_Save*` primitives. Errors only surface on load through
+//! [`RdbError`].
+
+pub mod entry;
+pub mod str_trie_map;
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
+pub mod trie_map;
+
+use std::io;
+
+use rdb_io::RdbIO;
+
+pub use entry::{TrieEntry, WireFields};
+
+/// Read the entry stream shared by both key flavors and feed each decoded
+/// entry to `insert`.
+///
+/// Owns the count framing and the per-entry field layout so the byte- and
+/// str-keyed loaders cannot drift apart. The two flavors differ only in how
+/// raw key bytes become a key: `key_from_bytes` maps the NUL-stripped buffer
+/// into the caller's key type (identity for bytes, UTF-8 validation for str),
+/// and `insert` places the finished `(key, entry)` into the caller's map.
+pub(crate) fn read_entries<IO: RdbIO, K>(
+    reader: &mut IO,
+    opts: RdbOpts,
+    mut key_from_bytes: impl FnMut(Vec<u8>) -> Result<K, RdbError>,
+    mut insert: impl FnMut(K, TrieEntry),
+) -> Result<(), RdbError> {
+    let count = reader.read_u64()?;
+    for _ in 0..count {
+        let key = key_from_bytes(load_nul_terminated(reader)?)?;
+        let score = reader.read_f64()?;
+        let payload = opts
+            .payloads
+            .then(|| load_payload(reader))
+            .transpose()?
+            .filter(|b| !b.is_empty());
+        let num_docs = if opts.num_docs { reader.read_u64()? } else { 0 };
+        insert(
+            key,
+            TrieEntry {
+                score,
+                payload,
+                num_docs,
+            },
+        );
+    }
+    Ok(())
+}
+
+/// Write `b` followed by one trailing NUL byte as a single length-prefixed
+/// record, reusing `scratch` as the temporary contiguous buffer.
+///
+/// `scratch` is borrowed from the caller so one allocation can amortize
+/// across an entire save loop.
+pub(crate) fn save_nul_terminated<IO: RdbIO>(writer: &mut IO, scratch: &mut Vec<u8>, b: &[u8]) {
+    scratch.clear();
+    scratch.reserve(b.len() + 1);
+    scratch.extend_from_slice(b);
+    scratch.push(0);
+    writer.write_buffer(scratch);
+}
+
+/// Read one length-prefixed key buffer and return its contents with the
+/// trailing NUL stripped. Returns [`RdbError::MissingTrailingNul`] when the
+/// wire buffer is empty or does not end in `0x00`.
+pub(crate) fn load_nul_terminated<IO: RdbIO>(reader: &mut IO) -> Result<Vec<u8>, RdbError> {
+    let mut buf = reader.read_buffer()?;
+    if buf.pop() != Some(0) {
+        return Err(RdbError::MissingTrailingNul);
+    }
+    Ok(buf)
+}
+
+/// Read one length-prefixed payload buffer and return its contents with the
+/// trailing byte dropped, whatever that byte is — see
+/// [trailing-NUL framing](crate#trailing-nul-framing) for why a payload's
+/// terminator value is not checked. Returns
+/// [`RdbError::MissingTrailingNul`] only when the wire buffer is empty, and
+/// so has no terminator slot at all.
+pub(crate) fn load_payload<IO: RdbIO>(reader: &mut IO) -> Result<Vec<u8>, RdbError> {
+    let mut buf = reader.read_buffer()?;
+    if buf.pop().is_none() {
+        return Err(RdbError::MissingTrailingNul);
+    }
+    Ok(buf)
+}
+
+/// Controls which optional fields are present on the wire.
+///
+/// The same value must be used at save and load time. Mismatches misalign
+/// the wire layout, so subsequent reads either fail with an [`RdbError`] or
+/// silently parse the wrong bytes as the next field.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RdbOpts {
+    /// Persist each entry's payload (with trailing NUL).
+    pub payloads: bool,
+    /// Persist each entry's `num_docs`.
+    pub num_docs: bool,
+}
+
+/// Errors that can occur while reading a trie RDB payload.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RdbError {
+    /// The underlying RDB read failed (EOF, corrupted stream, etc.).
+    ///
+    /// The originating [`std::io::Error`] is intentionally not retained:
+    /// dropping it keeps [`RdbError`] `Clone + PartialEq + Eq`, which the
+    /// wire-shape tests rely on to assert exact error values.
+    #[error("rdb io error")]
+    Io,
+    /// A framed buffer had no terminator byte at all, or — for keys, whose
+    /// terminator value is checked — ended in something other than `0x00`.
+    #[error("rdb bytes buffer missing trailing NUL")]
+    MissingTrailingNul,
+    /// A key buffer was not valid UTF-8 when loaded through the
+    /// [`crate::str_trie_map`] wrapper that requires UTF-8 keys.
+    #[error("rdb key bytes not valid UTF-8")]
+    InvalidUtf8,
+}
+
+impl From<io::Error> for RdbError {
+    /// Lift an IO failure from the [`RdbIO`] load primitives into the framing
+    /// error type, so `?` threads `io::Result` through the framing helpers.
+    fn from(_: io::Error) -> Self {
+        RdbError::Io
+    }
+}

--- a/src/redisearch_rs/trie_rdb/src/str_trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/str_trie_map.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! RDB serialization for [`StrTrieMap`].
+//!
+//! Wraps the byte-keyed [`crate::trie_map`] surface for callers whose keys are
+//! UTF-8 by type; the wire output is byte-identical. Each loaded key buffer
+//! is validated with [`String::from_utf8`], so non-UTF-8 input surfaces as
+//! [`RdbError::InvalidUtf8`] rather than silently materializing as an
+//! ill-formed `String`.
+
+use super::{RdbError, RdbOpts, read_entries, trie_map};
+use crate::{TrieEntry, WireFields};
+use rdb_io::RdbIO;
+use trie_rs::str_trie_map::StrTrieMap;
+
+/// Serialize a [`StrTrieMap`] with an arbitrary payload type to `writer`
+/// in the trie RDB wire format.
+///
+/// `fields` produces the wire fields for each entry's payload, as in
+/// [`crate::trie_map::save_with`]. Delegates to it on the inner byte-keyed
+/// [`trie_rs::TrieMap`].
+pub fn save_with<P, IO: RdbIO>(
+    map: &StrTrieMap<P>,
+    writer: &mut IO,
+    opts: RdbOpts,
+    fields: impl for<'a> FnMut(&'a P) -> WireFields<'a>,
+) {
+    trie_map::save_with(map.byte_trie(), writer, opts, fields);
+}
+
+/// Serialize a [`StrTrieMap<TrieEntry>`] to `writer` in the trie RDB wire
+/// format.
+///
+/// Shorthand for [`save_with`] with the identity field mapping.
+pub fn save<IO: RdbIO>(map: &StrTrieMap<TrieEntry>, writer: &mut IO, opts: RdbOpts) {
+    trie_map::save(map.byte_trie(), writer, opts);
+}
+
+/// Stream the entries of a serialized trie from `reader`, in stream order,
+/// into `sink`.
+///
+/// `opts` must match the [`RdbOpts`] used at save time. Each loaded key
+/// buffer is UTF-8 validated; on failure the load aborts with
+/// [`RdbError::InvalidUtf8`].
+///
+/// This is the building block for callers that store the entries in their
+/// own structure (possibly transforming keys on the way in) and would
+/// otherwise pay for an intermediate [`StrTrieMap`] build.
+pub fn load_entries<IO: RdbIO>(
+    reader: &mut IO,
+    opts: RdbOpts,
+    sink: impl FnMut(String, TrieEntry),
+) -> Result<(), RdbError> {
+    read_entries(
+        reader,
+        opts,
+        |bytes| String::from_utf8(bytes).map_err(|_| RdbError::InvalidUtf8),
+        sink,
+    )
+}
+
+/// Deserialize a [`StrTrieMap`] with an arbitrary payload type from
+/// `reader`.
+///
+/// `opts` must match the [`RdbOpts`] used at save time. `payload` builds
+/// each stored payload from the decoded wire fields, as in
+/// [`crate::trie_map::load_with`]. Each loaded key buffer is UTF-8 validated;
+/// on failure the load aborts with [`RdbError::InvalidUtf8`].
+pub fn load_with<P, IO: RdbIO>(
+    reader: &mut IO,
+    opts: RdbOpts,
+    mut payload: impl FnMut(TrieEntry) -> P,
+) -> Result<StrTrieMap<P>, RdbError> {
+    let mut map = StrTrieMap::new();
+    load_entries(reader, opts, |key, entry| {
+        map.insert(&key, payload(entry));
+    })?;
+    Ok(map)
+}
+
+/// Deserialize a [`StrTrieMap<TrieEntry>`] from `reader`.
+///
+/// Shorthand for [`load_with`] with the identity payload mapping.
+pub fn load<IO: RdbIO>(reader: &mut IO, opts: RdbOpts) -> Result<StrTrieMap<TrieEntry>, RdbError> {
+    load_with(reader, opts, |entry| entry)
+}

--- a/src/redisearch_rs/trie_rdb/src/test_utils.rs
+++ b/src/redisearch_rs/trie_rdb/src/test_utils.rs
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Test-only in-memory implementation of [`RdbIO`].
+//!
+//! [`MockRdbIO`] records every write as a typed [`Op`] and replays the ops
+//! on read, standing in for a real `RedisModuleIO` handle. Both the
+//! byte-keyed and the str-keyed serializer test suites use it, so it lives
+//! here rather than in either suite: sharing one [`Op`] type is what lets
+//! the str-flavor suite assert its save traces equal the byte-flavor's.
+//!
+//! Gated behind the `test-utils` feature, which the crate's own
+//! dev-dependency on itself turns on; nothing in a production build compiles
+//! it.
+
+use super::*;
+
+/// One typed call against [`RdbIO`]. The wire-shape tests assert against
+/// `Vec<Op>` traces directly.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Op {
+    U64(u64),
+    F64(f64),
+    Bytes(Vec<u8>),
+}
+
+/// Round-trip [`RdbIO`] mock: `save_*` append to `ops`; `load_*` replay
+/// them in order from an internal read cursor. One buffer, so saving into
+/// the mock and then loading it back reproduces the production save→load
+/// path against a single endpoint — the shape the real `RedisModuleIO`
+/// handle has. `ops` is public so wire-shape tests can assert the exact
+/// recorded trace.
+#[derive(Default)]
+pub struct MockRdbIO {
+    pub ops: Vec<Op>,
+    read_pos: usize,
+    fail_after: Option<usize>,
+    read_calls: usize,
+}
+
+impl MockRdbIO {
+    /// Preload the mock with a known op stream, for load-only tests that
+    /// feed a hand-built (possibly malformed) trace rather than saving one.
+    pub fn from_ops(ops: Vec<Op>) -> Self {
+        Self {
+            ops,
+            ..Self::default()
+        }
+    }
+
+    /// Short-circuit `load_*` with an [`std::io::Error`] after `n`
+    /// successful reads, to exercise mid-stream IO failure paths.
+    pub fn fail_after(mut self, n: usize) -> Self {
+        self.fail_after = Some(n);
+        self
+    }
+
+    fn next_read(&mut self) -> io::Result<Op> {
+        if let Some(n) = self.fail_after
+            && self.read_calls >= n
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "mock: injected io failure",
+            ));
+        }
+        self.read_calls += 1;
+        let op = self.ops.get(self.read_pos).cloned().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::UnexpectedEof, "mock: op stream exhausted")
+        })?;
+        self.read_pos += 1;
+        Ok(op)
+    }
+}
+
+// The trie RDB wire format only ever uses u64/f64/buffer; the `i64`/`f32`
+// methods of the shared `RdbIO` trait exist for other consumers (e.g. RSE's
+// vecsim) and are never reached by `trie_rdb`'s serializers, so the mock
+// asserts that invariant rather than modeling them.
+impl RdbIO for MockRdbIO {
+    fn write_u64(&mut self, v: u64) {
+        self.ops.push(Op::U64(v));
+    }
+    fn write_f64(&mut self, v: f64) {
+        self.ops.push(Op::F64(v));
+    }
+    fn write_buffer(&mut self, b: &[u8]) {
+        self.ops.push(Op::Bytes(b.to_vec()));
+    }
+    fn write_i64(&mut self, _v: i64) {
+        unreachable!("trie_rdb never serializes i64");
+    }
+    fn write_f32(&mut self, _v: f32) {
+        unreachable!("trie_rdb never serializes f32");
+    }
+
+    fn read_u64(&mut self) -> io::Result<u64> {
+        match self.next_read()? {
+            Op::U64(v) => Ok(v),
+            op => panic!("mock: expected U64, got {op:?}"),
+        }
+    }
+    fn read_f64(&mut self) -> io::Result<f64> {
+        match self.next_read()? {
+            Op::F64(v) => Ok(v),
+            op => panic!("mock: expected F64, got {op:?}"),
+        }
+    }
+    fn read_buffer(&mut self) -> io::Result<Vec<u8>> {
+        match self.next_read()? {
+            Op::Bytes(v) => Ok(v),
+            op => panic!("mock: expected Bytes, got {op:?}"),
+        }
+    }
+    fn read_i64(&mut self) -> io::Result<i64> {
+        unreachable!("trie_rdb never deserializes i64");
+    }
+    fn read_f32(&mut self) -> io::Result<f32> {
+        unreachable!("trie_rdb never deserializes f32");
+    }
+}

--- a/src/redisearch_rs/trie_rdb/src/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/trie_map.rs
@@ -15,6 +15,7 @@
 
 use super::{RdbError, RdbOpts, read_entries, save_nul_terminated};
 use crate::{TrieEntry, WireFields};
+use lending_iterator::LendingIterator;
 use rdb_io::RdbIO;
 use trie_rs::TrieMap;
 
@@ -36,9 +37,10 @@ pub fn save_with<P, IO: RdbIO>(
 ) {
     writer.write_u64(map.n_unique_keys() as u64);
     let mut scratch = Vec::new();
-    for (key, payload) in map.iter() {
+    let mut entries = map.lending_iter();
+    while let Some((key, payload)) = entries.next() {
         let entry = fields(payload);
-        save_nul_terminated(writer, &mut scratch, &key);
+        save_nul_terminated(writer, &mut scratch, key);
         writer.write_f64(entry.score);
         if opts.payloads {
             save_nul_terminated(writer, &mut scratch, entry.payload.unwrap_or(&[]));

--- a/src/redisearch_rs/trie_rdb/src/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/trie_map.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! RDB serialization for the byte-keyed [`TrieMap`].
+//!
+//! This is the canonical serializer; the UTF-8-keyed [`crate::str_trie_map`]
+//! wrapper delegates to it. The wire format and framing rules are documented
+//! on the crate root.
+
+use super::{RdbError, RdbOpts, read_entries, save_nul_terminated};
+use crate::{TrieEntry, WireFields};
+use rdb_io::RdbIO;
+use trie_rs::TrieMap;
+
+/// Serialize a [`TrieMap`] with an arbitrary payload type to `writer` in
+/// the trie RDB wire format.
+///
+/// `fields` produces the wire fields ([`WireFields`]) for each entry's
+/// payload; which of them actually reach the wire is governed by `opts`.
+/// Payload types that carry no wire data map to constants (e.g. a `()`
+/// payload saving as score 1).
+///
+/// Iterates entries in lexicographic key order; the NUL framing applied to
+/// each field is documented on the crate root.
+pub fn save_with<P, IO: RdbIO>(
+    map: &TrieMap<P>,
+    writer: &mut IO,
+    opts: RdbOpts,
+    mut fields: impl for<'a> FnMut(&'a P) -> WireFields<'a>,
+) {
+    writer.write_u64(map.n_unique_keys() as u64);
+    let mut scratch = Vec::new();
+    for (key, payload) in map.iter() {
+        let entry = fields(payload);
+        save_nul_terminated(writer, &mut scratch, &key);
+        writer.write_f64(entry.score);
+        if opts.payloads {
+            save_nul_terminated(writer, &mut scratch, entry.payload.unwrap_or(&[]));
+        }
+        if opts.num_docs {
+            writer.write_u64(entry.num_docs);
+        }
+    }
+}
+
+/// Serialize a [`TrieMap<TrieEntry>`] to `writer` in the trie RDB wire
+/// format.
+///
+/// Shorthand for [`save_with`] with the identity field mapping.
+pub fn save<IO: RdbIO>(map: &TrieMap<TrieEntry>, writer: &mut IO, opts: RdbOpts) {
+    save_with(map, writer, opts, |entry| entry.into());
+}
+
+/// Deserialize a [`TrieMap`] with an arbitrary payload type from `reader`.
+///
+/// `opts` must match the [`RdbOpts`] used at save time. `payload` builds
+/// each stored payload from the decoded wire fields; payload types that
+/// carry no wire data simply discard them (e.g. `|_| ()`).
+pub fn load_with<P, IO: RdbIO>(
+    reader: &mut IO,
+    opts: RdbOpts,
+    mut payload: impl FnMut(TrieEntry) -> P,
+) -> Result<TrieMap<P>, RdbError> {
+    let mut map = TrieMap::new();
+    read_entries(reader, opts, Ok, |key, entry| {
+        map.insert(&key, payload(entry));
+    })?;
+    Ok(map)
+}
+
+/// Deserialize a [`TrieMap<TrieEntry>`] from `reader`.
+///
+/// Shorthand for [`load_with`] with the identity payload mapping.
+pub fn load<IO: RdbIO>(reader: &mut IO, opts: RdbOpts) -> Result<TrieMap<TrieEntry>, RdbError> {
+    load_with(reader, opts, |entry| entry)
+}

--- a/src/redisearch_rs/trie_rdb/tests/integration/main.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/main.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod str_trie_map;
+mod trie_map;

--- a/src/redisearch_rs/trie_rdb/tests/integration/str_trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/str_trie_map.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rdb::str_trie_map::{load, load_with, save, save_with};
+use trie_rdb::test_utils::{MockRdbIO, Op};
+use trie_rdb::{RdbError, RdbOpts, TrieEntry, WireFields, trie_map};
+use trie_rs::str_trie_map::StrTrieMap;
+
+fn entry(score: f64, payload: Option<&[u8]>, num_docs: u64) -> TrieEntry {
+    TrieEntry {
+        score,
+        payload: payload.map(<[u8]>::to_vec),
+        num_docs,
+    }
+}
+
+#[test]
+fn roundtrip_str_keys_with_all_opts() {
+    let mut map = StrTrieMap::new();
+    map.insert("alpha", entry(1.0, Some(b"p"), 3));
+    map.insert("héllo", entry(2.5, None, 7));
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: true,
+    };
+    let mut mock = MockRdbIO::default();
+    save(&map, &mut mock, opts);
+    let loaded = load(&mut mock, opts).expect("load should succeed");
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded.get("alpha"), Some(&entry(1.0, Some(b"p"), 3)));
+    assert_eq!(loaded.get("héllo"), Some(&entry(2.5, None, 7)));
+}
+
+#[test]
+fn invalid_utf8_key_errors() {
+    // count=1, key=<two stray high bytes + NUL>, score=1.0
+    let ops = vec![Op::U64(1), Op::Bytes(b"\xff\xfe\0".to_vec()), Op::F64(1.0)];
+    // Use `match` rather than `unwrap_err`: `StrTrieMap` doesn't impl
+    // `Debug`, and adding it just to satisfy the test would force a
+    // `Data: Debug` bound on every map instantiation.
+    match load(&mut MockRdbIO::from_ops(ops), RdbOpts::default()) {
+        Err(RdbError::InvalidUtf8) => {}
+        Err(other) => panic!("expected InvalidUtf8, got {other:?}"),
+        Ok(_) => panic!("expected InvalidUtf8 error, got Ok"),
+    }
+}
+
+#[test]
+fn unit_payload_roundtrip_str_keys() {
+    let mut map = StrTrieMap::new();
+    map.insert("héllo", ());
+    map.insert("world", ());
+    let mut mock = MockRdbIO::default();
+    save_with(&map, &mut mock, RdbOpts::default(), |()| WireFields {
+        score: 1.0,
+        payload: None,
+        num_docs: 0,
+    });
+
+    let loaded = load_with(&mut mock, RdbOpts::default(), |_| ()).expect("load should succeed");
+
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded.get("héllo"), Some(&()));
+    assert_eq!(loaded.get("world"), Some(&()));
+}
+
+#[test]
+fn save_wire_matches_trie_map_api() {
+    // Sanity-check: the wrapper produces the same Op trace as the
+    // byte-keyed trie_map API for an ASCII key set, since it delegates to
+    // crate::trie_map::save.
+    let mut str_map = StrTrieMap::new();
+    str_map.insert("x", entry(1.0, Some(b"pay"), 7));
+
+    let mut byte_map = trie_rs::TrieMap::new();
+    byte_map.insert(b"x", entry(1.0, Some(b"pay"), 7));
+
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: true,
+    };
+    let mut rec_str = MockRdbIO::default();
+    let mut rec_bytes = MockRdbIO::default();
+    save(&str_map, &mut rec_str, opts);
+    trie_map::save(&byte_map, &mut rec_bytes, opts);
+    assert_eq!(rec_str.ops, rec_bytes.ops);
+}

--- a/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rdb::test_utils::{MockRdbIO, Op};
+use trie_rdb::trie_map::{load, load_with, save, save_with};
+use trie_rdb::{RdbError, RdbOpts, TrieEntry, WireFields};
+use trie_rs::TrieMap;
+
+fn entry(score: f64, payload: Option<&[u8]>, num_docs: u64) -> TrieEntry {
+    TrieEntry {
+        score,
+        payload: payload.map(<[u8]>::to_vec),
+        num_docs,
+    }
+}
+
+fn round_trip(map: &TrieMap<TrieEntry>, opts: RdbOpts) -> TrieMap<TrieEntry> {
+    let mut mock = MockRdbIO::default();
+    save(map, &mut mock, opts);
+    load(&mut mock, opts).expect("load should succeed")
+}
+
+#[test]
+fn save_empty_map() {
+    let map: TrieMap<TrieEntry> = TrieMap::new();
+    let mut mock = MockRdbIO::default();
+    save(&map, &mut mock, RdbOpts::default());
+    assert_eq!(mock.ops, vec![Op::U64(0)]);
+}
+
+#[test]
+fn save_protocol_shape_keys_only() {
+    let mut map = TrieMap::new();
+    map.insert(b"alpha", entry(1.0, None, 0));
+    map.insert(b"beta", entry(2.5, None, 0));
+    let mut mock = MockRdbIO::default();
+    save(&map, &mut mock, RdbOpts::default());
+    assert_eq!(
+        mock.ops,
+        vec![
+            Op::U64(2),
+            Op::Bytes(b"alpha\0".to_vec()),
+            Op::F64(1.0),
+            Op::Bytes(b"beta\0".to_vec()),
+            Op::F64(2.5),
+        ]
+    );
+}
+
+#[test]
+fn save_protocol_shape_with_all_opts() {
+    let mut map = TrieMap::new();
+    map.insert(b"x", entry(1.0, Some(b"pay"), 7));
+    let mut mock = MockRdbIO::default();
+    save(
+        &map,
+        &mut mock,
+        RdbOpts {
+            payloads: true,
+            num_docs: true,
+        },
+    );
+    assert_eq!(
+        mock.ops,
+        vec![
+            Op::U64(1),
+            Op::Bytes(b"x\0".to_vec()),
+            Op::F64(1.0),
+            Op::Bytes(b"pay\0".to_vec()),
+            Op::U64(7),
+        ]
+    );
+}
+
+#[test]
+fn roundtrip_no_opts() {
+    let mut map = TrieMap::new();
+    map.insert(b"a", entry(1.0, None, 0));
+    map.insert(b"b", entry(2.0, None, 0));
+    let loaded = round_trip(&map, RdbOpts::default());
+    assert_eq!(loaded.n_unique_keys(), 2);
+    assert_eq!(loaded.find(b"a"), Some(&entry(1.0, None, 0)));
+    assert_eq!(loaded.find(b"b"), Some(&entry(2.0, None, 0)));
+}
+
+#[test]
+fn roundtrip_payloads_only() {
+    let mut map = TrieMap::new();
+    // num_docs is set but not persisted by the opts; it must come back as 0.
+    map.insert(b"foo", entry(1.0, Some(b"payload"), 99));
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let loaded = round_trip(&map, opts);
+    assert_eq!(loaded.find(b"foo"), Some(&entry(1.0, Some(b"payload"), 0)));
+}
+
+#[test]
+fn roundtrip_num_docs_only() {
+    let mut map = TrieMap::new();
+    // Payload is set but not persisted; it must come back as None.
+    map.insert(b"foo", entry(1.0, Some(b"ignored"), 42));
+    let opts = RdbOpts {
+        payloads: false,
+        num_docs: true,
+    };
+    let loaded = round_trip(&map, opts);
+    assert_eq!(loaded.find(b"foo"), Some(&entry(1.0, None, 42)));
+}
+
+#[test]
+fn roundtrip_both() {
+    let mut map = TrieMap::new();
+    map.insert(b"foo", entry(3.5, Some(b"pay"), 11));
+    map.insert(b"bar", entry(0.5, Some(b"x"), 1));
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: true,
+    };
+    let loaded = round_trip(&map, opts);
+    assert_eq!(loaded.find(b"foo"), Some(&entry(3.5, Some(b"pay"), 11)));
+    assert_eq!(loaded.find(b"bar"), Some(&entry(0.5, Some(b"x"), 1)));
+}
+
+#[test]
+fn empty_trie_roundtrip() {
+    let map: TrieMap<TrieEntry> = TrieMap::new();
+    let loaded = round_trip(&map, RdbOpts::default());
+    assert_eq!(loaded.n_unique_keys(), 0);
+}
+
+#[test]
+fn lex_order_preserved() {
+    let mut map = TrieMap::new();
+    for key in [b"zebra".as_slice(), b"apple", b"mango", b"banana"] {
+        map.insert(key, entry(1.0, None, 0));
+    }
+    let mut mock = MockRdbIO::default();
+    save(&map, &mut mock, RdbOpts::default());
+    let keys: Vec<Vec<u8>> = mock
+        .ops
+        .into_iter()
+        .filter_map(|op| match op {
+            Op::Bytes(mut b) => {
+                b.pop();
+                Some(b)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        keys,
+        vec![
+            b"apple".to_vec(),
+            b"banana".to_vec(),
+            b"mango".to_vec(),
+            b"zebra".to_vec(),
+        ]
+    );
+}
+
+#[test]
+fn empty_payload_normalizes_to_none() {
+    let mut from_empty = TrieMap::new();
+    from_empty.insert(b"k", entry(1.0, Some(b""), 0));
+    let mut from_none = TrieMap::new();
+    from_none.insert(b"k", entry(1.0, None, 0));
+
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let mut rec_empty = MockRdbIO::default();
+    let mut rec_none = MockRdbIO::default();
+    save(&from_empty, &mut rec_empty, opts);
+    save(&from_none, &mut rec_none, opts);
+    assert_eq!(
+        rec_empty.ops, rec_none.ops,
+        "empty Vec and None must match on the wire"
+    );
+
+    let loaded = load(&mut rec_empty, opts).unwrap();
+    assert_eq!(loaded.find(b"k").unwrap().payload, None);
+}
+
+#[test]
+fn trailing_nul_on_every_bytes_op() {
+    let mut map = TrieMap::new();
+    map.insert(b"abc", entry(1.0, Some(b"def"), 1));
+    let mut mock = MockRdbIO::default();
+    save(
+        &map,
+        &mut mock,
+        RdbOpts {
+            payloads: true,
+            num_docs: true,
+        },
+    );
+    for op in &mock.ops {
+        if let Op::Bytes(b) = op {
+            assert_eq!(b.last(), Some(&0), "bytes op missing trailing NUL: {b:?}");
+        }
+    }
+}
+
+#[test]
+fn io_error_propagates() {
+    let mut map = TrieMap::new();
+    map.insert(b"a", entry(1.0, None, 0));
+    let mut rec = MockRdbIO::default();
+    save(&map, &mut rec, RdbOpts::default());
+    // Recorded ops are U64(1), Bytes("a\0"), F64(1.0), so failing after the
+    // first one injects the error at the count read.
+    let mut mock = MockRdbIO::from_ops(rec.ops).fail_after(1);
+    let err = load(&mut mock, RdbOpts::default()).unwrap_err();
+    assert_eq!(err, RdbError::Io);
+}
+
+#[test]
+fn multibyte_utf8_keys_roundtrip() {
+    let mut map = TrieMap::new();
+    let k1 = "héllo".as_bytes();
+    let k2 = "日本語".as_bytes();
+    map.insert(k1, entry(1.0, None, 0));
+    map.insert(k2, entry(2.0, None, 0));
+    let loaded = round_trip(&map, RdbOpts::default());
+    assert_eq!(loaded.find(k1), Some(&entry(1.0, None, 0)));
+    assert_eq!(loaded.find(k2), Some(&entry(2.0, None, 0)));
+}
+
+#[test]
+fn unit_payload_save_matches_trie_entry_wire() {
+    // A `()` payload mapped to constant fields must be wire-identical to
+    // a `TrieEntry` map holding the same constants.
+    let mut unit_map = TrieMap::new();
+    unit_map.insert(b"a", ());
+    unit_map.insert(b"b", ());
+    let mut entry_map = TrieMap::new();
+    entry_map.insert(b"a", entry(1.0, None, 0));
+    entry_map.insert(b"b", entry(1.0, None, 0));
+
+    let mut rec_unit = MockRdbIO::default();
+    let mut rec_entry = MockRdbIO::default();
+    save_with(&unit_map, &mut rec_unit, RdbOpts::default(), |()| {
+        WireFields {
+            score: 1.0,
+            payload: None,
+            num_docs: 0,
+        }
+    });
+    save(&entry_map, &mut rec_entry, RdbOpts::default());
+
+    assert_eq!(rec_unit.ops, rec_entry.ops);
+}
+
+#[test]
+fn unit_payload_roundtrip_discards_wire_fields() {
+    let mut map = TrieMap::new();
+    map.insert(b"k", ());
+    let mut mock = MockRdbIO::default();
+    save_with(&map, &mut mock, RdbOpts::default(), |()| WireFields {
+        score: 1.0,
+        payload: None,
+        num_docs: 0,
+    });
+
+    let loaded = load_with(&mut mock, RdbOpts::default(), |_| ()).expect("load should succeed");
+
+    assert_eq!(loaded.n_unique_keys(), 1);
+    assert_eq!(loaded.find(b"k"), Some(&()));
+}
+
+#[test]
+fn missing_trailing_nul_errors() {
+    let ops = vec![
+        Op::U64(1),
+        Op::Bytes(b"abc".to_vec()), // missing trailing NUL
+        Op::F64(1.0),
+    ];
+    let err = load(&mut MockRdbIO::from_ops(ops), RdbOpts::default()).unwrap_err();
+    assert_eq!(err, RdbError::MissingTrailingNul);
+}
+
+#[test]
+fn payload_terminator_value_is_ignored() {
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let ops = vec![
+        Op::U64(1),
+        Op::Bytes(b"k\0".to_vec()),
+        Op::F64(1.0),
+        Op::Bytes(b"pay\xAA".to_vec()),
+    ];
+
+    let loaded = load(&mut MockRdbIO::from_ops(ops), opts).expect("load should succeed");
+
+    assert_eq!(
+        loaded.find(b"k").unwrap().payload.as_deref(),
+        Some(&b"pay"[..])
+    );
+}
+
+#[test]
+fn empty_payload_buffer_errors() {
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let ops = vec![
+        Op::U64(1),
+        Op::Bytes(b"k\0".to_vec()),
+        Op::F64(1.0),
+        Op::Bytes(Vec::new()), // no terminator slot at all
+    ];
+
+    let err = load(&mut MockRdbIO::from_ops(ops), opts).unwrap_err();
+
+    assert_eq!(err, RdbError::MissingTrailingNul);
+}
+
+#[test]
+fn key_terminator_value_is_still_checked_with_payloads_on() {
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let ops = vec![Op::U64(1), Op::Bytes(b"k\xAA".to_vec())];
+
+    let err = load(&mut MockRdbIO::from_ops(ops), opts).unwrap_err();
+
+    assert_eq!(err, RdbError::MissingTrailingNul);
+}

--- a/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
@@ -103,6 +103,20 @@ fn roundtrip_payloads_only() {
 }
 
 #[test]
+fn roundtrip_interior_nul_payload() {
+    // Payloads are length-framed, so a NUL inside the bytes must survive
+    // the round trip untouched; only the appended terminator is stripped.
+    let mut map = TrieMap::new();
+    map.insert(b"k", entry(1.0, Some(b"ab\0cd"), 0));
+    let opts = RdbOpts {
+        payloads: true,
+        num_docs: false,
+    };
+    let loaded = round_trip(&map, opts);
+    assert_eq!(loaded.find(b"k"), Some(&entry(1.0, Some(b"ab\0cd"), 0)));
+}
+
+#[test]
 fn roundtrip_num_docs_only() {
     let mut map = TrieMap::new();
     // Payload is set but not persisted; it must come back as None.

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -82,6 +82,11 @@ impl<Data> StrTrieMap<Data> {
         self.inner.mem_usage()
     }
 
+    /// Borrow the underlying byte-keyed [`TrieMap`].
+    pub const fn byte_trie(&self) -> &TrieMap<Data> {
+        &self.inner
+    }
+
     /// Iterate over all entries in lexicographical key order. See [`TrieMap::iter`].
     ///
     /// Yields `(String, &Data)` — keys are decoded back into owned `String`s


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the trie's RDB wire format exists only in C, in `TrieType_GenericSave` and
   `TrieType_GenericLoad`. Nothing on the Rust side can read or write it, so a Rust trie
   cannot own its own persistence.
2. Change: add a `trie_rdb` crate that saves and loads that format for both
   `trie_rs::TrieMap` (byte keys) and `StrTrieMap` (UTF-8 keys), generic over the payload
   type. IO goes through the existing `RdbIO` trait, so the crate makes no direct use of
   the Redis module API and is exercisable over a plain buffer.
3. Outcome: internal-only — no callers, and nothing wired into `src/rdb.c`. It is the
   substrate needed before trie persistence can move off the C implementation.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `trie_rdb` (new) — the shared substrate: `RdbOpts`, `RdbError`, the trailing-NUL
   framing helpers, the `read_entries` entry-stream reader, and the `TrieEntry` value type
   the wire fields are modeled on. Worth a reviewer's attention: a key's terminator is
   verified to be NUL, a payload's deliberately is not, because streams written before
   `triePayload_New` assigned that byte carry whatever heap value occupied the slot and
   must stay loadable.
2. `trie_rdb::byte` and `trie_rdb::str` — the two key flavors. `str` is a thin delegation
   to `byte` that decodes keys as UTF-8; both expose a `*_with` form that maps per-entry
   to and from the wire fields, plus a shorthand for maps storing `TrieEntry` itself.
3. `trie_rs::StrTrieMap` — new `byte_trie()` accessor, so the `str` flavor can borrow the
   backing byte trie rather than duplicate its traversal.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
