### PR TITLE
perf(vector): resolve the adhoc distance-lookup arguments once per scan

### DIFF
--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -270,9 +270,11 @@ impl<'index> IndexRef<'index> {
         let query = unsafe { self.prepare_query(query_vector) };
         // SAFETY: `self.inner` upholds its invariant.
         unsafe { VecSimTieredIndex_AcquireSharedLocks(self.inner.as_ptr()) };
+        let lookup_args = (self.inner.as_ptr(), query.ptr());
         SharedLockGuard {
             index: *self,
             query,
+            lookup_args,
         }
     }
 
@@ -361,6 +363,14 @@ pub struct SharedLockGuard<'index> {
     /// call: an owned normalized copy for cosine indexes, or a borrow of the
     /// caller's blob (no copy) for non-cosine — see [`PreparedAdhocQueryBlob`].
     query: PreparedAdhocQueryBlob,
+    /// The two arguments every [`get_distance_from`](Self::get_distance_from)
+    /// passes to VecSim, resolved once here so a lookup is a single call rather
+    /// than a re-walk of [`index`](Self::index) and [`query`](Self::query).
+    ///
+    /// Stays valid for the guard's lifetime: the blob is never mutated after
+    /// the guard is built, and neither variant of [`PreparedAdhocQueryBlob`]
+    /// keeps its bytes inline, so moving the guard does not move them.
+    lookup_args: (*mut VecSimIndex, *const c_void),
 }
 
 impl SharedLockGuard<'_> {
@@ -369,20 +379,15 @@ impl SharedLockGuard<'_> {
     /// returns `NaN` (label not found).
     pub fn get_distance_from(&self, doc_id: DocId) -> Option<f64> {
         // SAFETY:
-        // 1. `self.index.inner` upholds its invariant.
+        // 1. `lookup_args.0` is `IndexRef::inner`, which upholds its invariant.
         // 2. The tiered-index shared locks are held for the lifetime of
         //    `self`, satisfying the `_Unsafe` precondition.
-        // 3. `self.query` was sized and (for cosine) normalized to match the
-        //    index in `acquire_shared_locks`. For the non-cosine `Borrowed`
-        //    variant the pointer aliases the caller's blob, whose validity for
+        // 3. `lookup_args.1` addresses a blob sized and (for cosine) normalized
+        //    to match the index in `acquire_shared_locks`. For the non-cosine
+        //    `Borrowed` variant it aliases the caller's blob, whose validity for
         //    `self`'s lifetime is guaranteed by `acquire_shared_locks`' contract.
-        let distance = unsafe {
-            VecSimIndex_GetDistanceFrom_Unsafe(
-                self.index.inner.as_ptr(),
-                doc_id as usize,
-                self.query.ptr(),
-            )
-        };
+        let (index, query) = self.lookup_args;
+        let distance = unsafe { VecSimIndex_GetDistanceFrom_Unsafe(index, doc_id as usize, query) };
         (!distance.is_nan()).then_some(distance)
     }
 }


### PR DESCRIPTION
SharedLockGuard::get_distance_from re-walked the index reference and matched on the prepared query blob for every candidate, to rebuild two arguments that are fixed for the guard's lifetime. Resolving them when the guard is built makes a lookup a single call.

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
