### PR TITLE
vector_score_bench: sweep child size at a fixed k

### DIFF
--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -21,11 +21,12 @@
 //! point, so both sides drive the same child implementation. See
 //! `hybrid_shim.c` for details.
 //!
-//! Three groups × two sides (rust / c):
+//! Four groups × two sides (rust / c):
 //!
-//! - `vector_top_k_hybrid/batches`         — hybrid, batches mode forced.
-//! - `vector_top_k_hybrid/adhoc`           — hybrid, adhoc-BF mode forced.
-//! - `vector_top_k_hybrid/mode_comparison` — both modes across child sizes.
+//! - `vector_top_k_hybrid/batches`           — hybrid, batches mode forced.
+//! - `vector_top_k_hybrid/adhoc`             — hybrid, adhoc-BF mode forced.
+//! - `vector_top_k_hybrid/adhoc_child_sweep` — adhoc-BF, child size swept at a fixed `k`.
+//! - `vector_top_k_hybrid/mode_comparison`   — both modes across child sizes.
 //!
 //! Swept over index size and top-k width at a fixed vector dimension.
 
@@ -355,6 +356,52 @@ fn bench_adhoc(c: &mut Criterion) {
     group.finish();
 }
 
+/// Index size for the child sweep. The adhoc-selected region here is any child
+/// below 7% of this, so every [`SWEEP_CHILDREN`] entry stays inside it.
+const SWEEP_N: usize = 100_000;
+
+/// Child result counts spanning the adhoc-selected region at [`SWEEP_N`].
+const SWEEP_CHILDREN: &[usize] = &[1, 10, 100, 1_000, 6_900];
+
+/// Sweep child size at a fixed `k`, in forced adhoc-BF mode.
+///
+/// The `adhoc` group ties child size to `k` (`child = k * 5`), which cannot
+/// separate the two cost models the implementations have: the Rust iterator's
+/// overhead falls on every candidate it examines, while the C reader's falls on
+/// every candidate it *retains* — it allocates a result per insert while the heap
+/// fills. Their ratio therefore tracks the retention rate rather than the child
+/// size, and only a sweep at fixed `k` shows that.
+fn bench_adhoc_child_sweep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_top_k_hybrid/adhoc_child_sweep");
+
+    // SAFETY: make_index + VecSimIndex_Free are paired.
+    let index = unsafe { make_index(SWEEP_N) };
+    let query = random_query(7);
+
+    for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+        for &child_count in SWEEP_CHILDREN {
+            let ids: Vec<u64> = child_ids(SWEEP_N, child_count)
+                .iter()
+                .map(|&id| id as u64)
+                .collect();
+            let param_str = format!("k{k}_child{child_count}");
+
+            preflight(index, &query, k, &ids, TopKMode::AdhocBF, true);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(), |b, _| {
+                b.iter(|| black_box(run_rust(index, &query, k, &ids, TopKMode::AdhocBF)))
+            });
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(), |b, _| {
+                b.iter(|| black_box(run_c(index, &query, k, &ids, true)))
+            });
+        }
+    }
+
+    // SAFETY: `index` was created with make_index.
+    unsafe { VecSimIndex_Free(index) };
+    group.finish();
+}
+
 // ── Adhoc vs Batches mode comparison ─────────────────────────────────────────
 //
 // At a fixed index size and top-k, sweep child-filter selectivity across the
@@ -431,5 +478,11 @@ fn bench_mode_comparison(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_batches, bench_adhoc, bench_mode_comparison);
+criterion_group!(
+    benches,
+    bench_batches,
+    bench_adhoc,
+    bench_adhoc_child_sweep,
+    bench_mode_comparison
+);
 criterion_main!(benches);


### PR DESCRIPTION
benchmarking vector top k found out Rust was performing worse than C in some adhoc conditions.

The adhoc group ties child size to k, so it cannot separate per-candidate cost from per-retained-candidate cost. Sweeping child size at a fixed k does, across the range where the heuristic still selects adhoc-BF.

This PR adds the benchmark I used to spot differences in performances :

### Baseline:

observed noise in a run is ~3%

k=10 :

| child | r | Rust | C | Δ | ratio |
| -----: | ----: | -------: | -------: | --------: | ----: |
| 1 | 0.00001 | 229.7 ns | 179.0 ns | +50.7 ns | 1.28× |
| 10 | 0.0001 | 999.7 ns | 789.1 ns | +210.7 ns | 1.27× |
| 100 | 0.001 | 3.513 µs | 2.850 µs | +662.6 ns | 1.23× |
| 1 000 | 0.01 | 32.98 µs | 28.46 µs | +4.522 µs | 1.16× |
| 6 900 | 0.069 | 219.3 µs | 187.7 µs | **+31.62 µs** | 1.17× |


k = 100

| child | Rust | C | Δ | ratio |
| -----: | -------: | -------: | --------: | ----: |
| 1 | 223.3 ns | 183.8 ns | +39.5 ns | 1.22× |
| 10 | 1.052 µs | 795.5 ns | +256.4 ns | 1.32× |
| 100 | 10.23 µs | 10.45 µs | −222 ns | **0.98×** |
| 1 000 | 55.87 µs | 54.76 µs | +1.106 µs | 1.02× |
| 6 900 | 251.9 µs | 224.6 µs | +27.34 µs | 1.12× |


### After follow up PRs ?

- vecsim: https://github.com/RediSearch/RediSearch/pull/11035
- ordering: https://github.com/RediSearch/RediSearch/pull/11036
- gate: https://github.com/RediSearch/RediSearch/pull/11034

