### PR TITLE
bench(vector): make benches C vs rust more comparable

### DIFF
--- a/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
@@ -32,6 +32,7 @@
 
 #include "redisearch.h"
 #include "search_ctx.h"
+#include "rlookup.h"
 #include "spec.h"
 #include "iterators/iterator_api.h"
 #include "iterators/hybrid_reader.h"
@@ -106,6 +107,11 @@ size_t bench_c_hybrid(VecSimIndex *index, const void *query_vec, size_t dim, siz
     QueryError_ClearError(&err);
     return 0;
   }
+
+  // Yield the vector score under a lookup key, matching the Rust side. A zeroed
+  // key is enough: the metrics path stores the pointer and never dereferences it.
+  RLookupKey own_key = {0};
+  *HybridIterator_GetOwnKeyRef(it) = &own_key;
 
   size_t count = 0;
   while (it->Read(it) == ITERATOR_OK) {

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -214,7 +214,10 @@ fn run_rust(
     *source.own_key = (&raw mut own_key).cast();
 
     let child: Box<dyn RQEIterator> = Box::new(IdList::<true>::new(ids.to_vec()));
-    let mut it = TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode);
+    // Matches the shim's `canTrimDeepResults`: capture only the child's yielded
+    // metrics on a match, rather than deep-copying its whole scoring subtree.
+    let mut it = TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode)
+        .with_trim_deep_results(true);
     let mut count = 0usize;
     while it.read().unwrap().is_some() {
         count += 1;

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -174,6 +174,12 @@ fn run_rust(
     ids: &[u64],
     mode: TopKMode,
 ) -> usize {
+    // Declared before the source so it outlives every result that borrows it.
+    // A zeroed key is enough: the metrics path stores the pointer and never
+    // dereferences it.
+    // SAFETY: `RLookupKey` is plain data whose all-zero state is valid.
+    let mut own_key: ffi::RLookupKey = unsafe { std::mem::zeroed() };
+
     // Pin the source's HYBRID_POLICY to match the forced `mode`, mirroring the C
     // shim's `qParams.searchMode`. This keeps `batch_strategy` on the same path
     // as production (and C) instead of the unset-policy heuristic.
@@ -201,6 +207,12 @@ fn run_rust(
             MockExpirationChecker::new(std::collections::HashSet::new()),
         )
     };
+    // Yield the vector score under a lookup key, as a real query does. Without
+    // this the score push is skipped entirely, while the C side still pushes a
+    // keyless entry, so the two would not do comparable per-result work.
+    let mut source = source;
+    *source.own_key = (&raw mut own_key).cast();
+
     let child: Box<dyn RQEIterator> = Box::new(IdList::<true>::new(ids.to_vec()));
     let mut it = TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode);
     let mut count = 0usize;

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -13,23 +13,21 @@
 //! Both sides:
 //! - drive the same HNSW index and the same sorted-id child filter,
 //! - maintain a real bounded top-k heap,
-//! - are forced into the same execution mode (batches / adhoc-BF).
+//! - are forced into the same execution mode (batches / adhoc-BF),
+//! - yield the vector score under a lookup key, and trim deep results.
 //!
 //! The C side builds a minimal mock `RedisSearchCtx` and wraps the child in
-//! `NewSortedIdListIterator` (the C twin of the Rust `IdList`). See
+//! `NewSortedIdListIterator`, which is a Rust `IdList` behind an FFI entry
+//! point, so both sides drive the same child implementation. See
 //! `hybrid_shim.c` for details.
 //!
-//! Two groups × two sides (rust / c):
+//! Three groups × two sides (rust / c):
 //!
-//! - `vector_top_k_hybrid/batches` — hybrid, batches mode forced.
-//! - `vector_top_k_hybrid/adhoc`   — hybrid, adhoc-BF mode forced.
+//! - `vector_top_k_hybrid/batches`         — hybrid, batches mode forced.
+//! - `vector_top_k_hybrid/adhoc`           — hybrid, adhoc-BF mode forced.
+//! - `vector_top_k_hybrid/mode_comparison` — both modes across child sizes.
 //!
 //! Swept over index size and top-k width at a fixed vector dimension.
-//!
-//! Known asymmetry (MOD-14210): the C path pushes a vector-score metric per
-//! candidate (`ResultMetrics_Add`) that Rust's `build_result` doesn't yet — a
-//! small C-only cost that mildly favors Rust in small-k adhoc cases until parity
-//! lands.
 
 // Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
 // `RedisModule_Alloc` is one of those symbols, defined by the crate's


### PR DESCRIPTION
A new benchmark run of the vector top k surfaced performance regressions, I'll make more PRs to address them.

This PR is improves its bench setup to be more comparable:

- benchmarks were done in parallel to the metrics feature, and It silently became a diff with C when introduced in Rust. (previously: Rust appeared faster in benchmarks).
- Rust is now using the trim deep results path, like the c shim. (previously: Rust appeared slower)

the changes introduced in the benchmarks in this PR are not much (around 1-2%), but this helps comparing apples to apples.


| child | Rust | C | Δ | ratio |
| -----: | -------: | -------: | --------: | ----: |
| 1 | 223.3 ns | 183.8 ns | +39.5 ns | 1.22× |
| 10 | 1.052 µs | 795.5 ns | +256.4 ns | 1.32× |
| 100 | 10.23 µs | 10.45 µs | −222 ns | **0.98×** |
| 1 000 | 55.87 µs | 54.76 µs | +1.106 µs | 1.02× |
| 6 900 | 251.9 µs | 224.6 µs | +27.34 µs | 1.12× |

- It's an important PR to get comparisons correct in followin perf PRs (listed in https://github.com/RediSearch/RediSearch/pull/11033 )

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
