### PR TITLE
[MOD-15869] Use Redis node metadata for cluster TLS connections

### DIFF
--- a/src/coord/rmr/cluster_topology.c
+++ b/src/coord/rmr/cluster_topology.c
@@ -15,7 +15,6 @@
 #include "endpoint.h"
 #include "rmalloc.h"
 #include "slot_ranges.h"
-#include "config.h"
 #include "rmutil/rm_assert.h"
 #include "rmr/node.h"
 
@@ -74,10 +73,6 @@ MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *au
 
   bool saw_myself = false;
 
-  // The port RedisModule_GetClusterNodeInfo is a TLS/TCP port depending on the `tls-cluster` config.
-  // TODO: Improve the API to return the endpoint type (TLS/TCP) instead of relying on this logic mirroring
-  bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false);
-
   // Topology can contain at most one entry per node; replicas and slot-less
   // masters will be skipped, so this is an upper bound on the final size.
   MRClusterTopology *topo = MR_NewTopology(numNodes);
@@ -117,7 +112,7 @@ MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *au
       .endpoint = (MREndpoint){
         .host = rm_strdup(ip),
         .port = port,
-        .isTls = is_tls,
+        .isTls = (flags & REDISMODULE_NODE_PORT_TLS) != 0,
         .unixSock = NULL,
         .password = (auth && auth_len > 0) ? rm_strndup(auth, auth_len) : NULL,
       },

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -300,6 +300,7 @@ This flag should not be used directly by the module.
 #define REDISMODULE_NODE_PFAIL      (1<<3)
 #define REDISMODULE_NODE_FAIL       (1<<4)
 #define REDISMODULE_NODE_NOFAILOVER (1<<5)
+#define REDISMODULE_NODE_PORT_TLS   (1<<6)
 
 #define REDISMODULE_CLUSTER_FLAG_NONE 0
 #define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER (1<<1)

--- a/tests/cpptests/coord_tests/test_cpp_cluster_topology.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_cluster_topology.cpp
@@ -96,6 +96,26 @@ TEST_F(ClusterTopologyFromAPITest, ThreeMasters_LocalIsMaster) {
   MRClusterTopology_Free(topo);
 }
 
+TEST_F(ClusterTopologyFromAPITest, EndpointTransportUsesNodeInfoFlags) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 8191}});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_PORT_TLS,
+          {{8192, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+
+  int tcp_shard = findShardByNodeId(topo, NODE_A);
+  int tls_shard = findShardByNodeId(topo, NODE_B);
+  ASSERT_GE(tcp_shard, 0);
+  ASSERT_GE(tls_shard, 0);
+  EXPECT_FALSE(topo->shards[tcp_shard].node.endpoint.isTls);
+  EXPECT_TRUE(topo->shards[tls_shard].node.endpoint.isTls);
+
+  MRClusterTopology_Free(topo);
+}
+
 // ============================================================================
 // Auth NULL/empty should leave the password unset on every shard.
 // ============================================================================


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: OSS cluster topology construction infers every node's connection transport from the local `tls-cluster` configuration.
2. Change: Use the transport flag returned with each node by `RedisModule_GetClusterNodeInfo`.
3. Outcome: Coordinator connections use the TLS or TCP transport associated with the returned node port without duplicating Redis configuration logic.

#### Which additional issues this PR fixes

1. MOD-15869

#### Main objects this PR modified

1. OSS cluster topology endpoint transport selection
2. Redis module cluster-node flags
3. Coordinator topology unit coverage

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