#### adhoc_child_sweep, k=10

| case | side | baseline | +vecsim | +ordering | +gate | all three |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `k10_child1` | Rust | 228.4 ns | 252.7 ns (+10.7%) | 210.9 ns (-7.7%) | 226.6 ns (-0.8%) | 199.1 ns (-12.8%) |
| `k10_child1` | C | 172.5 ns | 182.1 ns (+5.6%) | 176.5 ns (+2.3%) | 176.4 ns (+2.3%) | 170.6 ns (-1.1%) |
| `k10_child1` | *ratio* | 1.32× | **1.39×** | **1.19×** | **1.28×** | **1.17×** |
| `k10_child10` | Rust | 992.8 ns | 1.011 µs (+1.8%) | 717.5 ns (-27.7%) | 1.044 µs (+5.2%) | 680.2 ns (-31.5%) |
| `k10_child10` | C | 790.2 ns | 833.6 ns (+5.5%) | 796 ns (+0.7%) | 785.8 ns (-0.6%) | 793.2 ns (+0.4%) |
| `k10_child10` | *ratio* | 1.26× | **1.21×** | **0.90×** | **1.33×** | **0.86×** |
| `k10_child100` | Rust | 3.481 µs | 3.434 µs (-1.3%) | 2.872 µs (-17.5%) | 3.52 µs (+1.1%) | 2.849 µs (-18.2%) |
| `k10_child100` | C | 2.841 µs | 2.805 µs (-1.3%) | 2.841 µs (-0.0%) | 2.79 µs (-1.8%) | 2.815 µs (-0.9%) |
| `k10_child100` | *ratio* | 1.23× | **1.22×** | **1.01×** | **1.26×** | **1.01×** |
| `k10_child1000` | Rust | 32.1 µs | 31.29 µs (-2.5%) | 31.03 µs (-3.3%) | 31.94 µs (-0.5%) | 28.32 µs (-11.8%) |
| `k10_child1000` | C | 27.35 µs | 27.18 µs (-0.6%) | 27.76 µs (+1.5%) | 27.24 µs (-0.4%) | 27.49 µs (+0.5%) |
| `k10_child1000` | *ratio* | 1.17× | **1.15×** | **1.12×** | **1.17×** | **1.03×** |
| `k10_child6900` | Rust | 213.5 µs | 216.6 µs (+1.5%) | 206.1 µs (-3.5%) | 212.4 µs (-0.5%) | 200.1 µs (-6.3%) |
| `k10_child6900` | C | 184.8 µs | 182.7 µs (-1.1%) | 184.5 µs (-0.2%) | 178.8 µs (-3.2%) | 186.3 µs (+0.8%) |
| `k10_child6900` | *ratio* | 1.16× | **1.19×** | **1.12×** | **1.19×** | **1.07×** |

#### adhoc_child_sweep, k=100

| case | side | baseline | +vecsim | +ordering | +gate | all three |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `k100_child1` | Rust | 219.1 ns | 233.1 ns (+6.4%) | 183.8 ns (-16.1%) | 243.4 ns (+11.1%) | 187.5 ns (-14.4%) |
| `k100_child1` | C | 189.6 ns | 191.3 ns (+0.9%) | 192 ns (+1.3%) | 197.3 ns (+4.1%) | 186.6 ns (-1.6%) |
| `k100_child1` | *ratio* | 1.16× | **1.22×** | **0.96×** | **1.23×** | **1.00×** |
| `k100_child10` | Rust | 1.03 µs | 983.9 ns (-4.5%) | 696.9 ns (-32.3%) | 939.2 ns (-8.8%) | 712 ns (-30.9%) |
| `k100_child10` | C | 796.8 ns | 824.9 ns (+3.5%) | 830.6 ns (+4.2%) | 804.2 ns (+0.9%) | 809.1 ns (+1.5%) |
| `k100_child10` | *ratio* | 1.29× | **1.19×** | **0.84×** | **1.17×** | **0.88×** |
| `k100_child100` | Rust | 10.09 µs | 10.07 µs (-0.2%) | 6.715 µs (-33.4%) | 10.29 µs (+2.0%) | 6.839 µs (-32.2%) |
| `k100_child100` | C | 10.45 µs | 10.88 µs (+4.2%) | 10.39 µs (-0.6%) | 10.35 µs (-0.9%) | 10.64 µs (+1.8%) |
| `k100_child100` | *ratio* | 0.97× | **0.93×** | **0.65×** | **0.99×** | **0.64×** |
| `k100_child1000` | Rust | 54.5 µs | 53.91 µs (-1.1%) | 45.64 µs (-16.2%) | 54.24 µs (-0.5%) | 44.3 µs (-18.7%) |
| `k100_child1000` | C | 53.85 µs | 55.79 µs (+3.6%) | 53.25 µs (-1.1%) | 52.93 µs (-1.7%) | 54.58 µs (+1.4%) |
| `k100_child1000` | *ratio* | 1.01× | **0.97×** | **0.86×** | **1.02×** | **0.81×** |
| `k100_child6900` | Rust | 248.6 µs | 249 µs (+0.2%) | 231 µs (-7.1%) | 249.5 µs (+0.3%) | 218.7 µs (-12.0%) |
| `k100_child6900` | C | 222.3 µs | 224.2 µs (+0.9%) | 221.3 µs (-0.4%) | 220.9 µs (-0.6%) | 221.7 µs (-0.3%) |
| `k100_child6900` | *ratio* | 1.12× | **1.11×** | **1.04×** | **1.13×** | **0.99×** |


## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
