### PR TITLE
[MOD-15099] perf(top_k): make the score ordering a type instead of a function pointer

### DIFF
--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -33,28 +33,29 @@ pub use range_iterator::NumericRangeIterator;
 pub use score_batch::NumericScoreBatch;
 pub use source::{AllValid, DocValidity, NumericScoreSource};
 
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use rqe_iterators::{
     ExpirationChecker, NoOpChecker, RQEIterator,
     utils::{NoTimeoutChecker, TimeoutContext},
 };
-use top_k::{TopKIterator, TopKMode};
+use top_k::{RuntimeOrder, TopKIterator, TopKMode};
 
 /// A [`TopKIterator`] driven by a [`NumericScoreSource`].
 ///
 /// Construct one with [`new_numeric_top_k_unfiltered`] or
 /// [`new_numeric_top_k_filtered`].
 pub type NumericTopKIterator<'index, V = AllValid, E = NoOpChecker, T = NoTimeoutChecker> =
-    TopKIterator<'index, NumericScoreSource<'index, V, E, T>>;
+    TopKIterator<
+        'index,
+        NumericScoreSource<'index, V, E, T>,
+        Box<dyn rqe_iterators::RQEIterator<'index> + 'index>,
+        RuntimeOrder,
+    >;
 
-/// Pick the heap comparator for the query's sort direction.
-fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
-    if ascending {
-        f64::total_cmp
-    } else {
-        |a, b| b.total_cmp(a)
-    }
+/// Pick the heap's score ordering for the query's sort direction.
+fn cmp_for(ascending: bool) -> RuntimeOrder {
+    RuntimeOrder::new(ascending)
 }
 
 /// Construct an unfiltered [`NumericTopKIterator`] (no filter child).

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -16,6 +16,8 @@ use std::num::NonZeroUsize;
 use index_result::RSIndexResult;
 use rqe_core::DocId;
 
+use crate::order::{Ascending, ScoreOrdering};
+
 /// A (doc_id, score) pair stored in the heap.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScoredResult {
@@ -40,8 +42,8 @@ pub struct HeapResult<'index> {
     pub record: Option<RSIndexResult<'index>>,
 }
 
