### PR TITLE
[MOD-16400] Trie - enforce C key and score domains on RDB save

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ RUST_TOOLCHAIN_MODIFIER="" # Rust toolchain to use (e.g., +nightly)
 
 # Rust code is built first, so exclude benchmarking crates that link C code,
 # since the static libraries they depend on haven't been built yet.
-EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude numeric_score_source_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude ttl_table_bencher --exclude vector_score_source_bencher"
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude numeric_score_source_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude trie_rdb_ffi --exclude ttl_table_bencher --exclude vector_score_source_bencher"
 
 # Retrieve our pinned nightly version.
 NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3325,8 +3325,10 @@ dependencies = [
 name = "trie_rdb"
 version = "0.0.1"
 dependencies = [
+ "ffi",
  "lending-iterator",
  "rdb_io",
+ "string_utils",
  "thiserror",
  "trie_rdb",
  "trie_rs",
@@ -3339,6 +3341,7 @@ version = "0.0.1"
 dependencies = [
  "cheadergen",
  "redis-module",
+ "redis_mock",
  "trie_rdb",
  "trie_rs",
  "workspace_hack",

--- a/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/Cargo.toml
@@ -14,3 +14,9 @@ redis-module.workspace = true
 trie_rs = { workspace = true }
 trie_rdb = { workspace = true }
 workspace_hack.workspace = true
+
+[dev-dependencies]
+redis_mock.workspace = true
+
+[target.'cfg(miri)'.dependencies]
+redis_mock.workspace = true

--- a/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
@@ -56,11 +56,18 @@ pub unsafe extern "C" fn LexTrieRs_Free(t: *mut LexTrieRs) {
     drop(unsafe { Box::from_raw(t) });
 }
 
-/// Serialize a [`LexTrieRs`] to `io` in the trie RDB wire format.
+/// Serialize a [`LexTrieRs`] to `io` in the wire format the C function
+/// `TrieType_GenericSave` writes.
 ///
-/// Mirrors the C function `TrieType_GenericSave` for a Rust-side trie.
-/// Save doesn't report errors at this layer; any underlying RDB IO error surfaces
-/// later via `RedisModule_IsIOError` on the load side.
+/// Returns `true` on success. Returns `false`, having written nothing at
+/// all, when the map holds a key `Trie_InsertStringBuffer` would refuse —
+/// the C loader drops such keys silently while the entry count still counts
+/// them, so the stream is refused rather than written. `io` is left as it
+/// was found, so the caller can write a substitute record in its place.
+///
+/// A `true` return is not a guarantee that the bytes reached the RDB file:
+/// the underlying `RedisModule_Save*` primitives report nothing, so an IO
+/// failure surfaces later via `RedisModule_IsIOError`.
 ///
 /// # Safety
 ///
@@ -76,7 +83,7 @@ pub unsafe extern "C" fn LexTrieRs_RdbSave(
     map: *const LexTrieRs,
     save_payloads: bool,
     save_num_docs: bool,
-) {
+) -> bool {
     debug_assert!(!io.is_null(), "io cannot be NULL");
     debug_assert!(!map.is_null(), "map cannot be NULL");
 
@@ -88,13 +95,17 @@ pub unsafe extern "C" fn LexTrieRs_RdbSave(
         payloads: save_payloads,
         num_docs: save_num_docs,
     };
-    str_rdb::save(&map.0, &mut rm_io, opts);
+    str_rdb::save(&map.0, &mut rm_io, opts).is_ok()
 }
 
-/// Deserialize a [`LexTrieRs`] from `io` in the trie RDB wire format.
+/// Deserialize a [`LexTrieRs`] from `io`, reading the wire format
+/// `TrieType_GenericSave` writes, and returning NULL on any RDB IO or
+/// framing error as `TrieType_GenericLoad` does.
 ///
-/// Mirrors the C function `TrieType_GenericLoad` for a Rust-side trie,
-/// including its NULL return on any RDB IO or framing error.
+/// Two differences from that function are deliberate. A key that is not
+/// valid UTF-8 fails the whole load here, where C pseudo-decodes it into
+/// runes; and the key restriction [`LexTrieRs_RdbSave`] enforces is not
+/// applied on load, so every stream C can write stays loadable.
 ///
 /// On success, the caller owns the returned pointer and must release it
 /// via [`LexTrieRs_Free`].

--- a/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/tests/handle.rs
+++ b/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/tests/handle.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Lifecycle of the [`LexTrieRs`] handle.
+//!
+//! The save and load entry points need a `RedisModuleIO`, which no Rust-side
+//! mock provides, so they are exercised from the C++ interop suite against
+//! `redismock`'s RDB IO instead. What is testable here is the allocation
+//! boundary — and it is worth testing under `miri`, which reports the leak or
+//! the double free these assertions cannot see on their own.
+
+use redis_mock::mock_or_stub_missing_redis_c_symbols;
+use trie_rdb_ffi::{LexTrieRs_Free, LexTrieRs_New};
+
+mock_or_stub_missing_redis_c_symbols!();
+
+#[test]
+fn new_allocates_a_handle_that_free_releases() {
+    let sut = LexTrieRs_New();
+
+    assert!(!sut.is_null());
+
+    // SAFETY: `sut` came from `LexTrieRs_New` and has not been freed.
+    unsafe { LexTrieRs_Free(sut) };
+}

--- a/src/redisearch_rs/headers/trie_rdb_ffi.h
+++ b/src/redisearch_rs/headers/trie_rdb_ffi.h
@@ -43,10 +43,14 @@ void LexTrieRs_Free(struct LexTrieRs *t);
 struct LexTrieRs *LexTrieRs_New(void);
 
 /**
- * Deserialize a [`LexTrieRs`] from `io` in the trie RDB wire format.
+ * Deserialize a [`LexTrieRs`] from `io`, reading the wire format
+ * `TrieType_GenericSave` writes, and returning NULL on any RDB IO or
+ * framing error as `TrieType_GenericLoad` does.
  *
- * Mirrors the C function `TrieType_GenericLoad` for a Rust-side trie,
- * including its NULL return on any RDB IO or framing error.
+ * Two differences from that function are deliberate. A key that is not
+ * valid UTF-8 fails the whole load here, where C pseudo-decodes it into
+ * runes; and the key restriction [`LexTrieRs_RdbSave`] enforces is not
+ * applied on load, so every stream C can write stays loadable.
  *
  * On success, the caller owns the returned pointer and must release it
  * via [`LexTrieRs_Free`].
@@ -60,11 +64,18 @@ struct LexTrieRs *LexTrieRs_New(void);
 struct LexTrieRs *LexTrieRs_RdbLoad(struct RedisModuleIO *io, bool load_payloads, bool load_num_docs);
 
 /**
- * Serialize a [`LexTrieRs`] to `io` in the trie RDB wire format.
+ * Serialize a [`LexTrieRs`] to `io` in the wire format the C function
+ * `TrieType_GenericSave` writes.
  *
- * Mirrors the C function `TrieType_GenericSave` for a Rust-side trie.
- * Save doesn't report errors at this layer; any underlying RDB IO error surfaces
- * later via `RedisModule_IsIOError` on the load side.
+ * Returns `true` on success. Returns `false`, having written nothing at
+ * all, when the map holds a key `Trie_InsertStringBuffer` would refuse —
+ * the C loader drops such keys silently while the entry count still counts
+ * them, so the stream is refused rather than written. `io` is left as it
+ * was found, so the caller can write a substitute record in its place.
+ *
+ * A `true` return is not a guarantee that the bytes reached the RDB file:
+ * the underlying `RedisModule_Save*` primitives report nothing, so an IO
+ * failure surfaces later via `RedisModule_IsIOError`.
  *
  * # Safety
  *
@@ -75,7 +86,7 @@ struct LexTrieRs *LexTrieRs_RdbLoad(struct RedisModuleIO *io, bool load_payloads
  *   immutably for the duration of the call; no aliasing mutable
  *   references must exist.
  */
-void LexTrieRs_RdbSave(struct RedisModuleIO *io, const struct LexTrieRs *map, bool save_payloads, bool save_num_docs);
+bool LexTrieRs_RdbSave(struct RedisModuleIO *io, const struct LexTrieRs *map, bool save_payloads, bool save_num_docs);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/rdb_io/src/lib.rs
+++ b/src/redisearch_rs/rdb_io/src/lib.rs
@@ -246,7 +246,7 @@ mod tests {
     /// write into the cursor, rewind, then read the same values back out. This
     /// is the sole test-only `Cursor` impl (the read-only `&[u8]` impl was
     /// dropped) and no OSS caller otherwise exercises it — `trie_rdb` uses its
-    /// own `RdbMock`.
+    /// own `MockRdbIO`.
     #[test]
     fn cursor_round_trip_all_primitives() {
         let mut backing = Vec::new();

--- a/src/redisearch_rs/string_utils/src/libnu.rs
+++ b/src/redisearch_rs/string_utils/src/libnu.rs
@@ -20,7 +20,9 @@
 //! This module models that decoder's walk once, for every caller that needs it:
 //! [`tail_may_overread`] says whether an input can trip the read-ahead,
 //! [`NU_MAX_READAHEAD`] says how many trailing zero bytes a padded copy needs
-//! when it can, and [`nu_rune_count`] says how many steps that walk takes.
+//! when it can, [`nu_rune_count`] says how many steps that walk takes, and
+//! [`nu_decodes_a_zero_codepoint`] says whether one of those steps produces
+//! the zero codepoint that C stops on.
 
 /// The most bytes the C decoder (`nu_utf8_read`) reads past a multibyte lead
 /// byte. A UTF-8 sequence is at most four bytes, so the decoder touches at most
@@ -89,6 +91,49 @@ pub fn nu_rune_count(bytes: &[u8]) -> usize {
     runes
 }
 
+/// Whether the C decoder produces the zero codepoint anywhere along its walk
+/// of `bytes` — the stopping condition of C's `strToRunes` that
+/// [`nu_rune_count`] cannot see.
+///
+/// A literal NUL byte produces it, but so do byte patterns no NUL scan finds:
+/// an overlong encoding of codepoint 0 such as `C0 80`, and a degenerate
+/// sequence assembling to zero such as the continuation pair `80 80` (the
+/// decoder treats a stray continuation byte as a two-byte lead and masks both
+/// bytes' value bits to nothing).
+///
+/// Replays the decoder's bit assembly exactly: no validation, only the value
+/// bits of each byte, over the [`nu_seq_len`] stride. A truncated trailing
+/// sequence is not stepped into — there the C decoder reads bytes outside the
+/// input, which no in-bounds replay can model — so this is only a complete
+/// answer when [`tail_may_overread`] is `false`.
+pub fn nu_decodes_a_zero_codepoint(bytes: &[u8]) -> bool {
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let Some(seq) = bytes.get(pos..pos + nu_seq_len(bytes[pos])) else {
+            return false;
+        };
+        let codepoint = match *seq {
+            [b0] => u32::from(b0),
+            [b0, b1] => (u32::from(b0) & 0x1F) << 6 | (u32::from(b1) & 0x3F),
+            [b0, b1, b2] => {
+                (u32::from(b0) & 0x0F) << 12 | (u32::from(b1) & 0x3F) << 6 | (u32::from(b2) & 0x3F)
+            }
+            [b0, b1, b2, b3] => {
+                (u32::from(b0) & 0x07) << 18
+                    | (u32::from(b1) & 0x3F) << 12
+                    | (u32::from(b2) & 0x3F) << 6
+                    | (u32::from(b3) & 0x3F)
+            }
+            _ => unreachable!("nu_seq_len returns 1..=4"),
+        };
+        if codepoint == 0 {
+            return true;
+        }
+        pos += seq.len();
+    }
+    false
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -145,6 +190,35 @@ mod test {
         // cursor stepping past the end.
         assert_eq!(nu_rune_count(b"a\xF0"), 2);
         assert_eq!(nu_rune_count(b"a\xE0\x80"), 2);
+    }
+
+    #[test]
+    fn zero_codepoint_walk_finds_every_zero_encoding() {
+        // The three shapes that hide a zero from a NUL-byte scan, plus the
+        // literal byte itself.
+        assert!(nu_decodes_a_zero_codepoint(b"ab\0cd"));
+        assert!(nu_decodes_a_zero_codepoint(b"a\xC0\x80b"));
+        assert!(nu_decodes_a_zero_codepoint(b"\x80\x80"));
+        assert!(nu_decodes_a_zero_codepoint(b"a\xE0\x80\x80"));
+        assert!(nu_decodes_a_zero_codepoint(b"a\xF0\x80\x80\x80"));
+    }
+
+    #[test]
+    fn zero_codepoint_walk_passes_well_formed_input() {
+        assert!(!nu_decodes_a_zero_codepoint(b""));
+        assert!(!nu_decodes_a_zero_codepoint(b"hello"));
+        assert!(!nu_decodes_a_zero_codepoint("日本".as_bytes()));
+        assert!(!nu_decodes_a_zero_codepoint("ab😀".as_bytes()));
+        // Malformed but nonzero: resynchronises and keeps walking.
+        assert!(!nu_decodes_a_zero_codepoint(b"\xC3(ab"));
+    }
+
+    #[test]
+    fn zero_codepoint_walk_stops_before_a_truncated_tail() {
+        // The truncated step itself is out of scope — `tail_may_overread`
+        // owns it — but a zero found before it must still be reported.
+        assert!(!nu_decodes_a_zero_codepoint(b"ab\xF0"));
+        assert!(nu_decodes_a_zero_codepoint(b"a\0b\xF0"));
     }
 
     #[test]

--- a/src/redisearch_rs/trie_rdb/Cargo.toml
+++ b/src/redisearch_rs/trie_rdb/Cargo.toml
@@ -15,8 +15,10 @@ workspace = true
 test-utils = []
 
 [dependencies]
+ffi.workspace = true
 lending-iterator.workspace = true
 rdb_io.workspace = true
+string_utils.workspace = true
 thiserror.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/trie_rdb/src/entry.rs
+++ b/src/redisearch_rs/trie_rdb/src/entry.rs
@@ -54,7 +54,9 @@ pub struct TrieEntry {
     /// Score associated with the entry. Semantics are caller-defined (e.g.
     /// suggestion weight, or a constant for index-term tries) and may be
     /// mutated by callers after the initial insert. The C trie stores this
-    /// as `float`; the RDB wire format widens it to `f64`.
+    /// as `float`; the RDB wire format widens it to `f64`, and the
+    /// serializers collapse it back — see
+    /// [score domain](crate#score-domain).
     pub score: f64,
     /// Optional opaque payload bytes.
     pub payload: Option<Vec<u8>>,

--- a/src/redisearch_rs/trie_rdb/src/lib.rs
+++ b/src/redisearch_rs/trie_rdb/src/lib.rs
@@ -100,6 +100,15 @@
 //! contain an out-of-domain key, and enforcing the domain on load would only
 //! turn streams C itself accepts into load failures.
 //!
+//! # Score domain
+//!
+//! The C trie stores each score as a `float`: its saver widens that `float`
+//! to the wire's `f64`, and its loader narrows the wire value back on
+//! insert, so no score survives a pass through C with more than `f32`
+//! precision. The serializers here collapse every score to that domain on
+//! both save and load, so a map round-trips to the same scores whichever
+//! implementation writes or reads the stream.
+//!
 //! # IO model
 //!
 //! The only way a save can fail is the key domain above — the write
@@ -140,7 +149,7 @@ pub(crate) fn read_entries<IO: RdbIO, K>(
     let count = reader.read_u64()?;
     for _ in 0..count {
         let key = key_from_bytes(load_nul_terminated(reader)?)?;
-        let score = reader.read_f64()?;
+        let score = quantize_score(reader.read_f64()?);
         let payload = opts
             .payloads
             .then(|| load_payload(reader))
@@ -240,6 +249,12 @@ pub enum SaveError {
     /// read past the end of the loaded buffer to complete.
     #[error("key ends in a truncated multibyte sequence, which the C trie would over-read")]
     TruncatedSequence,
+}
+
+/// Collapse `score` to the value it would hold after a pass through the C
+/// trie's `float` storage — see [score domain](crate#score-domain).
+pub(crate) const fn quantize_score(score: f64) -> f64 {
+    score as f32 as f64
 }
 
 /// Reject a key the C trie could not store faithfully.

--- a/src/redisearch_rs/trie_rdb/src/lib.rs
+++ b/src/redisearch_rs/trie_rdb/src/lib.rs
@@ -55,21 +55,60 @@
 //!
 //! The two field kinds differ in how much of that framing the loader trusts.
 //! A key's terminator is verified to be NUL. A payload's is not: RDB files and
-//! replication streams written earlier by C carry whatever heap byte occupied
-//! that slot, and they must stay loadable. Only the byte's presence is guaranteed,
-//! so [`load_payload`] discards it unread and rejects nothing but the zero-length buffer.
+//! replication streams written before `triePayload_New` assigned the
+//! terminator carry whatever heap byte occupied that slot, and they must stay
+//! loadable. Only the byte's presence is guaranteed, so [`load_payload`]
+//! discards it unread and rejects nothing but the zero-length buffer.
 //!
 //! # Empty-payload normalization
 //!
 //! When [`RdbOpts::payloads`] is `true`, both `payload: None` and
 //! `payload: Some(vec![])` emit a single-NUL buffer (`"\0"`) and load back as
-//! `None`.
+//! `None`. This mirrors the C-side collapse `payload.len ? &payload : NULL`.
+//!
+//! # Key domain
+//!
+//! C's `Trie_InsertStringBuffer` — the insertion path `TrieType_GenericLoad`
+//! feeds every loaded entry through — accepts only a narrow set of keys, and
+//! silently ignores the rest: a key must be non-empty, at most
+//! [`MAX_KEY_BYTES`] bytes long, and decode to at most [`MAX_KEY_RUNES`]
+//! runes. C's decoder additionally stops at the first *zero codepoint* it
+//! decodes — produced by a literal NUL byte, but also by byte patterns no NUL
+//! scan finds, such as the overlong sequence `C0 80` or the continuation pair
+//! `80 80` — so a key carrying one would enter the C trie truncated to its
+//! prefix, or not at all. The entry count is written ahead of the entries and
+//! is not revised for any of this, so a stream holding such a key loads into
+//! C as a trie that has fewer entries than its own header claims. A key
+//! ending in a truncated multibyte sequence is worse still: C's decoder
+//! strides a fixed 1–4 bytes per step with no bounds check, so completing the
+//! final sequence would read past the end of the loaded buffer.
+//!
+//! The savers therefore reject those keys instead of emitting a stream C
+//! would mis-load. Every key is checked before the first byte is written, so
+//! a save that returns [`SaveError`] has left `writer` untouched and the
+//! caller is free to write something else in its place.
+//!
+//! Passing the check makes a key loadable by C, not byte-stable through it:
+//! C holds keys as `u16` runes, so a key that is not valid UTF-8, or that
+//! carries codepoints beyond the Basic Multilingual Plane, re-emerges from a
+//! pass through C with different bytes — and two such keys can even collapse
+//! into one when their decodes coincide. Byte identity through C is
+//! guaranteed only for valid UTF-8 keys confined to that plane, which every
+//! [`str_trie_map`]-flavor key without astral codepoints is.
+//!
+//! Loading applies no such check, deliberately: a stream written by C cannot
+//! contain an out-of-domain key, and enforcing the domain on load would only
+//! turn streams C itself accepts into load failures.
 //!
 //! # IO model
 //!
-//! Save is infallible at the Rust API level, matching the void-returning C
-//! `RedisModule_Save*` primitives. Errors only surface on load through
-//! [`RdbError`].
+//! The only way a save can fail is the key domain above — the write
+//! primitives are the void-returning C `RedisModule_Save*` and report nothing
+//! back. IO errors therefore surface only on load, through [`RdbError`].
+//! Payloads in particular are not validated: they are opaque bytes at this
+//! layer, but C's loader aborts the whole load on a payload whose size (plus
+//! terminator) does not fit its `u32` length field, so a payload approaching
+//! 4 GiB produces a stream C refuses to load.
 
 pub mod entry;
 pub mod str_trie_map;
@@ -80,6 +119,7 @@ pub mod trie_map;
 use std::io;
 
 use rdb_io::RdbIO;
+use string_utils::libnu::{nu_decodes_a_zero_codepoint, nu_rune_count, tail_may_overread};
 
 pub use entry::{TrieEntry, WireFields};
 
@@ -155,6 +195,74 @@ pub(crate) fn load_payload<IO: RdbIO>(reader: &mut IO) -> Result<Vec<u8>, RdbErr
         return Err(RdbError::MissingTrailingNul);
     }
     Ok(buf)
+}
+
+/// The fixed capacity the C trie sizes its key limits against.
+const TRIE_INITIAL_STRING_LEN: usize = ffi::TRIE_INITIAL_STRING_LEN as usize;
+
+/// Longest key, in bytes, that C's `Trie_InsertStringBuffer` accepts.
+///
+/// It rejects anything longer outright, before decoding — see
+/// [key domain](crate#key-domain).
+pub const MAX_KEY_BYTES: usize = TRIE_INITIAL_STRING_LEN * size_of::<ffi::rune>();
+
+/// Most runes a key may decode to for C's `Trie_InsertRune` to accept it.
+///
+/// One below [`TRIE_INITIAL_STRING_LEN`], since C compares with a strict
+/// `<` to leave room for the terminator its rune buffers carry.
+#[expect(rustdoc::private_intra_doc_links)]
+pub const MAX_KEY_RUNES: usize = TRIE_INITIAL_STRING_LEN - 1;
+
+/// Reasons a key makes a map unserializable — see
+/// [key domain](crate#key-domain) for why each one is fatal.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SaveError {
+    /// The map holds the empty key.
+    #[error("the empty key cannot be stored by the C trie")]
+    EmptyKey,
+    /// A key exceeds [`MAX_KEY_BYTES`].
+    #[error("key of {bytes} bytes exceeds the C trie's {MAX_KEY_BYTES}-byte limit")]
+    KeyTooLong {
+        /// Length of the offending key, in bytes.
+        bytes: usize,
+    },
+    /// A key decodes to more than [`MAX_KEY_RUNES`] runes.
+    #[error("key of {runes} runes exceeds the C trie's {MAX_KEY_RUNES}-rune limit")]
+    TooManyRunes {
+        /// Rune count of the offending key, per [`nu_rune_count`].
+        runes: usize,
+    },
+    /// A key decodes to a zero codepoint before its end, where C's decoder
+    /// would stop — truncating the key, or dropping it entirely.
+    #[error("key decodes to a zero codepoint, at which the C trie would cut it short")]
+    DecodesToNul,
+    /// A key ends in a truncated multibyte sequence, which C's decoder would
+    /// read past the end of the loaded buffer to complete.
+    #[error("key ends in a truncated multibyte sequence, which the C trie would over-read")]
+    TruncatedSequence,
+}
+
+/// Reject a key the C trie could not store faithfully.
+pub(crate) fn validate_key(key: &[u8]) -> Result<(), SaveError> {
+    if key.is_empty() {
+        return Err(SaveError::EmptyKey);
+    }
+    if key.len() > MAX_KEY_BYTES {
+        return Err(SaveError::KeyTooLong { bytes: key.len() });
+    }
+    if tail_may_overread(key) {
+        return Err(SaveError::TruncatedSequence);
+    }
+    if nu_decodes_a_zero_codepoint(key) {
+        return Err(SaveError::DecodesToNul);
+    }
+    // With both walks above clean, the rune count replays C's decode without
+    // hitting either condition it cannot model, so it cannot over-count.
+    let runes = nu_rune_count(key);
+    if runes > MAX_KEY_RUNES {
+        return Err(SaveError::TooManyRunes { runes });
+    }
+    Ok(())
 }
 
 /// Controls which optional fields are present on the wire.

--- a/src/redisearch_rs/trie_rdb/src/str_trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/str_trie_map.rs
@@ -14,8 +14,16 @@
 //! is validated with [`String::from_utf8`], so non-UTF-8 input surfaces as
 //! [`RdbError::InvalidUtf8`] rather than silently materializing as an
 //! ill-formed `String`.
+//!
+//! That makes this wrapper fit only for tries whose keys are UTF-8 by
+//! construction — the lexicographic dictionaries. C's trie keys are `rune`
+//! arrays that libnu produces from arbitrary bytes without ever validating
+//! them, so a trie fed from user input directly (`FT.SUGADD`'s) can hold keys
+//! that re-encode to byte sequences no UTF-8 decoder accepts. Serializing one
+//! of those needs a rune-keyed flavor alongside [`crate::trie_map`], not this
+//! wrapper.
 
-use super::{RdbError, RdbOpts, read_entries, trie_map};
+use super::{RdbError, RdbOpts, SaveError, read_entries, trie_map};
 use crate::{TrieEntry, WireFields};
 use rdb_io::RdbIO;
 use trie_rs::str_trie_map::StrTrieMap;
@@ -25,22 +33,28 @@ use trie_rs::str_trie_map::StrTrieMap;
 ///
 /// `fields` produces the wire fields for each entry's payload, as in
 /// [`crate::trie_map::save_with`]. Delegates to it on the inner byte-keyed
-/// [`trie_rs::TrieMap`].
+/// [`trie_rs::TrieMap`], and so enforces the same
+/// [key domain](crate#key-domain): a `String` key is UTF-8, but that alone
+/// does not put it in range of the C trie.
 pub fn save_with<P, IO: RdbIO>(
     map: &StrTrieMap<P>,
     writer: &mut IO,
     opts: RdbOpts,
     fields: impl for<'a> FnMut(&'a P) -> WireFields<'a>,
-) {
-    trie_map::save_with(map.byte_trie(), writer, opts, fields);
+) -> Result<(), SaveError> {
+    trie_map::save_with(map.byte_trie(), writer, opts, fields)
 }
 
 /// Serialize a [`StrTrieMap<TrieEntry>`] to `writer` in the trie RDB wire
 /// format.
 ///
 /// Shorthand for [`save_with`] with the identity field mapping.
-pub fn save<IO: RdbIO>(map: &StrTrieMap<TrieEntry>, writer: &mut IO, opts: RdbOpts) {
-    trie_map::save(map.byte_trie(), writer, opts);
+pub fn save<IO: RdbIO>(
+    map: &StrTrieMap<TrieEntry>,
+    writer: &mut IO,
+    opts: RdbOpts,
+) -> Result<(), SaveError> {
+    trie_map::save(map.byte_trie(), writer, opts)
 }
 
 /// Stream the entries of a serialized trie from `reader`, in stream order,

--- a/src/redisearch_rs/trie_rdb/src/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/trie_map.rs
@@ -13,7 +13,7 @@
 //! wrapper delegates to it. The wire format and framing rules are documented
 //! on the crate root.
 
-use super::{RdbError, RdbOpts, read_entries, save_nul_terminated};
+use super::{RdbError, RdbOpts, SaveError, read_entries, save_nul_terminated, validate_key};
 use crate::{TrieEntry, WireFields};
 use lending_iterator::LendingIterator;
 use rdb_io::RdbIO;
@@ -29,12 +29,23 @@ use trie_rs::TrieMap;
 ///
 /// Iterates entries in lexicographic key order; the NUL framing applied to
 /// each field is documented on the crate root.
+///
+/// Returns [`SaveError`] without writing anything when any key falls outside
+/// the [key domain](crate#key-domain).
 pub fn save_with<P, IO: RdbIO>(
     map: &TrieMap<P>,
     writer: &mut IO,
     opts: RdbOpts,
     mut fields: impl for<'a> FnMut(&'a P) -> WireFields<'a>,
-) {
+) -> Result<(), SaveError> {
+    // A full pass before the first write, because the entry count leads the
+    // stream: bailing out mid-loop would leave a truncated, self-inconsistent
+    // record behind.
+    let mut keys = map.lending_iter();
+    while let Some((key, _)) = keys.next() {
+        validate_key(key)?;
+    }
+
     writer.write_u64(map.n_unique_keys() as u64);
     let mut scratch = Vec::new();
     let mut entries = map.lending_iter();
@@ -49,14 +60,19 @@ pub fn save_with<P, IO: RdbIO>(
             writer.write_u64(entry.num_docs);
         }
     }
+    Ok(())
 }
 
 /// Serialize a [`TrieMap<TrieEntry>`] to `writer` in the trie RDB wire
 /// format.
 ///
 /// Shorthand for [`save_with`] with the identity field mapping.
-pub fn save<IO: RdbIO>(map: &TrieMap<TrieEntry>, writer: &mut IO, opts: RdbOpts) {
-    save_with(map, writer, opts, |entry| entry.into());
+pub fn save<IO: RdbIO>(
+    map: &TrieMap<TrieEntry>,
+    writer: &mut IO,
+    opts: RdbOpts,
+) -> Result<(), SaveError> {
+    save_with(map, writer, opts, |entry| entry.into())
 }
 
 /// Deserialize a [`TrieMap`] with an arbitrary payload type from `reader`.

--- a/src/redisearch_rs/trie_rdb/src/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/src/trie_map.rs
@@ -13,7 +13,9 @@
 //! wrapper delegates to it. The wire format and framing rules are documented
 //! on the crate root.
 
-use super::{RdbError, RdbOpts, SaveError, read_entries, save_nul_terminated, validate_key};
+use super::{
+    RdbError, RdbOpts, SaveError, quantize_score, read_entries, save_nul_terminated, validate_key,
+};
 use crate::{TrieEntry, WireFields};
 use lending_iterator::LendingIterator;
 use rdb_io::RdbIO;
@@ -52,7 +54,7 @@ pub fn save_with<P, IO: RdbIO>(
     while let Some((key, payload)) = entries.next() {
         let entry = fields(payload);
         save_nul_terminated(writer, &mut scratch, key);
-        writer.write_f64(entry.score);
+        writer.write_f64(quantize_score(entry.score));
         if opts.payloads {
             save_nul_terminated(writer, &mut scratch, entry.payload.unwrap_or(&[]));
         }

--- a/src/redisearch_rs/trie_rdb/tests/integration/str_trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/str_trie_map.rs
@@ -9,7 +9,7 @@
 
 use trie_rdb::str_trie_map::{load, load_with, save, save_with};
 use trie_rdb::test_utils::{MockRdbIO, Op};
-use trie_rdb::{RdbError, RdbOpts, TrieEntry, WireFields, trie_map};
+use trie_rdb::{MAX_KEY_RUNES, RdbError, RdbOpts, SaveError, TrieEntry, WireFields, trie_map};
 use trie_rs::str_trie_map::StrTrieMap;
 
 fn entry(score: f64, payload: Option<&[u8]>, num_docs: u64) -> TrieEntry {
@@ -30,7 +30,7 @@ fn roundtrip_str_keys_with_all_opts() {
         num_docs: true,
     };
     let mut mock = MockRdbIO::default();
-    save(&map, &mut mock, opts);
+    save(&map, &mut mock, opts).expect("save should succeed");
     let loaded = load(&mut mock, opts).expect("load should succeed");
     assert_eq!(loaded.len(), 2);
     assert_eq!(loaded.get("alpha"), Some(&entry(1.0, Some(b"p"), 3)));
@@ -61,13 +61,47 @@ fn unit_payload_roundtrip_str_keys() {
         score: 1.0,
         payload: None,
         num_docs: 0,
-    });
+    })
+    .expect("save should succeed");
 
     let loaded = load_with(&mut mock, RdbOpts::default(), |_| ()).expect("load should succeed");
 
     assert_eq!(loaded.len(), 2);
     assert_eq!(loaded.get("héllo"), Some(&()));
     assert_eq!(loaded.get("world"), Some(&()));
+}
+
+#[test]
+fn save_rejects_out_of_domain_key() {
+    // A `String` key is UTF-8 but still not necessarily storable by the C
+    // trie; the wrapper inherits the byte flavor's domain check.
+    let mut map = StrTrieMap::new();
+    map.insert(&"a".repeat(MAX_KEY_RUNES + 1), entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(
+        err,
+        SaveError::TooManyRunes {
+            runes: MAX_KEY_RUNES + 1
+        }
+    );
+    assert!(mock.ops.is_empty());
+}
+
+#[test]
+fn save_rejects_key_with_embedded_nul() {
+    // Valid UTF-8 can still carry a literal NUL, the one zero-codepoint
+    // encoding the str flavor's keys can reach.
+    let mut map = StrTrieMap::new();
+    map.insert("a\0b", entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(err, SaveError::DecodesToNul);
+    assert!(mock.ops.is_empty());
 }
 
 #[test]
@@ -87,7 +121,7 @@ fn save_wire_matches_trie_map_api() {
     };
     let mut rec_str = MockRdbIO::default();
     let mut rec_bytes = MockRdbIO::default();
-    save(&str_map, &mut rec_str, opts);
-    trie_map::save(&byte_map, &mut rec_bytes, opts);
+    save(&str_map, &mut rec_str, opts).expect("save should succeed");
+    trie_map::save(&byte_map, &mut rec_bytes, opts).expect("save should succeed");
     assert_eq!(rec_str.ops, rec_bytes.ops);
 }

--- a/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
@@ -9,7 +9,7 @@
 
 use trie_rdb::test_utils::{MockRdbIO, Op};
 use trie_rdb::trie_map::{load, load_with, save, save_with};
-use trie_rdb::{RdbError, RdbOpts, TrieEntry, WireFields};
+use trie_rdb::{MAX_KEY_BYTES, MAX_KEY_RUNES, RdbError, RdbOpts, SaveError, TrieEntry, WireFields};
 use trie_rs::TrieMap;
 
 fn entry(score: f64, payload: Option<&[u8]>, num_docs: u64) -> TrieEntry {
@@ -22,7 +22,7 @@ fn entry(score: f64, payload: Option<&[u8]>, num_docs: u64) -> TrieEntry {
 
 fn round_trip(map: &TrieMap<TrieEntry>, opts: RdbOpts) -> TrieMap<TrieEntry> {
     let mut mock = MockRdbIO::default();
-    save(map, &mut mock, opts);
+    save(map, &mut mock, opts).expect("save should succeed");
     load(&mut mock, opts).expect("load should succeed")
 }
 
@@ -30,7 +30,7 @@ fn round_trip(map: &TrieMap<TrieEntry>, opts: RdbOpts) -> TrieMap<TrieEntry> {
 fn save_empty_map() {
     let map: TrieMap<TrieEntry> = TrieMap::new();
     let mut mock = MockRdbIO::default();
-    save(&map, &mut mock, RdbOpts::default());
+    save(&map, &mut mock, RdbOpts::default()).expect("save should succeed");
     assert_eq!(mock.ops, vec![Op::U64(0)]);
 }
 
@@ -40,7 +40,7 @@ fn save_protocol_shape_keys_only() {
     map.insert(b"alpha", entry(1.0, None, 0));
     map.insert(b"beta", entry(2.5, None, 0));
     let mut mock = MockRdbIO::default();
-    save(&map, &mut mock, RdbOpts::default());
+    save(&map, &mut mock, RdbOpts::default()).expect("save should succeed");
     assert_eq!(
         mock.ops,
         vec![
@@ -65,7 +65,8 @@ fn save_protocol_shape_with_all_opts() {
             payloads: true,
             num_docs: true,
         },
-    );
+    )
+    .expect("save should succeed");
     assert_eq!(
         mock.ops,
         vec![
@@ -157,7 +158,7 @@ fn lex_order_preserved() {
         map.insert(key, entry(1.0, None, 0));
     }
     let mut mock = MockRdbIO::default();
-    save(&map, &mut mock, RdbOpts::default());
+    save(&map, &mut mock, RdbOpts::default()).expect("save should succeed");
     let keys: Vec<Vec<u8>> = mock
         .ops
         .into_iter()
@@ -193,8 +194,8 @@ fn empty_payload_normalizes_to_none() {
     };
     let mut rec_empty = MockRdbIO::default();
     let mut rec_none = MockRdbIO::default();
-    save(&from_empty, &mut rec_empty, opts);
-    save(&from_none, &mut rec_none, opts);
+    save(&from_empty, &mut rec_empty, opts).expect("save should succeed");
+    save(&from_none, &mut rec_none, opts).expect("save should succeed");
     assert_eq!(
         rec_empty.ops, rec_none.ops,
         "empty Vec and None must match on the wire"
@@ -216,7 +217,8 @@ fn trailing_nul_on_every_bytes_op() {
             payloads: true,
             num_docs: true,
         },
-    );
+    )
+    .expect("save should succeed");
     for op in &mock.ops {
         if let Op::Bytes(b) = op {
             assert_eq!(b.last(), Some(&0), "bytes op missing trailing NUL: {b:?}");
@@ -229,9 +231,10 @@ fn io_error_propagates() {
     let mut map = TrieMap::new();
     map.insert(b"a", entry(1.0, None, 0));
     let mut rec = MockRdbIO::default();
-    save(&map, &mut rec, RdbOpts::default());
-    // Recorded ops are U64(1), Bytes("a\0"), F64(1.0), so failing after the
-    // first one injects the error at the count read.
+    save(&map, &mut rec, RdbOpts::default()).expect("save should succeed");
+    // Recorded ops are U64(1), Bytes("a\0"), F64(1.0). Letting exactly one
+    // read succeed puts the failure on the key buffer, mid-entry, rather
+    // than on the count that precedes the loop.
     let mut mock = MockRdbIO::from_ops(rec.ops).fail_after(1);
     let err = load(&mut mock, RdbOpts::default()).unwrap_err();
     assert_eq!(err, RdbError::Io);
@@ -268,8 +271,9 @@ fn unit_payload_save_matches_trie_entry_wire() {
             payload: None,
             num_docs: 0,
         }
-    });
-    save(&entry_map, &mut rec_entry, RdbOpts::default());
+    })
+    .expect("save should succeed");
+    save(&entry_map, &mut rec_entry, RdbOpts::default()).expect("save should succeed");
 
     assert_eq!(rec_unit.ops, rec_entry.ops);
 }
@@ -283,7 +287,8 @@ fn unit_payload_roundtrip_discards_wire_fields() {
         score: 1.0,
         payload: None,
         num_docs: 0,
-    });
+    })
+    .expect("save should succeed");
 
     let loaded = load_with(&mut mock, RdbOpts::default(), |_| ()).expect("load should succeed");
 
@@ -339,6 +344,117 @@ fn empty_payload_buffer_errors() {
     let err = load(&mut MockRdbIO::from_ops(ops), opts).unwrap_err();
 
     assert_eq!(err, RdbError::MissingTrailingNul);
+}
+
+#[test]
+fn save_rejects_empty_key() {
+    let mut map = TrieMap::new();
+    map.insert(b"", entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(err, SaveError::EmptyKey);
+}
+
+#[test]
+fn save_rejects_key_over_byte_limit() {
+    let mut map = TrieMap::new();
+    // Multi-byte, so the key trips the byte limit rather than the rune one.
+    let key = "é".repeat(MAX_KEY_BYTES / 2 + 1).into_bytes();
+    map.insert(&key, entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(err, SaveError::KeyTooLong { bytes: key.len() });
+}
+
+#[test]
+fn save_rejects_key_over_rune_limit() {
+    let mut map = TrieMap::new();
+    map.insert(&vec![b'a'; MAX_KEY_RUNES + 1], entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(
+        err,
+        SaveError::TooManyRunes {
+            runes: MAX_KEY_RUNES + 1
+        }
+    );
+}
+
+#[test]
+fn save_rejects_key_with_embedded_nul() {
+    let mut map = TrieMap::new();
+    map.insert(b"a\0b", entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(err, SaveError::DecodesToNul);
+}
+
+#[test]
+fn save_rejects_key_decoding_to_a_zero_codepoint_without_a_nul_byte() {
+    // Both keys hold no NUL byte, yet C's decoder reads a zero codepoint out
+    // of them: the continuation pair as the whole key (C drops the entry),
+    // the overlong encoding mid-key (C truncates the key at it).
+    for key in [b"\x80\x80".as_slice(), b"a\xC0\x80b"] {
+        let mut map = TrieMap::new();
+        map.insert(key, entry(1.0, None, 0));
+        let mut mock = MockRdbIO::default();
+
+        let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+        assert_eq!(err, SaveError::DecodesToNul, "key {key:?}");
+        assert!(mock.ops.is_empty(), "key {key:?}");
+    }
+}
+
+#[test]
+fn save_rejects_key_ending_in_a_truncated_sequence() {
+    let mut map = TrieMap::new();
+    map.insert(b"ab\xF0", entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    let err = save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert_eq!(err, SaveError::TruncatedSequence);
+}
+
+#[test]
+fn save_accepts_key_at_both_limits() {
+    // Astral characters occupy four bytes each, so a key can sit exactly on
+    // the byte limit while staying well inside the rune limit — the case
+    // that separates rune counting from byte counting.
+    let mut map = TrieMap::new();
+    let astral = "😀".repeat(MAX_KEY_BYTES / 4);
+    map.insert(astral.as_bytes(), entry(1.0, None, 0));
+    map.insert(&vec![b'a'; MAX_KEY_RUNES], entry(2.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    save(&map, &mut mock, RdbOpts::default()).expect("both keys are in domain");
+
+    assert_eq!(mock.ops.first(), Some(&Op::U64(2)));
+}
+
+#[test]
+fn a_rejected_key_suppresses_the_whole_stream() {
+    let mut map = TrieMap::new();
+    map.insert(b"fine", entry(1.0, None, 0));
+    map.insert(b"", entry(1.0, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    save(&map, &mut mock, RdbOpts::default()).unwrap_err();
+
+    assert!(
+        mock.ops.is_empty(),
+        "validation must precede the count write: {:?}",
+        mock.ops
+    );
 }
 
 #[test]

--- a/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
+++ b/src/redisearch_rs/trie_rdb/tests/integration/trie_map.rs
@@ -469,3 +469,66 @@ fn key_terminator_value_is_still_checked_with_payloads_on() {
 
     assert_eq!(err, RdbError::MissingTrailingNul);
 }
+
+#[test]
+fn save_quantizes_score_to_f32_domain() {
+    let over_precise = 1.000_000_000_1_f64;
+    assert_ne!(over_precise as f32 as f64, over_precise);
+
+    let mut map = TrieMap::new();
+    map.insert(b"k", entry(over_precise, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    save(&map, &mut mock, RdbOpts::default()).expect("save should succeed");
+
+    assert_eq!(
+        mock.ops,
+        vec![
+            Op::U64(1),
+            Op::Bytes(b"k\0".to_vec()),
+            Op::F64(over_precise as f32 as f64),
+        ]
+    );
+}
+
+#[test]
+fn load_quantizes_score_to_f32_domain() {
+    // Only a hand-authored stream can carry an over-precise score — a saved
+    // one is already quantized — so this pins the load side on its own.
+    let over_precise = 1.000_000_000_1_f64;
+    assert_ne!(over_precise as f32 as f64, over_precise);
+
+    let ops = vec![
+        Op::U64(1),
+        Op::Bytes(b"k\0".to_vec()),
+        Op::F64(over_precise),
+    ];
+    let loaded = load(&mut MockRdbIO::from_ops(ops), RdbOpts::default()).unwrap();
+
+    assert_eq!(
+        loaded.find(b"k"),
+        Some(&entry(over_precise as f32 as f64, None, 0))
+    );
+}
+
+#[test]
+fn quantization_preserves_non_finite_scores() {
+    // The f32 round-trip must pass NaN and the infinities through rather
+    // than manufacture a finite value; f64::MAX collapses to infinity the
+    // same way C's double-to-float narrowing overflows it.
+    let mut map = TrieMap::new();
+    map.insert(b"inf", entry(f64::INFINITY, None, 0));
+    map.insert(b"max", entry(f64::MAX, None, 0));
+    map.insert(b"nan", entry(f64::NAN, None, 0));
+    map.insert(b"neg", entry(f64::NEG_INFINITY, None, 0));
+    let mut mock = MockRdbIO::default();
+
+    save(&map, &mut mock, RdbOpts::default()).expect("save should succeed");
+
+    let loaded = load(&mut mock, RdbOpts::default()).unwrap();
+    assert_eq!(loaded.find(b"inf").unwrap().score, f64::INFINITY);
+    assert_eq!(loaded.find(b"max").unwrap().score, f64::INFINITY);
+    assert_eq!(loaded.find(b"neg").unwrap().score, f64::NEG_INFINITY);
+    // NaN fails PartialEq against itself, so it needs its own predicate.
+    assert!(loaded.find(b"nan").unwrap().score.is_nan());
+}

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -1320,7 +1320,7 @@ static void expectRdbInterop(Trie *original, bool payloads, bool numDocs,
   });
   ASSERT_TRUE(ioRust != nullptr);
 
-  LexTrieRs_RdbSave(ioRust, rustMap, payloads, numDocs);
+  ASSERT_TRUE(LexTrieRs_RdbSave(ioRust, rustMap, payloads, numDocs));
   EXPECT_EQ(0, RMCK_IsIOError(ioRust));
   EXPECT_EQ(ioC->buffer, ioRust->buffer);
 
@@ -1420,7 +1420,7 @@ TEST_F(TrieTest, testCRustRdbInteropEmpty) {
   });
   ASSERT_TRUE(ioRust != nullptr);
 
-  LexTrieRs_RdbSave(ioRust, rustMap, /*save_payloads=*/true, /*save_num_docs=*/true);
+  ASSERT_TRUE(LexTrieRs_RdbSave(ioRust, rustMap, /*save_payloads=*/true, /*save_num_docs=*/true));
   EXPECT_EQ(0, RMCK_IsIOError(ioRust));
   EXPECT_EQ(ioC->buffer, ioRust->buffer);
 
@@ -1449,4 +1449,119 @@ TEST_F(TrieTest, testCRustRdbInteropKeysOnly) {
       {"日本", 4.0f},
   });
   expectRdbInterop(original.get(), /*payloads=*/false, /*numDocs=*/false);
+}
+
+// The tests below hand-author RDB streams through the mock's save
+// primitives rather than through `TrieType_GenericSave`, because each one
+// carries something the C serializer cannot emit: a key that is not valid
+// UTF-8, a truncated record, or a key the C loader would refuse to insert.
+TEST_F(TrieTest, testRustRdbLoadRejectsNonUtf8Key) {
+  RedisModuleIO *io = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+    RMCK_FreeRdbIO(io);
+  });
+  ASSERT_TRUE(io != nullptr);
+
+  RMCK_SaveUnsigned(io, 1);
+  RMCK_SaveStringBuffer(io, "\xff\xfe", 3);  // two stray high bytes plus the terminator
+  RMCK_SaveDouble(io, 1.0);
+
+  io->read_pos = 0;
+  LexTrieRs *rustMap = LexTrieRs_RdbLoad(io, /*load_payloads=*/false, /*load_num_docs=*/false);
+
+  EXPECT_EQ(nullptr, rustMap);
+}
+
+TEST_F(TrieTest, testRustRdbLoadRejectsTruncatedStream) {
+  RedisModuleIO *io = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+    RMCK_FreeRdbIO(io);
+  });
+  ASSERT_TRUE(io != nullptr);
+
+  // Header promises two entries; only the first one is present.
+  RMCK_SaveUnsigned(io, 2);
+  RMCK_SaveStringBuffer(io, "a", 2);
+  RMCK_SaveDouble(io, 1.0);
+
+  io->read_pos = 0;
+  LexTrieRs *rustMap = LexTrieRs_RdbLoad(io, /*load_payloads=*/false, /*load_num_docs=*/false);
+
+  EXPECT_EQ(nullptr, rustMap);
+}
+
+TEST_F(TrieTest, testRustRdbSaveRejectsKeyTheCLoaderWouldDrop) {
+  // Longer than `TRIE_INITIAL_STRING_LEN * sizeof(rune)`, so
+  // `Trie_InsertStringBuffer` refuses it.
+  const std::string longKey(600, 'a');
+
+  RedisModuleIO *io = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+    RMCK_FreeRdbIO(io);
+  });
+  ASSERT_TRUE(io != nullptr);
+
+  RMCK_SaveUnsigned(io, 1);
+  RMCK_SaveStringBuffer(io, longKey.c_str(), longKey.size() + 1);
+  RMCK_SaveDouble(io, 1.0);
+
+  // What such a stream costs C: the entry is dropped, but the count that
+  // announced it is not, so the trie loads one entry short of its own header.
+  io->read_pos = 0;
+  Trie *cTrie =
+      (Trie *)TrieType_GenericLoad(io, /*loadPayloads=*/false, /*loadNumDocs=*/false, Trie_Sort_Score);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> cTriePtr(cTrie, [](Trie *trie) {
+    TrieType_Free(trie);
+  });
+  ASSERT_TRUE(cTrie != nullptr);
+  EXPECT_EQ(0, Trie_Size(cTrie));
+
+  // Rust loads the same stream — the domain is enforced on save, not on load.
+  io->read_pos = 0;
+  LexTrieRs *rustMap = LexTrieRs_RdbLoad(io, /*load_payloads=*/false, /*load_num_docs=*/false);
+  std::unique_ptr<LexTrieRs, std::function<void(LexTrieRs *)>> rustMapPtr(rustMap, [](LexTrieRs *m) {
+    LexTrieRs_Free(m);
+  });
+  ASSERT_TRUE(rustMap != nullptr);
+
+  RedisModuleIO *ioRust = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioRustPtr(ioRust, [](RedisModuleIO *io) {
+    RMCK_FreeRdbIO(io);
+  });
+  ASSERT_TRUE(ioRust != nullptr);
+
+  EXPECT_FALSE(LexTrieRs_RdbSave(ioRust, rustMap, /*save_payloads=*/false, /*save_num_docs=*/false));
+  EXPECT_EQ(0u, ioRust->buffer.size());
+}
+
+TEST_F(TrieTest, testRdbZeroCodepointKeyDropsInCButRejectsInRust) {
+  RedisModuleIO *io = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+    RMCK_FreeRdbIO(io);
+  });
+  ASSERT_TRUE(io != nullptr);
+
+  // No NUL byte in the key, yet C's decoder reads a zero codepoint out of the
+  // continuation pair and stops before consuming a single rune.
+  RMCK_SaveUnsigned(io, 1);
+  RMCK_SaveStringBuffer(io, "\x80\x80", 3);
+  RMCK_SaveDouble(io, 1.0);
+
+  // C drops the entry silently: the trie loads empty while its own header
+  // announced one entry.
+  io->read_pos = 0;
+  Trie *cTrie =
+      (Trie *)TrieType_GenericLoad(io, /*loadPayloads=*/false, /*loadNumDocs=*/false, Trie_Sort_Score);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> cTriePtr(cTrie, [](Trie *trie) {
+    TrieType_Free(trie);
+  });
+  ASSERT_TRUE(cTrie != nullptr);
+  EXPECT_EQ(0, Trie_Size(cTrie));
+
+  // Rust refuses the whole stream instead: the pair is not valid UTF-8, so
+  // the key never enters the str-keyed trie.
+  io->read_pos = 0;
+  LexTrieRs *rustMap = LexTrieRs_RdbLoad(io, /*load_payloads=*/false, /*load_num_docs=*/false);
+
+  EXPECT_EQ(nullptr, rustMap);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The Rust trie RDB saver accepts any key and any `f64` score, but the C loader silently drops keys beyond its capacity (leaving the stream one entry short of its own count header) and stores scores as `float`. A Rust-written stream could therefore carry entries that C cannot faithfully load back.
2. Change: Save now refuses keys outside the C trie's domain (empty, over the byte or rune capacity, embedded NUL) — `LexTrieRs_RdbSave` reports success/failure — and scores are collapsed to the C `float` domain on both save and load.
3. Outcome: Internal-only; the crate is not yet wired into the module. It guarantees that any stream the Rust saver emits round-trips into the same trie through either implementation.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `trie_rdb` — key validation on save (`SaveError` variants per rejection cause) and `f32` score quantization on save and load
2. `trie_rdb_ffi` — `LexTrieRs_RdbSave` returns `bool`; key-capacity constants shared with C via the generated header
3. `string_utils` — rune counting reused from the shared libnu model so Rust and C agree on what "too many runes" means
4. `tests/cpptests/test_cpp_trie.cpp` — hand-authored streams covering non-UTF-8 keys, truncated records, and a key the C loader would drop

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
