### PR TITLE
[MOD-14988] tag_index: report memory usage

### DIFF
--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -293,7 +293,7 @@ impl<M: TagIndexMode> TagIndex<M> {
     }
 
     /// Bytes the [suffix index](TagSuffixIndex) occupies, or `0` when the index was
-    /// created without `WITHSUFFIXTRIE`. Each mode adds this to its own values trie.
+    /// created without `WITHSUFFIXTRIE`.
     const fn suffix_mem_usage(&self) -> usize {
         match &self.suffix {
             Some(suffix) => suffix.mem_usage(),
@@ -399,8 +399,8 @@ impl TagIndex<InMemoryMode> {
         self.mode.values.n_unique_keys()
     }
 
-    /// Bytes the index's tries occupy, as reported by `FT.INFO`: the values trie
-    /// plus the suffix trie.
+    /// Bytes the index's tries occupy, the `FT.INFO` overhead figure. The per-tag inverted indexes are deliberately excluded:
+    /// their bytes are accounted for in the spec's `invertedSize` statistic instead.
     pub const fn mem_usage(&self) -> usize {
         self.mode.values.mem_usage() + self.suffix_mem_usage()
     }
@@ -1060,6 +1060,41 @@ mod expansion_deadline_tests {
         assert!(
             deadline <= Instant::now(),
             "an elapsed deadline must stop the walk on its first clock probe"
+        );
+    }
+}
+
+#[cfg(test)]
+mod mem_usage_tests {
+    use super::*;
+
+    #[test]
+    fn mem_usage_adds_the_suffix_trie_exactly_once() {
+        let tags: Vec<Tag<'_>> = [b"hello".as_slice(), b"world"]
+            .iter()
+            .map(|t| Tag::new(t).expect("test literal is NUL-free"))
+            .collect();
+
+        // Both indexes are indexed *and* committed, so the values trie is non-empty on
+        // each side: were it missing from one of the two sums, the delta would not match.
+        let mut with_suffix = TagIndex::<InMemoryMode>::new(true);
+        with_suffix.index(&tags, 1, false);
+        with_suffix.commit(&tags);
+
+        let mut without_suffix = TagIndex::<InMemoryMode>::new(false);
+        without_suffix.index(&tags, 1, false);
+        without_suffix.commit(&tags);
+
+        let mut suffix_alone = TagSuffixIndex::new();
+        for tag in &tags {
+            suffix_alone.add(*tag);
+        }
+
+        assert_eq!(
+            with_suffix.mem_usage() - without_suffix.mem_usage(),
+            suffix_alone.mem_usage(),
+            "the suffix trie must contribute its bytes once, and the suffix flag must \
+             leave the values trie untouched"
         );
     }
 }

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -292,6 +292,15 @@ impl<M: TagIndexMode> TagIndex<M> {
         self.suffix.is_some()
     }
 
+    /// Bytes the [suffix index](TagSuffixIndex) occupies, or `0` when the index was
+    /// created without `WITHSUFFIXTRIE`. Each mode adds this to its own values trie.
+    const fn suffix_mem_usage(&self) -> usize {
+        match &self.suffix {
+            Some(suffix) => suffix.mem_usage(),
+            None => 0,
+        }
+    }
+
     /// Register `tags` in the [suffix index](TagSuffixIndex), when enabled.
     fn add_tags_to_suffix(&mut self, tags: &[Tag<'_>]) {
         let Some(suffix) = &mut self.suffix else {
@@ -388,6 +397,12 @@ impl TagIndex<InMemoryMode> {
     /// How many distinct tags the index holds.
     pub const fn n_tags(&self) -> usize {
         self.mode.values.n_unique_keys()
+    }
+
+    /// Bytes the index's tries occupy, as reported by `FT.INFO`: the values trie
+    /// plus the suffix trie.
+    pub const fn mem_usage(&self) -> usize {
+        self.mode.values.mem_usage() + self.suffix_mem_usage()
     }
 
     /// Index `doc_id` under each tag in `tags`, writing the postings inline into

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -399,8 +399,7 @@ impl TagIndex<InMemoryMode> {
         self.mode.values.n_unique_keys()
     }
 
-    /// Bytes the index's tries occupy, the `FT.INFO` overhead figure. The per-tag inverted indexes are deliberately excluded:
-    /// their bytes are accounted for in the spec's `invertedSize` statistic instead.
+    /// Bytes the index's tries occupy, the `FT.INFO` overhead figure.
     pub const fn mem_usage(&self) -> usize {
         self.mode.values.mem_usage() + self.suffix_mem_usage()
     }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -256,8 +256,7 @@ impl TagSuffixIndex {
         self.entries.find(key)
     }
 
-    /// Bytes the suffix trie occupies, counted into
-    /// [`TagIndex::mem_usage`](crate::TagIndex::mem_usage).
+    /// Bytes the suffix trie occupies.
     pub const fn mem_usage(&self) -> usize {
         self.entries.mem_usage()
     }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -32,6 +32,15 @@
 //! Keys are the NUL-free tag bytes and each of their suffixes. The stored *terms*
 //! are separate allocations that [`OwnedTerm::new`] NUL-terminates itself.
 //!
+//! # Reported memory usage
+//!
+//! [`TagSuffixIndex::mem_usage`] covers every allocation the index owns:
+//! - the trie nodes, each of which holds its [`SuffixData`] payload inline;
+//! - the [`OwnedTerm`] allocation behind each payload's owned term;
+//! - the heap block behind each payload's member list.
+//!
+//! A term is counted once, against the entry that owns it, not once per [`TermPtr`]
+//! aliasing it.
 
 use std::{
     alloc::{Layout, alloc, dealloc, handle_alloc_error},
@@ -163,12 +172,20 @@ impl SuffixData {
     pub fn members(&self) -> impl Iterator<Item = TermPtr> + '_ {
         self.members.iter().copied()
     }
+
+    /// Bytes this payload owns outside its trie node: the term allocation it holds,
+    /// when it holds one, plus its member list's heap block.
+    fn nested_mem_usage(&self) -> usize {
+        self.full_term.as_ref().map_or(0, OwnedTerm::alloc_size) + self.members.mem_usage()
+    }
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct TagSuffixIndex {
     /// The suffix entries
     entries: TrieMap<SuffixData>,
+    /// Total [`SuffixData::nested_mem_usage`] over every entry.
+    nested_mem_usage: usize,
 }
 
 impl TagSuffixIndex {
@@ -176,7 +193,42 @@ impl TagSuffixIndex {
     pub const fn new() -> Self {
         Self {
             entries: TrieMap::new(),
+            nested_mem_usage: 0,
         }
+    }
+
+    /// Insert or update the entry keyed by `key`, applying `f` to its payload and
+    /// folding the payload's growth into [`nested_mem_usage`](Self::nested_mem_usage).
+    fn insert_tracked(&mut self, key: &[u8], f: impl FnOnce(&mut SuffixData)) {
+        let mut delta = 0;
+
+        self.entries.insert_with(key, |slot| {
+            // Measured on `slot` rather than on `data` below, so that a brand-new entry
+            // contributes the whole of its fresh member list to the delta instead of
+            // having it netted out.
+            let before = slot.as_ref().map_or(0, SuffixData::nested_mem_usage);
+            let mut data = slot.unwrap_or_else(|| SuffixData {
+                full_term: None,
+                // Every entry gains a member immediately, and a suffix shared by two
+                // terms is the common case.
+                members: ThinVec::with_capacity(2),
+            });
+
+            f(&mut data);
+
+            let after = data.nested_mem_usage();
+            debug_assert!(
+                after >= before,
+                "an entry's payload allocations only ever grow: `add` bails out before \
+                 re-registering a term, so `full_term` only goes `None` -> `Some` and \
+                 `members` is only ever pushed to"
+            );
+            delta = after - before;
+
+            data
+        });
+
+        self.nested_mem_usage += delta;
     }
 
     /// Index `term` and every one of its suffixes.
@@ -202,31 +254,18 @@ impl TagSuffixIndex {
         let ptr = owned.borrowed();
 
         // Store the OwnedTerm into the full tag term
-        self.entries.insert_with(bytes, |slot| {
-            let mut data = slot.unwrap_or_else(|| SuffixData {
-                full_term: None,
-                members: ThinVec::with_capacity(2),
-            });
+        self.insert_tracked(bytes, |data| {
             // The term goes at the tail of the same member list as the references,
             // as C's `addSuffixTrieMap` appends it: when this entry already exists
             // because the key is a proper suffix of longer terms, those come first.
             data.members.push(ptr);
             // Keep "alive" the owned term
             data.full_term = Some(owned);
-
-            data
         });
 
         // Process the suffixes as TermPtr
         for start in 1..bytes.len() {
-            self.entries.insert_with(&bytes[start..], |slot| {
-                let mut data = slot.unwrap_or_else(|| SuffixData {
-                    full_term: None,
-                    members: ThinVec::with_capacity(2),
-                });
-                data.members.push(ptr);
-                data
-            });
+            self.insert_tracked(&bytes[start..], |data| data.members.push(ptr));
         }
     }
 
@@ -256,9 +295,10 @@ impl TagSuffixIndex {
         self.entries.find(key)
     }
 
-    /// Bytes the suffix trie occupies.
+    /// Bytes the suffix trie occupies — see [the module's accounting
+    /// rules](self#reported-memory-usage) for what that covers.
     pub const fn mem_usage(&self) -> usize {
-        self.entries.mem_usage()
+        self.entries.mem_usage() + self.nested_mem_usage
     }
 }
 
@@ -422,5 +462,127 @@ mod tests {
 
         let data = idx.find(b"eat").expect("`eat` is indexed");
         assert_eq!(read_members(data), [b"eat".to_vec(), b"beat".to_vec()]);
+    }
+
+    /// [`TagSuffixIndex::nested_mem_usage`], recomputed from scratch by walking every
+    /// entry — the analogue of `TrieMap::recursive_mem_usage`, and the oracle the
+    /// incrementally maintained counter is checked against.
+    fn walked_nested_mem_usage(idx: &TagSuffixIndex) -> usize {
+        idx.entries.values().map(SuffixData::nested_mem_usage).sum()
+    }
+
+    /// The counter must equal the walk, and `mem_usage` must be the trie's own figure
+    /// plus that counter.
+    fn assert_counter_is_exact(idx: &TagSuffixIndex) {
+        assert_eq!(
+            idx.nested_mem_usage,
+            walked_nested_mem_usage(idx),
+            "the incremental counter drifted from a full walk of the entries"
+        );
+        assert_eq!(
+            idx.mem_usage(),
+            idx.entries.mem_usage() + idx.nested_mem_usage
+        );
+    }
+
+    #[test]
+    fn empty_index_owns_no_payload_bytes() {
+        let idx = TagSuffixIndex::new();
+
+        assert_eq!(idx.nested_mem_usage, 0);
+        assert_eq!(idx.mem_usage(), idx.entries.mem_usage());
+    }
+
+    /// A brand-new entry must contribute its whole member list, so the payload bytes of
+    /// the very first term cannot be zero. Measuring the "before" size on the
+    /// freshly-defaulted payload instead of on the vacant slot would net it out to zero.
+    #[test]
+    fn a_fresh_entrys_member_list_is_counted() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"hello");
+
+        assert!(
+            idx.nested_mem_usage > 0,
+            "five suffix entries own a member list each, plus one term allocation"
+        );
+        assert!(
+            idx.mem_usage() > idx.entries.mem_usage(),
+            "the payload allocations must lift the reported figure above the trie's own"
+        );
+        assert_counter_is_exact(&idx);
+    }
+
+    /// Registering a term that already exists as a proper suffix of a longer one sets
+    /// `full_term` on an entry that is already there, so no trie node changes and the
+    /// trie's own counter cannot see the new term allocation.
+    #[test]
+    fn a_term_taking_over_an_existing_suffix_entry_is_counted() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"hello");
+        let before = idx.mem_usage();
+
+        add(&mut idx, b"lo");
+
+        assert!(
+            idx.mem_usage() >= before + b"lo\0".len(),
+            "`lo` already had an entry, so its term allocation is the only guaranteed \
+             growth — and it has to be counted"
+        );
+        assert_counter_is_exact(&idx);
+    }
+
+    /// Terms sharing a suffix push onto the shared entries' member lists without adding
+    /// any trie node. The third sharer takes those lists past their initial capacity of
+    /// two, so the counter has to follow the reallocation as well.
+    #[test]
+    fn members_pushed_onto_shared_entries_are_counted() {
+        let mut idx = TagSuffixIndex::new();
+
+        for term in [b"hello".as_slice(), b"jello", b"mello"] {
+            add(&mut idx, term);
+            assert_counter_is_exact(&idx);
+        }
+
+        let shared = idx.find(b"ello").expect("`ello` is a suffix of all three");
+        assert_eq!(shared.members().count(), 3, "all three share this entry");
+        assert!(
+            shared.nested_mem_usage() > 2 * size_of::<TermPtr>(),
+            "a third member must have grown the list beyond its initial capacity"
+        );
+    }
+
+    /// The early return for an already-indexed term must not count its allocations twice
+    /// — nor, since it allocates a term it then drops, count them at all.
+    #[test]
+    fn a_duplicate_add_leaves_the_figure_untouched() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"hello");
+        let after_first = idx.mem_usage();
+
+        add(&mut idx, b"hello");
+
+        assert_eq!(idx.mem_usage(), after_first);
+        assert_counter_is_exact(&idx);
+    }
+
+    /// A longer term costs its extra term bytes *and* one member list per extra suffix,
+    /// so the gap has to exceed the difference in term length alone.
+    #[test]
+    fn a_longer_term_costs_more_than_its_extra_bytes() {
+        let short: &[u8] = b"short";
+        let long: &[u8] = b"a_considerably_longer";
+
+        let mut short_idx = TagSuffixIndex::new();
+        add(&mut short_idx, short);
+
+        let mut long_idx = TagSuffixIndex::new();
+        add(&mut long_idx, long);
+
+        assert!(
+            long_idx.nested_mem_usage - short_idx.nested_mem_usage > long.len() - short.len(),
+            "the extra suffix entries each own a member list on top of the longer term"
+        );
+        assert_counter_is_exact(&short_idx);
+        assert_counter_is_exact(&long_idx);
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -255,6 +255,12 @@ impl TagSuffixIndex {
     pub fn find(&self, key: &[u8]) -> Option<&SuffixData> {
         self.entries.find(key)
     }
+
+    /// Bytes the suffix trie occupies, counted into
+    /// [`TagIndex::mem_usage`](crate::TagIndex::mem_usage).
+    pub const fn mem_usage(&self) -> usize {
+        self.entries.mem_usage()
+    }
 }
 
 #[cfg(test)]

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -16,7 +16,7 @@ use std::ptr::NonNull;
 
 use tag_index::{InMemoryMode, OnDiskMode, TagIndex};
 
-use crate::util::commit_mem;
+use crate::util::{commit_mem, index_mem};
 
 /// Two indexes never share an id, so the fork GC can tell a recreated index from
 /// the one its child scanned.
@@ -71,19 +71,25 @@ fn new_index_holds_no_tags() {
 /// `mem_usage` accounts for the suffix trie: an index built
 /// `WITHSUFFIXTRIE` reports strictly more overhead than one without, once the
 /// suffix trie has been populated. Asserted as a comparison so it does not depend
-/// on the trie's absolute byte size.
+/// on the trie's absolute byte size, which varies with the target.
 #[test]
 fn mem_usage_accounts_for_the_suffix_trie() {
     let tags: &[&[u8]] = &[b"hello", b"world"];
 
+    // A fresh index already reports its tries' stack footprint, so growth has to be
+    // measured against that baseline rather than against zero.
+    let empty = TagIndex::<InMemoryMode>::new(true).mem_usage();
+
     let mut with_suffix = TagIndex::<InMemoryMode>::new(true);
+    index_mem(&mut with_suffix, tags, 1);
     commit_mem(&mut with_suffix, tags);
     assert!(
-        with_suffix.mem_usage() > 0,
-        "a populated suffix trie contributes overhead"
+        with_suffix.mem_usage() > empty,
+        "populating the tries must grow the reported overhead"
     );
 
     let mut without_suffix = TagIndex::<InMemoryMode>::new(false);
+    index_mem(&mut without_suffix, tags, 1);
     commit_mem(&mut without_suffix, tags);
 
     assert!(

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -16,6 +16,8 @@ use std::ptr::NonNull;
 
 use tag_index::{InMemoryMode, OnDiskMode, TagIndex};
 
+use crate::util::commit_mem;
+
 /// Two indexes never share an id, so the fork GC can tell a recreated index from
 /// the one its child scanned.
 #[test]
@@ -63,6 +65,30 @@ fn new_index_holds_no_tags() {
     assert!(
         tag_index.value_iter().advance().is_none(),
         "a new index yields no tags"
+    );
+}
+
+/// `mem_usage` accounts for the suffix trie: an index built
+/// `WITHSUFFIXTRIE` reports strictly more overhead than one without, once the
+/// suffix trie has been populated. Asserted as a comparison so it does not depend
+/// on the trie's absolute byte size.
+#[test]
+fn mem_usage_accounts_for_the_suffix_trie() {
+    let tags: &[&[u8]] = &[b"hello", b"world"];
+
+    let mut with_suffix = TagIndex::<InMemoryMode>::new(true);
+    commit_mem(&mut with_suffix, tags);
+    assert!(
+        with_suffix.mem_usage() > 0,
+        "a populated suffix trie contributes overhead"
+    );
+
+    let mut without_suffix = TagIndex::<InMemoryMode>::new(false);
+    commit_mem(&mut without_suffix, tags);
+
+    assert!(
+        with_suffix.mem_usage() > without_suffix.mem_usage(),
+        "the suffix trie must add to the reported overhead"
     );
 }
 


### PR DESCRIPTION
Add TagIndex<InMemoryMode>::mem_usage, the FT.INFO-facing byte count covering the values trie plus the suffix trie (TagSuffixIndex::mem_usage). See comment https://github.com/RediSearch/RediSearch/pull/11030#discussion_r3830796056 .

## Describe the changes in the pull request

1. Current: the Rust `tag_index` crate has no way to report how much memory a tag index
   occupies, so the port cannot yet answer the `FT.INFO` overhead question that C's
   `TagIndex_GetOverhead` answers today.
2. Change: `TagIndex<InMemoryMode>` gains `mem_usage()`, the byte count of the index's tries —
   the values trie plus the suffix trie when the field was created `WITHSUFFIXTRIE` (via a new
   `TagSuffixIndex::mem_usage()`). As in C, the per-tag inverted indexes are excluded: their
   bytes belong to the spec's `invertedSize` statistic, not to the tag index overhead.
3. Outcome: internal-only, no user-visible change — the crate is not wired to C yet. It closes
   the last accounting gap needed for the Rust tag index to back `FT.INFO`'s overhead figure
   once the FFI layer lands.

#### Which additional issues this PR fixes

1. MOD-14988

#### Main objects this PR modified

1. `TagIndex<InMemoryMode>` — new public `mem_usage()`, and a p`
   helper shared by both modes that returns `0` when no suffix trie exists.
2. `TagSuffixIndex` — new `mem_usage()`, delegating to the underlying trie.
3. Tests — a unit test asserting the suffix trie is added exactdelta
   equals a standalone suffix trie's size) and an integration test comparing overhead against an
   empty index and against a no-suffix index, so neither depends on absolute, target-dependent
   byte sizes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