-impl<'index> From<HeapEntry<'index>> for HeapResult<'index> {
-    fn from(value: HeapEntry<'index>) -> Self {
+impl<'index, O: ScoreOrdering> From<HeapEntry<'index, O>> for HeapResult<'index> {
+    fn from(value: HeapEntry<'index, O>) -> Self {
         HeapResult {
             scored: value.result,
             record: value.record,
@@ -58,34 +60,34 @@ impl<'index> From<HeapEntry<'index>> for HeapResult<'index> {
 /// - `compare(a, b) == Greater` → `a` is **worse** than `b` (= heap-max, evicted first).
 ///
 /// Ties on score are broken by doc id: the lower doc id is **better**.
-struct HeapEntry<'index> {
+struct HeapEntry<'index, O: ScoreOrdering> {
     result: ScoredResult,
     /// The child's record captured at match time, carried alongside the score
     /// so it survives eviction and rides into the drained output.
     record: Option<RSIndexResult<'index>>,
-    /// Cached comparison function so [`Ord`] can be implemented without extra state.
-    compare: fn(&f64, &f64) -> Ordering,
+    /// Score ordering, carried so [`Ord`] can be implemented without extra state.
+    order: O,
 }
 
-impl PartialEq for HeapEntry<'_> {
+impl<O: ScoreOrdering> PartialEq for HeapEntry<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl Eq for HeapEntry<'_> {}
+impl<O: ScoreOrdering> Eq for HeapEntry<'_, O> {}
 
-impl PartialOrd for HeapEntry<'_> {
+impl<O: ScoreOrdering> PartialOrd for HeapEntry<'_, O> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for HeapEntry<'_> {
+impl<O: ScoreOrdering> Ord for HeapEntry<'_, O> {
     fn cmp(&self, other: &Self) -> Ordering {
         // We want the worst element at the top of the heap so eviction is O(log k).
         // `compare(self, other) == Greater` means self is worse.
-        let score_ord = (self.compare)(&self.result.score, &other.result.score);
+        let score_ord = self.order.compare(self.result.score, other.result.score);
         match score_ord {
             Ordering::Less => Ordering::Less,
             Ordering::Greater => Ordering::Greater,
@@ -112,21 +114,21 @@ impl Ord for HeapEntry<'_> {
 ///
 /// For descending order (higher score = better, e.g. numeric SORTBY):
 /// `compare = |a, b| b.partial_cmp(&a).unwrap_or(Ordering::Equal)`
-pub struct TopKHeap<'index> {
-    inner: BinaryHeap<HeapEntry<'index>>,
+pub struct TopKHeap<'index, O: ScoreOrdering = Ascending> {
+    inner: BinaryHeap<HeapEntry<'index, O>>,
     capacity: usize,
-    compare: fn(&f64, &f64) -> Ordering,
+    order: O,
 }
 
-impl<'index> TopKHeap<'index> {
+impl<'index, O: ScoreOrdering> TopKHeap<'index, O> {
     /// Creates a new heap that holds at most `capacity` elements,
-    /// using the supplied `compare` function to determine score order.
-    pub fn new(capacity: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
+    /// using `order` to determine which score is better.
+    pub fn new(capacity: NonZeroUsize, order: O) -> Self {
         let capacity = capacity.into();
         Self {
             inner: BinaryHeap::with_capacity(capacity),
             capacity,
-            compare,
+            order,
         }
     }
 
@@ -195,7 +197,7 @@ impl<'index> TopKHeap<'index> {
         let mut entry = HeapEntry {
             result: ScoredResult { doc_id, score },
             record: None,
-            compare: self.compare,
+            order: self.order,
         };
 
         if !self.is_full() {
@@ -229,13 +231,13 @@ impl<'index> TopKHeap<'index> {
     /// unlike [`push`](Self::push) this performs no eviction, so any excess
     /// would silently exceed capacity.
     pub fn rebuild_from(&mut self, results: impl IntoIterator<Item = HeapResult<'index>>) {
-        let compare = self.compare;
+        let order = self.order;
         self.inner = results
             .into_iter()
             .map(|r| HeapEntry {
                 result: r.scored,
                 record: r.record,
-                compare,
+                order,
             })
             .collect();
         debug_assert!(self.inner.len() <= self.capacity);
@@ -245,7 +247,9 @@ impl<'index> TopKHeap<'index> {
     ///
     /// Unlike [`drain_sorted`](Self::drain_sorted) this borrows the heap, so the
     /// caller can rescore the drained entries and push them back.
-    pub fn drain_unsorted(&mut self) -> impl Iterator<Item = HeapResult<'index>> + use<'index, '_> {
+    pub fn drain_unsorted(
+        &mut self,
+    ) -> impl Iterator<Item = HeapResult<'index>> + use<'index, '_, O> {
         self.inner.drain().map(HeapResult::from)
     }
 
@@ -268,24 +272,17 @@ mod tests {
     use itertools::Itertools;
 
     use super::*;
+    use crate::order::Descending;
 
     fn non_zero_capacity(capacity: usize) -> NonZeroUsize {
         NonZeroUsize::new(capacity).unwrap()
     }
 
     /// Ascending comparator: lower score is better (e.g. vector distance).
-    fn asc(a: &f64, b: &f64) -> Ordering {
-        a.total_cmp(b)
-    }
-
     /// Descending comparator: higher score is better (e.g. numeric SORTBY).
-    fn desc(a: &f64, b: &f64) -> Ordering {
-        b.total_cmp(&a)
-    }
-
     #[test]
     fn heap_fewer_than_k_preserves_all() {
-        let mut heap = TopKHeap::new(non_zero_capacity(5), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(5), Ascending);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -304,7 +301,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -329,7 +326,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Descending);
         heap.push(1, 1.0);
         heap.push(2, 3.0);
         heap.push(3, 2.0);
@@ -353,7 +350,7 @@ mod tests {
 
     #[test]
     fn heap_capacity_one_keeps_best_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(1), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(1), Ascending);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -371,7 +368,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Ascending);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie)
@@ -390,7 +387,7 @@ mod tests {
 
     #[test]
     fn heap_exact_duplicate_not_inserted_when_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Ascending);
         heap.push(1, 1.0);
         heap.push(2, 2.0);
 
@@ -409,7 +406,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Descending);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie, regardless of sort direction)
@@ -428,7 +425,7 @@ mod tests {
 
     #[test]
     fn heap_tiebreak_desc_evicts_higher_doc_id() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Descending);
         heap.push(5, 1.0);
         heap.push(10, 1.0);
         heap.push(3, 1.0);
@@ -446,7 +443,7 @@ mod tests {
     }
     #[test]
     fn heap_tiebreak_asc_evicts_higher_doc_id() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Ascending);
         heap.push(5, 1.0);
         heap.push(10, 1.0);
         heap.push(3, 1.0);
@@ -465,7 +462,7 @@ mod tests {
 
     #[test]
     fn heap_peek_worst_returns_eviction_candidate() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -475,7 +472,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), Ascending);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -492,7 +489,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), Descending);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -509,7 +506,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -523,7 +520,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Descending);
         heap.push(1, 4.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -537,19 +534,19 @@ mod tests {
 
     #[test]
     fn pop_worst_on_empty_returns_none() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         assert!(heap.pop_worst().is_none());
     }
 
     #[test]
     fn peek_worst_on_empty_returns_none() {
-        let heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         assert!(heap.peek_worst().is_none());
     }
 
     #[test]
     fn pop_worst_allows_reinsertion() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Ascending);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.pop_worst();
@@ -562,7 +559,7 @@ mod tests {
 
     #[test]
     fn drain_unsorted_empties_heap_and_returns_all() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), Ascending);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -591,7 +588,7 @@ mod tests {
 
     #[test]
     fn heap_is_empty_and_is_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), Ascending);
         assert!(heap.is_empty());
         assert!(!heap.is_full());
 

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -23,6 +23,7 @@ use rqe_iterators::{
 
 use crate::{
     heap::{HeapResult, ScoredResult, TopKHeap},
+    order::{Ascending, ScoreOrdering},
     traits::{BatchStrategy, ScoreBatch, ScoreSource},
 };
 
@@ -102,6 +103,7 @@ pub struct TopKIterator<
     'index,
     S: ScoreSource,
     C: RQEIterator<'index> + 'index = Box<dyn RQEIterator<'index> + 'index>,
+    O: ScoreOrdering = Ascending,
 > {
     source: S,
     mode: TopKMode,
@@ -109,11 +111,11 @@ pub struct TopKIterator<
     initial_mode: TopKMode,
     /// Captured child records alias `child`, so `heap`, `results`, and `current`
     /// are [`ManuallyDrop`] and freed by the [`Drop`] impl before `child`.
-    heap: ManuallyDrop<TopKHeap<'index>>,
+    heap: ManuallyDrop<TopKHeap<'index, O>>,
     /// Holds the in-progress batch for the Unfiltered path.
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
-    compare: fn(&f64, &f64) -> Ordering,
+    order: O,
     /// When `true`, filtered modes skip deep-copying the child's rich result
     /// subtree and yield its metrics with the source's score attached.
     /// Set when the downstream pipeline needs no rich results (no relevance
@@ -132,7 +134,9 @@ pub struct TopKIterator<
     pub metrics: TopKMetrics,
 }
 
-impl<'index, S: ScoreSource, C: RQEIterator<'index> + 'index> Drop for TopKIterator<'index, S, C> {
+impl<'index, S: ScoreSource, C: RQEIterator<'index> + 'index, O: ScoreOrdering> Drop
+    for TopKIterator<'index, S, C, O>
+{
     fn drop(&mut self) {
         // `heap`, `results`, and `current` hold child records captured via
         // `capture_child_record`, whose term borrows alias data owned by `child`.
@@ -147,22 +151,26 @@ impl<'index, S: ScoreSource, C: RQEIterator<'index> + 'index> Drop for TopKItera
     }
 }
 
-impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
+impl<'index, S: ScoreSource + 'index, O: ScoreOrdering>
+    TopKIterator<'index, S, Box<dyn RQEIterator<'index> + 'index>, O>
+{
     /// Create a new unfiltered [`TopKIterator`] (no child filter).
     ///
     /// Results are streamed directly from the source's batch — the heap is bypassed.
     /// Use [`new`](Self::new) when a filter child is present.
-    pub fn new_unfiltered(source: S, k: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
-        Self::new_with_mode(source, None, k, compare, TopKMode::Unfiltered)
+    pub fn new_unfiltered(source: S, k: NonZeroUsize, order: O) -> Self {
+        Self::new_with_mode(source, None, k, order, TopKMode::Unfiltered)
     }
 }
 
-impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKIterator<'index, S, C> {
+impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index, O: ScoreOrdering>
+    TopKIterator<'index, S, C, O>
+{
     /// Create a new [`TopKIterator`] with a filter child.
     ///
     /// The initial mode defaults to [`TopKMode::Batches`].
-    pub fn new(source: S, child: C, k: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
-        Self::new_with_mode(source, Some(child), k, compare, TopKMode::Batches)
+    pub fn new(source: S, child: C, k: NonZeroUsize, order: O) -> Self {
+        Self::new_with_mode(source, Some(child), k, order, TopKMode::Batches)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -170,18 +178,18 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         source: S,
         child: Option<C>,
         k: NonZeroUsize,
-        compare: fn(&f64, &f64) -> Ordering,
+        order: O,
         mode: TopKMode,
     ) -> Self {
         Self {
-            heap: ManuallyDrop::new(TopKHeap::new(k, compare)),
+            heap: ManuallyDrop::new(TopKHeap::new(k, order)),
             source,
             child,
             mode,
             initial_mode: mode,
             direct_batch: None,
             k,
-            compare,
+            order,
             can_trim_deep_results: false,
             phase: Phase::NotStarted,
             results: ManuallyDrop::new(Vec::new()),
@@ -249,7 +257,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // de-duping against it, so leftover hits would duplicate doc ids and
             // skew the top-k set. Rewind the source too: collect_batches/
             // prepare_unfiltered_direct resume from its cursor rather than the start.
-            *self.heap = TopKHeap::new(self.k, self.compare);
+            *self.heap = TopKHeap::new(self.k, self.order);
             self.source.rewind();
             if let Some(child) = &mut self.child {
                 child.rewind();
@@ -324,7 +332,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                     // rescans every match from scratch, so batch-phase entries
                     // are redundant. Keeping them would re-admit the same doc id
                     // (TopKHeap::push only de-dups against the worst element).
-                    *self.heap = TopKHeap::new(self.k, self.compare);
+                    *self.heap = TopKHeap::new(self.k, self.order);
                     self.collect_adhoc()?;
                     return Ok(());
                 }
@@ -417,7 +425,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// the [`Yielding`](Phase::Yielding) phase.
     fn finalize_collection(&mut self) {
         // Replace heap with a fresh one; drain_sorted consumes the old one.
-        let old_heap = std::mem::replace(&mut *self.heap, TopKHeap::new(self.k, self.compare));
+        let old_heap = std::mem::replace(&mut *self.heap, TopKHeap::new(self.k, self.order));
         *self.results = old_heap.drain_sorted();
         self.yield_pos = 0;
         self.phase = Phase::Yielding;
@@ -543,8 +551,8 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     }
 }
 
-impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterator<'index>
-    for TopKIterator<'index, S, C>
+impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index, O: ScoreOrdering>
+    RQEIterator<'index> for TopKIterator<'index, S, C, O>
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -601,7 +609,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
 
     #[inline(always)]
     fn rewind(&mut self) {
-        *self.heap = TopKHeap::new(self.k, self.compare);
+        *self.heap = TopKHeap::new(self.k, self.order);
         self.results.clear();
         *self.current = None;
         self.source.rewind();
@@ -696,10 +704,10 @@ fn capture_child_metrics<'index>(record: &RSIndexResult<'index>) -> RSIndexResul
 /// Uses a merge-join (alternating `skip_to` calls) to find matching doc IDs.
 ///
 /// The child is **rewound** at the start of each call.
-fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
+fn intersect_batch_with_child<'index, C: RQEIterator<'index>, O: ScoreOrdering>(
     child: &mut C,
     batch: &mut impl ScoreBatch,
-    heap: &mut TopKHeap<'index>,
+    heap: &mut TopKHeap<'index, O>,
     metrics: &mut TopKMetrics,
     can_trim_deep_results: bool,
 ) -> Result<(), RQEIteratorError> {
@@ -805,10 +813,11 @@ pub trait TopKSourceProfile {
     );
 }
 
-impl<'index, S, C> ProfilePrint for TopKIterator<'index, S, C>
+impl<'index, S, C, O> ProfilePrint for TopKIterator<'index, S, C, O>
 where
     S: ScoreSource + TopKSourceProfile + 'index,
     C: RQEIterator<'index> + ProfilePrint + 'index,
+    O: ScoreOrdering,
 {
     fn print_profile(&self, map: &mut MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         let child = self.child.as_ref().map(|c| c as &dyn ProfilePrint);
@@ -817,8 +826,9 @@ where
     }
 }
 
-impl<'index, S: ScoreSource + 'index> rqe_iterators::interop::ProfileChildren<'index>
-    for TopKIterator<'index, S, rqe_iterators::c2rust::CRQEIterator>
+impl<'index, S: ScoreSource + 'index, O: ScoreOrdering + 'index>
+    rqe_iterators::interop::ProfileChildren<'index>
+    for TopKIterator<'index, S, rqe_iterators::c2rust::CRQEIterator, O>
 {
     fn profile_children(mut self) -> Self {
         self.child = self

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod heap;
 pub mod iterator;
+pub mod order;
 pub mod traits;
 
 #[cfg(test)]
@@ -34,4 +35,5 @@ pub mod mock;
 
 pub use heap::{HeapResult, ScoredResult, TopKHeap};
 pub use iterator::{TopKIterator, TopKMode, TopKSourceProfile};
+pub use order::{Ascending, Descending, RuntimeOrder, ScoreOrdering};
 pub use traits::{BatchStrategy, ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/order.rs
+++ b/src/redisearch_rs/top_k/src/order.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Score orderings for [`TopKHeap`](crate::TopKHeap).
+
+use std::cmp::Ordering;
+
+/// Which score the top-k treats as better, and so which end of the range it
+/// keeps.
+///
+/// Implementers are [`Copy`] and carry nothing but the direction, so
+/// [`compare`](Self::compare) inlines into the heap's sift loops.
+pub trait ScoreOrdering: Copy {
+    /// Orders `a` against `b`, returning [`Ordering::Less`] when `a` is the
+    /// better score.
+    fn compare(self, a: f64, b: f64) -> Ordering;
+}
+
+/// Lower score is better, as for a vector distance.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Ascending;
+
+impl ScoreOrdering for Ascending {
+    #[inline]
+    fn compare(self, a: f64, b: f64) -> Ordering {
+        a.total_cmp(&b)
+    }
+}
+
+/// Higher score is better.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Descending;
+
+impl ScoreOrdering for Descending {
+    #[inline]
+    fn compare(self, a: f64, b: f64) -> Ordering {
+        b.total_cmp(&a)
+    }
+}
+
+/// A direction settled at run time, for queries whose sort order is not known
+/// until the request is parsed.
+///
+/// Costs one well-predicted branch per comparison — [`Ascending`] and
+/// [`Descending`] cost none — and still inlines.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RuntimeOrder {
+    ascending: bool,
+}
+
+impl RuntimeOrder {
+    /// Orders ascending when `ascending` is set, descending otherwise.
+    pub const fn new(ascending: bool) -> Self {
+        Self { ascending }
+    }
+}
+
+impl ScoreOrdering for RuntimeOrder {
+    #[inline]
+    fn compare(self, a: f64, b: f64) -> Ordering {
+        if self.ascending {
+            a.total_cmp(&b)
+        } else {
+            b.total_cmp(&a)
+        }
+    }
+}

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -12,21 +12,18 @@
 //! with exactly one begin and one end, including when the child errors
 //! mid-loop.
 
-use std::{cmp::Ordering, marker::PhantomData, num::NonZeroUsize};
+use std::{marker::PhantomData, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use rqe_iterators_test_utils::ContractChecker;
+use top_k::Ascending;
 use top_k::{
     BatchStrategy, ScoreSource, ScoredResult, TopKIterator, TopKMode, mock::MockScoreBatch,
     mock::MockScoreSource,
 };
-
-fn asc(a: &f64, b: &f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
-}
 
 fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
@@ -121,7 +118,7 @@ fn hooks_called_once_per_scan_with_lookups_in_between() {
         CallCountingScoreSource::default(),
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     );
     while it.read().unwrap().is_some() {}
@@ -221,7 +218,7 @@ fn end_adhoc_runs_when_child_errors_midscan() {
         CallCountingScoreSource::default(),
         Some(child),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     );
     assert!(matches!(it.read().unwrap_err(), RQEIteratorError::TimedOut));
@@ -244,7 +241,7 @@ fn rerank_runs_once_after_clean_scan() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     );
     while it.read().unwrap().is_some() {}
@@ -268,7 +265,7 @@ fn rerank_skipped_on_timeout() {
         source,
         Some(child),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     );
     assert!(matches!(it.read().unwrap_err(), RQEIteratorError::TimedOut));
@@ -298,7 +295,7 @@ fn rerank_reorders_topk_by_exact_scores() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
 
@@ -324,7 +321,7 @@ fn rerank_keeps_adhoc_score_for_unmapped_doc() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
 

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -9,7 +9,7 @@
 
 //! Integration tests for [`TopKIterator`].
 
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
@@ -19,6 +19,7 @@ use rqe_iterators::{
     IdList, RQEIterator, RQEIteratorError, c2rust::CRQEIterator, interop::ProfileChildren,
 };
 use rqe_iterators_test_utils::ContractChecker;
+use top_k::Ascending;
 use top_k::{
     BatchStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch, mock::MockScoreSource,
 };
@@ -80,10 +81,6 @@ impl ScoreSource for TimingOutSource {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Ascending comparator: lower score is better (e.g. vector distance).
-fn asc(a: &f64, b: &f64) -> Ordering {
-    a.total_cmp(&b)
-}
-
 fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
 }
@@ -105,7 +102,7 @@ fn read_triggers_collection_on_first_call() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
 
     assert!(!it.at_eof());
@@ -121,7 +118,7 @@ fn rewind_resets_to_not_started() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
     it.read().unwrap();
     it.read().unwrap();
@@ -145,7 +142,7 @@ fn eof_set_after_results_exhausted() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -165,7 +162,7 @@ fn filtered_path_clears_current_once_exhausted() {
         source,
         make_child(vec![1, 2]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     );
 
     assert!(it.read().unwrap().is_some());
@@ -187,7 +184,7 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
 
     assert_eq!(it.last_doc_id(), 0);
@@ -210,7 +207,7 @@ fn num_estimated_capped_at_k() {
     let it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
 
     assert_eq!(it.num_estimated(), 3);
@@ -228,7 +225,7 @@ fn num_estimated_capped_by_child() {
         source,
         make_child(vec![2]),
         NonZeroUsize::new(100).unwrap(),
-        asc,
+        Ascending,
     );
 
     assert_eq!(it.num_estimated(), 1);
@@ -246,7 +243,7 @@ fn unfiltered_yields_batch_in_source_order() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(ids, vec![1, 2, 3]);
@@ -258,7 +255,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -271,7 +268,7 @@ fn unfiltered_timeout_propagated() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         TimingOutSource,
         NonZeroUsize::new(5).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(matches!(
         it.read().unwrap_err(),
@@ -294,7 +291,7 @@ fn batches_overlap_intersection() {
         source,
         make_child(vec![1, 3, 5]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![5, 3, 1]);
@@ -309,7 +306,7 @@ fn batches_disjoint_yields_nothing() {
         source,
         make_child(vec![10, 20]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -324,7 +321,7 @@ fn batches_empty_child_yields_nothing() {
         source,
         make_child(vec![]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -343,7 +340,7 @@ fn batches_multiple_batches() {
         source,
         make_child(vec![1, 3, 4]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![3, 4, 1]);
@@ -360,7 +357,7 @@ fn batches_no_child(
         source,
         None,
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        Ascending,
         TopKMode::Batches,
     )
 }
@@ -414,7 +411,7 @@ fn batches_expired_doc_shrinks_results_without_refill() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(2).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![2]);
@@ -432,7 +429,7 @@ fn unfiltered_expired_docs_dropped_at_yield() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![2]);
@@ -452,7 +449,7 @@ fn unfiltered_timeout_polled_while_skipping_expired() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
 }
@@ -472,7 +469,7 @@ fn yield_timeout_polled_while_skipping_expired() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
 }
@@ -489,7 +486,7 @@ fn unfiltered_timeout_polled_before_yielding_valid() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
     assert_eq!(it.read().unwrap().map(|r| r.doc_id), Some(1));
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
@@ -509,7 +506,7 @@ fn yield_timeout_polled_before_yielding_valid() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(3).unwrap(),
-        asc,
+        Ascending,
     ));
     assert_eq!(it.read().unwrap().map(|r| r.doc_id), Some(1));
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
@@ -531,7 +528,7 @@ fn retry_after_timeout_discards_partial_collection() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
 
@@ -557,7 +554,7 @@ fn strategy_stop_stops_after_first_batch() {
         source,
         make_child(vec![1, 2, 3, 4]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids.len(), 2);
@@ -647,7 +644,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         source,
         make_child(vec![1, 3]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
 
     // Session 1: the source returns one batch (doc 1, doc 3 land in the heap)
@@ -688,7 +685,7 @@ fn strategy_switch_to_adhoc() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
@@ -717,7 +714,7 @@ fn strategy_expand_window_preserves_heap() {
         source,
         make_child(vec![1, 2]),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 2]);
@@ -735,7 +732,7 @@ fn adhoc_scores_known_docs_only() {
         source,
         Some(make_child(vec![1, 2, 3, 4, 5])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -756,7 +753,7 @@ fn adhoc_early_stop_when_heap_full() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(2).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -772,7 +769,7 @@ fn adhoc_child_eof_returns_what_was_found() {
         source,
         Some(make_child(vec![1, 2])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -793,7 +790,7 @@ fn adhoc_expired_doc_shrinks_results_without_refill() {
         source,
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(2).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -808,7 +805,7 @@ fn adhoc_empty_child_is_eof() {
         source,
         Some(make_child(vec![])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     assert!(it.read().unwrap().is_none());
@@ -872,7 +869,7 @@ fn adhoc_timeout_propagated() {
         TimingOutAdhocSource { adhoc_calls: 0 },
         Some(make_child(vec![1, 2, 3, 4, 5])),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     ));
     assert!(matches!(it.read().unwrap_err(), RQEIteratorError::TimedOut));
@@ -888,7 +885,7 @@ fn profile_children_wraps_child_in_profile_node() {
         BatchStrategy::Continue
     });
     let child = make_crqe_child(vec![1, 2, 3]);
-    let it = TopKIterator::new(source, child, NonZeroUsize::new(10).unwrap(), asc);
+    let it = TopKIterator::new(source, child, NonZeroUsize::new(10).unwrap(), Ascending);
 
     let mut profiled = it.profile_children();
 
@@ -899,7 +896,7 @@ fn profile_children_wraps_child_in_profile_node() {
         "filter child should be wrapped in a Profile node after profile_children()"
     );
 
-    // Results must be unchanged: all three docs, sorted best-first (asc).
+    // Results must be unchanged: all three docs, sorted best-first (Ascending).
     let doc_ids: Vec<_> =
         std::iter::from_fn(|| profiled.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![3, 1, 2]);
@@ -915,7 +912,7 @@ fn profile_children_with_no_child_is_identity() {
         source,
         None,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::Unfiltered,
     );
 
@@ -959,7 +956,7 @@ fn batches_preserves_child_scoring_fields() {
         source,
         Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     ));
 
     let mut emitted = Vec::new();
@@ -1000,7 +997,7 @@ fn batches_trim_deep_results_yields_metric_only() {
         source,
         Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     )
     .with_trim_deep_results(true);
 
@@ -1040,7 +1037,7 @@ fn adhoc_trim_deep_results_yields_metric_only() {
         source,
         Some(Box::new(child) as Box<dyn RQEIterator<'_> + '_>),
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
         TopKMode::AdhocBF,
     )
     .with_trim_deep_results(true);
@@ -1080,7 +1077,7 @@ fn batches_trim_deep_results_preserves_child_metrics() {
         source,
         Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     )
     .with_trim_deep_results(true);
 
@@ -1120,7 +1117,7 @@ fn batches_trim_deep_results_payload_carries_source_score() {
         source,
         Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
         NonZeroUsize::new(10).unwrap(),
-        asc,
+        Ascending,
     )
     .with_trim_deep_results(true);
 

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -9,20 +9,17 @@
 
 //! Integration tests for [`TopKIterator::revalidate`].
 
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
 use rqe_iterators::{RQEIterator, RQEValidateStatus};
 use rqe_iterators_test_utils::ContractChecker;
+use top_k::Ascending;
 use top_k::{BatchStrategy, TopKIterator, mock::MockScoreSource};
 
 /// Ascending comparator: lower score is better (e.g. vector distance).
-const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
-    f64::total_cmp
-}
-
 /// Child iterator whose `revalidate` unconditionally returns `Aborted`.
 ///
 /// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
@@ -164,7 +161,7 @@ fn without_child_returns_ok() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
         source,
         NonZeroUsize::new(5).unwrap(),
-        asc(),
+        Ascending,
     ));
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -181,7 +178,7 @@ fn with_child_delegates_ok() {
         source,
         child,
         NonZeroUsize::new(5).unwrap(),
-        asc(),
+        Ascending,
     ));
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -196,7 +193,7 @@ fn with_child_delegates_aborted() {
         source,
         child,
         NonZeroUsize::new(5).unwrap(),
-        asc(),
+        Ascending,
     ));
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Aborted);
@@ -213,7 +210,7 @@ fn moved_child_collapses_to_ok() {
         source,
         child,
         NonZeroUsize::new(5).unwrap(),
-        asc(),
+        Ascending,
     ));
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -17,16 +17,12 @@
 use top_k_bencher as _;
 
 use std::hint::black_box;
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{SeedableRng as _, seq::SliceRandom as _};
 use rqe_iterators::RQEIterator;
-use top_k::{BatchStrategy, TopKHeap, TopKIterator, TopKMode, mock::MockScoreSource};
-
-fn asc(a: &f64, b: &f64) -> Ordering {
-    a.partial_cmp(b).unwrap_or(Ordering::Equal)
-}
+use top_k::{Ascending, BatchStrategy, TopKHeap, TopKIterator, TopKMode, mock::MockScoreSource};
 
 // ── Heap benchmarks ───────────────────────────────────────────────────────────
 
@@ -41,7 +37,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, Ascending);
                 for i in 0..n {
                     heap.push(i as u64, i as f64);
                 }
@@ -58,7 +54,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, Ascending);
                 for i in (0..n).rev() {
                     heap.push(i as u64, i as f64);
                 }
@@ -79,7 +75,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         BenchmarkId::new("insert_rand", format!("{n}→k{k}")),
         |b| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, Ascending);
                 for &i in &scores {
                     heap.push(i, i as f64);
                 }
@@ -100,7 +96,7 @@ fn bench_heap_pop_all(c: &mut Criterion) {
         |b, &k| {
             b.iter_batched(
                 || {
-                    let mut heap = TopKHeap::new(k, asc);
+                    let mut heap = TopKHeap::new(k, Ascending);
                     for i in 0..k.get() {
                         heap.push(i as u64, i as f64);
                     }
@@ -135,7 +131,7 @@ fn bench_intersection_overlap(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, child, k, asc);
+                    let mut it = TopKIterator::new(source, child, k, Ascending);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,
@@ -164,7 +160,7 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, child, k, asc);
+                    let mut it = TopKIterator::new(source, child, k, Ascending);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,
@@ -198,8 +194,13 @@ fn bench_adhoc_vs_batches(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it =
-                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::AdhocBF);
+                    let mut it = TopKIterator::new_with_mode(
+                        source,
+                        Some(child),
+                        k,
+                        Ascending,
+                        TopKMode::AdhocBF,
+                    );
                     while it.read().unwrap().is_some() {}
                     black_box(it.at_eof())
                 },
@@ -218,8 +219,13 @@ fn bench_adhoc_vs_batches(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it =
-                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::Batches);
+                    let mut it = TopKIterator::new_with_mode(
+                        source,
+                        Some(child),
+                        k,
+                        Ascending,
+                        TopKMode::Batches,
+                    );
                     while it.read().unwrap().is_some() {}
                     black_box(it.at_eof())
                 },

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -36,7 +36,7 @@ use rqe_iterators::profile_print::ProfilePrint;
 pub use score_batch::VecSimScoreBatch;
 pub use source::VectorScoreSource;
 
-use std::{cmp::Ordering, ffi::CStr, num::NonZeroUsize};
+use std::{ffi::CStr, num::NonZeroUsize};
 
 use ffi::{
     VecSearchMode, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
@@ -46,7 +46,7 @@ use ffi::{
 use redis_reply::MapBuilder;
 use rqe_iterators::profile_print::ProfilePrintCtx;
 use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIterator};
-use top_k::{TopKIterator, TopKMode, TopKSourceProfile};
+use top_k::{Ascending, TopKIterator, TopKMode, TopKSourceProfile};
 
 /// A [`TopKIterator`] parameterised over [`VectorScoreSource`].
 ///
@@ -62,9 +62,9 @@ use top_k::{TopKIterator, TopKMode, TopKSourceProfile};
 pub type VectorTopKIterator<'index, E = FieldExpirationChecker, I = CRQEIterator> =
     TopKIterator<'index, VectorScoreSource<'index, E>, I>;
 
-/// Ascending comparator — lower distance score is better (vector L2/IP/Cosine).
-const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
-    f64::total_cmp
+/// Lower distance score is better (vector L2/IP/Cosine).
+const fn asc() -> Ascending {
+    Ascending
 }
 
 /// Map a [`TopKMode`] and its mid-run switch count to the [`VecSearchMode`]

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -13,7 +13,7 @@
 //! Index layout: doc `i` (1..=n) is `[i; dim]` under L2, so distance to query
 //! `[q; dim]` is `dim*(q-i)^2` and the nearest neighbours are the highest ids.
 
-use std::{cmp::Ordering, ffi::c_void, ptr, ptr::NonNull};
+use std::{ffi::c_void, ptr, ptr::NonNull};
 
 use ffi::{
     AlgoParams, BFParams, HNSWParams, VecSearchMode, VecSearchMode_EMPTY_MODE,
@@ -23,12 +23,13 @@ use ffi::{
     t_docId,
 };
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
+use top_k::Ascending;
 
 use crate::VectorScoreSource;
 
-/// Ascending comparator: lower distance score is better.
-pub const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
-    f64::total_cmp
+/// Lower distance score is better.
+pub const fn asc() -> Ascending {
+    Ascending
 }
 
 /// Native-endian f32 byte blob of `values`, as VecSim expects.

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -41,8 +41,6 @@ use std::{
     num::NonZeroUsize,
 };
 
-use std::cmp::Ordering;
-
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ffi::{
     HNSWParams, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
@@ -52,14 +50,8 @@ use ffi::{
 };
 use rqe_iterators::{IdList, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
-use top_k::{TopKIterator, TopKMode};
+use top_k::{Ascending, TopKIterator, TopKMode};
 use vector_score_source::VectorScoreSource;
-
-/// Score order for vector distance: ascending (lower distance = better).
-/// Matches the comparator `vector_score_source` uses internally.
-fn asc_cmp(a: &f64, b: &f64) -> Ordering {
-    a.partial_cmp(b).unwrap_or(Ordering::Equal)
-}
 
 // ── C shim (from hybrid_shim.c, compiled by build.rs) ────────────────────────
 
@@ -215,7 +207,7 @@ fn run_rust(
     let child: Box<dyn RQEIterator> = Box::new(IdList::<true>::new(ids.to_vec()));
     // Matches the shim's `canTrimDeepResults`: capture only the child's yielded
     // metrics on a match, rather than deep-copying its whole scoring subtree.
-    let mut it = TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode)
+    let mut it = TopKIterator::new_with_mode(source, Some(child), k, Ascending, mode)
         .with_trim_deep_results(true);
     let mut count = 0usize;
     while it.read().unwrap().is_some() {


### PR DESCRIPTION
The heap stored its comparator as a fn pointer in every element and called it through that pointer, so a comparison could not inline.

ScoreOrdering carries the direction in the type: the vector path gets Ascending, a zero-sized type that compiles to a bare total_cmp, and the numeric path gets RuntimeOrder for directions only known once the query is parsed.

outcome:

### `adhoc`

| case | Rust baseline | Rust with fix | Rust Δ | ratio baseline → with fix |
| --- | ---: | ---: | ---: | ---: |
| n=10 000, k=10 | 2.098 µs | 1.675 µs | **−20.1%** | 1.22× → **0.96×** |
| n=10 000, k=100 | 28.56 µs | 21.17 µs | **−25.9%** | 0.93× → **0.72×** |
| n=100 000, k=10 | 2.423 µs | 1.864 µs | **−23.1%** | 1.25× → **0.96×** |
| n=100 000, k=100 | 28.87 µs | 21.94 µs | **−24.0%** | 0.95× → **0.72×** |

### `adhoc_child_sweep`, n=100 000

| case | Rust baseline | Rust with fix | Rust Δ | ratio baseline → with fix |
| --- | ---: | ---: | ---: | ---: |
| k=10, child=1 | 228.4 ns | 210.9 ns | **−7.7%** | 1.32× → 1.19× |
| k=10, child=10 | 992.8 ns | 717.5 ns | **−27.7%** | 1.26× → **0.90×** |
| k=10, child=100 | 3.481 µs | 2.872 µs | **−17.5%** | 1.23× → **1.01×** |
| k=10, child=1 000 | 32.10 µs | 31.03 µs | −3.3% | 1.17× → 1.12× |
| k=10, child=6 900 | 213.5 µs | 206.1 µs | −3.5% | 1.16× → 1.12× |
| k=100, child=1 | 219.1 ns | 183.8 ns | **−16.1%** | 1.16× → **0.96×** |
| k=100, child=10 | 1.030 µs | 696.9 ns | **−32.3%** | 1.29× → **0.84×** |
| k=100, child=100 | 10.09 µs | 6.715 µs | **−33.4%** | 0.97× → **0.65×** |
| k=100, child=1 000 | 54.50 µs | 45.64 µs | **−16.2%** | 1.01× → **0.86×** |
| k=100, child=6 900 | 248.6 µs | 231.0 µs | **−7.1%** | 1.12× → **1.04×** |

### `mode_comparison`, adhoc mode

| config | Rust Δ | ratio baseline → with fix |
| --- | ---: | ---: |
| `adhoc_favored` | **−23.2%** | 0.95× → **0.72×** |
| `balanced` | **−7.2%** | 1.12× → **1.04×** |
| `batches_favored` | −0.3% | 1.08× → 1.02× |

### Batches

batches also benefits from this change but less, not pictured here.

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
