### PR TITLE
perf(top_k): reject unretainable adhoc candidates before the heap push

### DIFF
--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -145,6 +145,23 @@ impl<'index> TopKHeap<'index> {
         self.inner.len() >= self.capacity
     }
 
+    /// Whether an element scoring `score` could be retained: the heap has room,
+    /// or `score` is no worse than the worst element currently held.
+    ///
+    /// A tie reports `true`. Only
+    /// [`push_with_record_lazy`](Self::push_with_record_lazy) applies the doc-id
+    /// tiebreak, so a caller using this to pre-filter candidates never discards
+    /// one the heap would have kept.
+    pub fn may_retain(&self, score: f64) -> bool {
+        if !self.is_full() {
+            return true;
+        }
+        match self.inner.peek() {
+            Some(worst) => (self.compare)(&score, &worst.result.score) != Ordering::Greater,
+            None => true,
+        }
+    }
+
     /// Returns the worst element currently retained (the one that would be evicted next),
     /// without removing it.
     pub fn peek_worst(&self) -> Option<ScoredResult> {

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -376,6 +376,12 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                 // phase needn't re-walk the child. A discarded candidate skips the
                 // copy entirely. When rich results can be trimmed, copy only the
                 // child's yielded metrics rather than its full scoring subtree.
+                // A candidate the heap cannot keep — the common case once it is
+                // full and `k` is small — skips building the push frame and its
+                // record closure entirely.
+                if !self.heap.may_retain(score) {
+                    continue;
+                }
                 self.heap.push_with_record_lazy(doc_id, score, || {
                     Some(if can_trim_deep_results {
                         capture_child_metrics(result)


### PR DESCRIPTION
The adhoc scan called into the heap for every candidate, building the push frame and its record closure before the retention test ran. may_retain answers that test from the heap's root, and reports ties as retainable so the push still owns the doc-id tiebreak.

- perf to check after https://github.com/RediSearch/RediSearch/pull/11036

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
