### PR TITLE
[MOD-17877] Fix crash and missing results when writing documents while a cursor is open

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -1169,16 +1169,16 @@ pub unsafe extern "C" fn IndexReader_NumericFilter(ir: *const IndexReader) -> *c
     }
 }
 
-/// Revalidate the index reader against its inverted index. This is only needed if the inverted index
-/// has been modified since the last time the reader was used. The function returns true if the
-/// reader needs revalidation, false otherwise.
+/// Report whether the index reader needs to be revalidated against its inverted index. This is
+/// only needed if the inverted index has been modified since the last time the reader was used.
+/// The function returns true if the reader needs revalidation, false otherwise.
 ///
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexReader_Revalidate(ir: *mut IndexReader) -> bool {
+pub unsafe extern "C" fn IndexReader_NeedsRevalidation(ir: *mut IndexReader) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
 
     // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -1184,13 +1184,5 @@ pub unsafe extern "C" fn IndexReader_Revalidate(ir: *mut IndexReader) -> bool {
     // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
     let ir = unsafe { &mut *ir };
 
-    let needs_revalidation = ir_dispatch!(ir, needs_revalidation);
-
-    if !needs_revalidation {
-        // No GC occurred, but we still need to refresh buffer pointers
-        // in case blocks were reallocated
-        ir_dispatch!(ir, refresh_buffer_pointers);
-    }
-
-    needs_revalidation
+    ir_dispatch!(ir, needs_revalidation)
 }

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -174,6 +174,18 @@ bool IndexReader_HasMulti(const struct IndexReader *ir);
 bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
 
 /**
+ * Report whether the index reader needs to be revalidated against its inverted index. This is
+ * only needed if the inverted index has been modified since the last time the reader was used.
+ * The function returns true if the reader needs revalidation, false otherwise.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_NeedsRevalidation(struct IndexReader *ir);
+
+/**
  * Advance the index reader to the next entry in the index. If there is a next entry, it will be
  * written to the output parameter `res` and the function will return true. If there are no more
  * entries, the function will return false.
@@ -216,18 +228,6 @@ const struct NumericFilter *IndexReader_NumericFilter(const struct IndexReader *
  * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
  */
 void IndexReader_Reset(struct IndexReader *ir);
-
-/**
- * Revalidate the index reader against its inverted index. This is only needed if the inverted index
- * has been modified since the last time the reader was used. The function returns true if the
- * reader needs revalidation, false otherwise.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-bool IndexReader_Revalidate(struct IndexReader *ir);
 
 /**
  * Seek the index reader to the entry with the given document ID. If such an entry exists, it will be

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -393,15 +393,6 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>
         let live: *const [u8] = block.buffer.as_slice();
         !std::ptr::addr_eq(cached, live) || cached.len() != live.len()
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        let ii = self.ii.get();
-        if !ii.blocks.is_empty() && self.current_block_idx < ii.blocks.len() {
-            let current_block = &ii.blocks[self.current_block_idx];
-            // Update the cursor to point to the current position in the refreshed buffer
-            self.buf = SharedPtr::from_ref(current_block.buffer.as_slice());
-        }
-    }
 }
 
 impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> RawIndexReaderCore<Active<'index>, E> {

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -183,10 +183,10 @@ where
             if !std::ptr::eq(old_base, new_base) {
                 // The block buffer was reallocated to a different address by a
                 // non-GC operation (e.g. an append that outgrew its allocation)
-                // without bumping the GC marker.
-                // Since GC has not run, the number of "old" blocks
-                // is the same and there is no risk of ABA confusion.
-                //
+                // without bumping the GC marker. Comparing addresses is ABA-safe
+                // here for the reason given in [`IndexReader::needs_revalidation`]:
+                // only an append can free and reallocate a buffer without moving
+                // the marker, and an append cannot leave the length where it was.
                 //
                 // Refreshing only `self.buf` would
                 // leave the iterator's cached `result` holding an `RSOffsetSlice`
@@ -383,6 +383,14 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>
         //
         // Only the cached pointer's address and length are read, never the pointee, which is
         // what makes this safe to ask while the buffer it describes may already be freed.
+        //
+        // ABA-safe, and it is the length rather than the address that makes it so. Exactly two
+        // things write a block's buffer: GC repair, which bumps `gc_marker` as the last step of
+        // every pass, and appends, which start writing at `buffer.len()` and so only ever grow it.
+        // Freeing and reallocating the buffer therefore takes an append, which lengthens it
+        // whatever address the allocator hands back, and shortening it back takes a repair, which
+        // moves the marker. An unchanged marker, address and length together mean the block has
+        // not been written since the reader cached it.
         let Some(block) = ii.blocks.get(self.current_block_idx) else {
             // Nothing cached to go stale: an empty index leaves the reader on the empty slice,
             // and blocks only ever disappear by GC, which the marker above already caught.

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -370,7 +370,28 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>
     }
 
     fn needs_revalidation(&self) -> bool {
-        self.gc_marker != self.ii.get().gc_marker.load(atomic::Ordering::Relaxed)
+        let ii = self.ii.get();
+        if self.gc_marker != ii.gc_marker.load(atomic::Ordering::Relaxed) {
+            return true;
+        }
+
+        // Appending to a block reallocates its buffer without bumping `gc_marker`, and either
+        // outcome invalidates what this reader cached. A moved buffer leaves the cached pointer
+        // dangling. A buffer grown in place keeps the pointer good but makes the cached length
+        // short, which would end the read at the old end of the block and drop the appended
+        // entries. Both are reported so the caller re-seeks, which repairs either.
+        //
+        // Only the cached pointer's address and length are read, never the pointee, which is
+        // what makes this safe to ask while the buffer it describes may already be freed.
+        let Some(block) = ii.blocks.get(self.current_block_idx) else {
+            // Nothing cached to go stale: an empty index leaves the reader on the empty slice,
+            // and blocks only ever disappear by GC, which the marker above already caught.
+            return false;
+        };
+
+        let cached = self.buf.as_raw();
+        let live: *const [u8] = block.buffer.as_slice();
+        !std::ptr::addr_eq(cached, live) || cached.len() != live.len()
     }
 
     fn refresh_buffer_pointers(&mut self) {

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -148,10 +148,6 @@ impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterMaskReader<I
     fn needs_revalidation(&self) -> bool {
         self.inner.needs_revalidation()
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        self.inner.refresh_buffer_pointers();
-    }
 }
 
 impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> FilterMaskReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -222,10 +222,6 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
     fn needs_revalidation(&self) -> bool {
         self.inner.needs_revalidation()
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        self.inner.refresh_buffer_pointers();
-    }
 }
 
 impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> FilterGeoReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -75,11 +75,17 @@ pub trait IndexReader<'index> {
     /// Get the flags of the underlying index
     fn flags(&self) -> IndexFlags;
 
-    /// Check if the underlying index has been modified since the last time this reader read from it.
-    /// If it has, then the reader should be reset before reading from it again.
+    /// Check whether the underlying index changed under this reader in a way that invalidates
+    /// where it stands: a GC cycle shifting entries, or a write reallocating the block buffer it
+    /// is reading. The reader must then be reset and re-seeked before it reads again — re-pointing
+    /// the cached buffer is not a substitute, see [`ResumableReader::refresh_pointers`] for why.
     fn needs_revalidation(&self) -> bool;
 
-    /// Refresh buffer pointers in case blocks were reallocated without GC changes
+    /// Re-point the cached block buffer at the live one, keeping the read position.
+    ///
+    /// Sound only while the buffer's base address is unchanged, since the read position and
+    /// anything borrowing the bytes behind it are kept as they are. A reader that may have missed
+    /// a move must re-seek instead — see [`Self::needs_revalidation`].
     fn refresh_buffer_pointers(&mut self);
 }
 

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -80,13 +80,6 @@ pub trait IndexReader<'index> {
     /// is reading. The reader must then be reset and re-seeked before it reads again — re-pointing
     /// the cached buffer is not a substitute, see [`ResumableReader::refresh_pointers`] for why.
     fn needs_revalidation(&self) -> bool;
-
-    /// Re-point the cached block buffer at the live one, keeping the read position.
-    ///
-    /// Sound only while the buffer's base address is unchanged, since the read position and
-    /// anything borrowing the bytes behind it are kept as they are. A reader that may have missed
-    /// a move must re-seek instead — see [`Self::needs_revalidation`].
-    fn refresh_buffer_pointers(&mut self);
 }
 
 /// Type-level mapping from an Active reader to its Suspended counterpart.

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -242,10 +242,6 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericRea
     fn needs_revalidation(&self) -> bool {
         self.inner.needs_revalidation()
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        self.inner.refresh_buffer_pointers();
-    }
 }
 
 impl<'index, E: DecodedBy<Decoder = D>, D: Decoder>

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -80,3 +80,57 @@ impl<'a> PartialEq for TermRecordCompare<'a> {
         true
     }
 }
+
+/// Move a block's encoded-entry buffer to a different address, leaving its bytes and the index's
+/// `gc_marker` alone — what a write that outgrows the buffer's allocation does to a reader parked
+/// on that block.
+///
+/// Appending cannot stand in for this: whether `reserve_exact` growth moves the buffer or extends
+/// it in place is the allocator's choice, so a test that appends until the address changes may
+/// never see it change. Here the replacement is built while the original is still alive, so the
+/// two cannot share an address whatever the allocator does. The original is then freed, which is
+/// what makes a reader's cached pointer genuinely dangle.
+///
+/// Returns the buffer's new base address.
+///
+/// # Panics
+///
+/// If `block_idx` is out of range.
+pub fn relocate_block_buffer<E: crate::Encoder + crate::DecodedBy>(
+    index: &mut crate::InvertedIndex<E>,
+    block_idx: usize,
+) -> *const u8 {
+    let block = &mut index.blocks[block_idx];
+
+    // Hold the original allocation while the replacement is allocated, so they cannot overlap.
+    let original = std::mem::take(&mut block.buffer);
+    let mut relocated = Vec::with_capacity(original.len().max(1));
+    relocated.extend_from_slice(&original);
+
+    let base = relocated.as_ptr();
+    block.buffer = relocated;
+    drop(original);
+
+    assert_ne!(base, std::ptr::null(), "relocated buffer must be allocated");
+    base
+}
+
+/// Give a block's buffer enough spare capacity for `extra` more bytes, so that appends of up to
+/// that size grow it in place instead of reallocating.
+///
+/// The counterpart to [`relocate_block_buffer`]: it makes the *other* outcome of an append — the
+/// buffer keeping its address while its length grows — reachable on demand rather than at the
+/// allocator's discretion.
+///
+/// # Panics
+///
+/// If `block_idx` is out of range.
+pub fn reserve_block_buffer<E: crate::Encoder + crate::DecodedBy>(
+    index: &mut crate::InvertedIndex<E>,
+    block_idx: usize,
+    extra: usize,
+) -> *const u8 {
+    let buffer = &mut index.blocks[block_idx].buffer;
+    buffer.reserve(extra);
+    buffer.as_ptr()
+}

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -888,3 +888,58 @@ fn test_refresh_buffer_pointers_after_reallocation() {
     assert_eq!(doc_count, 990);
     assert_eq!(expected_doc_id, 1000);
 }
+
+/// A write that moves a block's buffer must be reported by
+/// [`needs_revalidation`](crate::IndexReader::needs_revalidation), even though no GC ran.
+///
+/// [`test_refresh_buffer_pointers_after_reallocation`] covers the repair but refreshes the reader
+/// itself, so it never checks that a caller is told to. A reader that is not told holds a pointer
+/// into freed memory.
+#[test]
+#[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]
+fn test_needs_revalidation_after_block_buffer_moved() {
+    use crate::IndexReader as _;
+
+    let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(10).build())
+        .unwrap();
+    ii.add_record(&RSIndexResult::build_virt().doc_id(11).build())
+        .unwrap();
+
+    // SAFETY: mirrors what a suspended cursor does — the reader is parked, untouched, while the
+    // index is written to. The reader is not used until after the writes, and the writes only ever
+    // reallocate block buffers, leaving the `InvertedIndex` itself in place.
+    let ii_ptr = &mut ii as *mut InvertedIndex<Dummy>;
+
+    let mut reader: crate::IndexReaderCore<'_, Dummy> = ii.reader();
+    let mut result = RSIndexResult::build_virt().build();
+    assert!(reader.next_record(&mut result).unwrap());
+    assert_eq!(result.doc_id, 10);
+    assert!(
+        !reader.needs_revalidation(),
+        "an untouched index must not ask for revalidation"
+    );
+
+    // Append a document the reader has not reached, then move the buffer. Appending alone would
+    // leave it to the allocator whether the address changes at all — see
+    // [`relocate_block_buffer`](crate::test_utils::relocate_block_buffer).
+    let base_before = ii.block_ref(0).unwrap().data().as_ptr();
+    // SAFETY: see the `ii_ptr` construction above.
+    let base_after = unsafe {
+        (*ii_ptr)
+            .add_record(&RSIndexResult::build_virt().doc_id(12).build())
+            .unwrap();
+        crate::test_utils::relocate_block_buffer(&mut *ii_ptr, 0)
+    };
+    assert_ne!(base_before, base_after, "the buffer did not move");
+
+    assert_eq!(
+        ii.gc_marker(),
+        0,
+        "no GC ran, so the marker cannot be what flags this"
+    );
+    assert!(
+        reader.needs_revalidation(),
+        "a moved block buffer must be reported: the reader's cached pointer is now dangling"
+    );
+}

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -833,67 +833,12 @@ fn ii_apply_gc_entries_tracking_index() {
         }
     );
 }
-#[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]
-#[test]
-fn test_refresh_buffer_pointers_after_reallocation() {
-    use crate::IndexReader as _;
-
-    let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
-
-    // Add initial records
-    ii.add_record(&RSIndexResult::build_virt().doc_id(10).build())
-        .unwrap();
-    ii.add_record(&RSIndexResult::build_virt().doc_id(11).build())
-        .unwrap();
-
-    // SAFETY: We need to bypass Rust's borrowing rules to simulate the real-world
-    // scenario where buffer reallocation happens while a reader is active.
-    // This is safe because:
-    // 1. We're not accessing the reader during the mutation
-    // 2. The InvertedIndex structure remains valid
-    // 3. We call refresh_buffer_pointers before using the reader again
-    let ii_ptr = &mut ii as *mut InvertedIndex<Dummy>;
-
-    let mut reader: crate::IndexReaderCore<'_, Dummy> = ii.reader();
-    let mut result = RSIndexResult::build_virt().build();
-
-    // Read first record
-    assert!(reader.next_record(&mut result).unwrap());
-    assert_eq!(result.doc_id, 10);
-
-    // Force buffer reallocation by adding many records to the same block
-    // This should cause the buffer to grow and potentially move
-    unsafe {
-        for i in 12..1000 {
-            (*ii_ptr)
-                .add_record(&RSIndexResult::build_virt().doc_id(i).build())
-                .unwrap();
-        }
-    }
-
-    // Buffer was reallocated - test refresh_buffer_pointers
-    reader.refresh_buffer_pointers();
-
-    // Verify we can still read correctly from the new buffer
-    let mut doc_count = 1; // Already read doc_id 10
-    let mut expected_doc_id = 11;
-
-    while reader.next_record(&mut result).unwrap() {
-        assert_eq!(result.doc_id, expected_doc_id);
-        doc_count += 1;
-        expected_doc_id += 1;
-    }
-
-    // Should have read all 990 documents (10, 11, 12..999)
-    assert_eq!(doc_count, 990);
-    assert_eq!(expected_doc_id, 1000);
-}
 
 /// A write that moves a block's buffer must be reported by
 /// [`needs_revalidation`](crate::IndexReader::needs_revalidation), even though no GC ran.
 ///
-/// [`test_refresh_buffer_pointers_after_reallocation`] covers the repair but refreshes the reader
-/// itself, so it never checks that a caller is told to. A reader that is not told holds a pointer
+/// The repair itself is the reader's re-seek on `revalidate`; this test only checks that a
+/// caller is told to revalidate in the first place. A reader that is not told holds a pointer
 /// into freed memory.
 #[test]
 #[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]

--- a/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
@@ -586,10 +586,6 @@ impl<'index, I: Iterator<Item = RSIndexResult<'index>>> IndexReader<'index> for 
     fn needs_revalidation(&self) -> bool {
         false
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        unimplemented!("This test won't refresh buffer pointers")
-    }
 }
 
 // Claim iterators are numeric readers so they can be used in tests.

--- a/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
@@ -231,6 +231,53 @@ fn reader_needs_revalidation() {
     assert!(ir.needs_revalidation(), "index was modified");
 }
 
+/// A reader on an index with no blocks has cached nothing, so it has nothing to find stale — and
+/// must not ask to be revalidated on every cursor read for the lack of a block to compare against.
+#[test]
+fn reader_needs_no_revalidation_when_index_has_no_blocks() {
+    let ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    assert_eq!(ii.number_of_blocks(), 0);
+
+    assert!(!ii.reader().needs_revalidation());
+}
+
+/// A block buffer that grows *in place* must be reported too. The reader's cached pointer still
+/// aims at live memory, so nothing dangles, but its cached length stops short of the appended
+/// entries — reading on would end the block early and drop them.
+#[test]
+#[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]
+fn reader_needs_revalidation_when_block_buffer_grew_in_place() {
+    let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(10).build())
+        .unwrap();
+
+    // Spare capacity up front, so the append below cannot move the buffer.
+    let base_before = crate::test_utils::reserve_block_buffer(&mut ii, 0, 128);
+
+    // SAFETY: mirrors a suspended cursor — the reader is parked and untouched while the index is
+    // written to. The write only appends into the block's spare capacity, leaving the
+    // `InvertedIndex` itself in place.
+    let ii_ptr = &mut ii as *mut InvertedIndex<Dummy>;
+
+    let ir = ii.reader();
+    assert!(!ir.needs_revalidation(), "index was not modified yet");
+
+    // SAFETY: see the `ii_ptr` construction above.
+    unsafe {
+        (*ii_ptr)
+            .add_record(&RSIndexResult::build_virt().doc_id(11).build())
+            .unwrap();
+    }
+    assert_eq!(
+        ii.block_ref(0).unwrap().data().as_ptr(),
+        base_before,
+        "the append was supposed to grow the buffer in place"
+    );
+    assert_eq!(ii.gc_marker(), 0, "no GC ran");
+
+    assert!(ir.needs_revalidation(), "the cached length is now short");
+}
+
 #[test]
 fn reader_unique_docs() {
     let blocks = medium_thin_vec![

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -327,11 +327,4 @@ impl<'a> IndexReader<'a> for NumericIndexReader<'a> {
             Self::Compressed(r) => r.needs_revalidation(),
         }
     }
-
-    fn refresh_buffer_pointers(&mut self) {
-        match self {
-            Self::Uncompressed(r) => r.refresh_buffer_pointers(),
-            Self::Compressed(r) => r.refresh_buffer_pointers(),
-        }
-    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -454,8 +454,10 @@ where
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // If there has been a GC cycle on this key while we were suspended, the offset might not be valid
-        // anymore. This means that we need to seek the last docId we were at
+        // Either a GC cycle moved the entries this reader had already passed, or a write
+        // reallocated the block buffer it was reading. Both leave the cached read offset
+        // describing something that is no longer there, so the position has to be found again by
+        // seeking to the last document id we returned.
         let last_doc_id = self.last_doc_id();
         let was_at_eos = self.at_eos;
         let result_doc_id = self.result.doc_id;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -373,11 +373,6 @@ impl<'index> IndexReader<'index> for TermIndexReader<'index> {
     fn needs_revalidation(&self) -> bool {
         term_ir_dispatch!(self, needs_revalidation)
     }
-
-    #[inline(always)]
-    fn refresh_buffer_pointers(&mut self) {
-        term_ir_dispatch!(self, refresh_buffer_pointers)
-    }
 }
 
 /// Resolve an opaque index and compare it against the current variant's reader.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -447,6 +447,48 @@ mod not_miri {
         assert_eq!(status, RQEValidateStatus::Aborted);
     }
 
+    /// Term records carry borrowed offsets into the block buffer, so a moved buffer puts both the
+    /// reader's cursor and the current record's offsets on freed memory.
+    #[test]
+    fn term_revalidate_after_block_buffer_moved() {
+        let test = TermRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+        };
+
+        test.test
+            .revalidate_after_block_buffer_moved(&mut it, ii, appended_record);
+    }
+
+    /// Driven bare, deliberately: this test garbage-collects the index while the iterator is
+    /// parked. `num_estimated()` shrinks with the collected document, while the checker's upper
+    /// bound counts every result yielded since the last rewind, including those yielded before the
+    /// GC. That bound only holds for an index that does not shrink underneath the iterator.
+    #[test]
+    fn term_revalidate_after_block_buffer_moved_and_gc() {
+        let test = TermRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        let ii = {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+        };
+
+        test.test
+            .revalidate_after_block_buffer_moved_and_gc(&mut it, ii, appended_record);
+    }
+
+    /// Build a record shaped like the ones [`TermRevalidateTest`] seeds the index with.
+    fn appended_record(doc_id: DocId) -> RSIndexResult<'static> {
+        const OFFSETS: &[u8] = &[0, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+
+        let mut term = RSQueryTerm::new("term", 1, 0);
+        term.set_idf(5.0);
+        term.set_bm25_idf(10.0);
+        expected_record(doc_id, u32::MAX as FieldMask, term, OFFSETS)
+    }
+
     #[test]
     fn term_revalidate_after_document_deleted() {
         let test = TermRevalidateTest::new(10);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -553,6 +553,122 @@ impl RevalidateTest {
         }
     }
 
+    /// A write that moves a block's buffer must cost the iterator nothing.
+    ///
+    /// A suspended iterator whose block buffer moved holds a pointer into freed memory, while the
+    /// GC marker still says the index is untouched. Reading on decodes recycled bytes — a short
+    /// read that silently drops documents, or a decode error — so the complete document set is
+    /// asserted rather than merely the absence of a crash.
+    pub fn revalidate_after_block_buffer_moved<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(DocId) -> RSIndexResult<'static>,
+    {
+        self.block_buffer_moved(it, ii, make_record, false);
+    }
+
+    /// [`revalidate_after_block_buffer_moved`](Self::revalidate_after_block_buffer_moved) with a GC
+    /// cycle interleaved: both invalidate the iterator, and a repair that handles only one of them
+    /// fails here.
+    pub fn revalidate_after_block_buffer_moved_and_gc<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(DocId) -> RSIndexResult<'static>,
+    {
+        self.block_buffer_moved(it, ii, make_record, true);
+    }
+
+    fn block_buffer_moved<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+        interleave_gc: bool,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(DocId) -> RSIndexResult<'static>,
+    {
+        // Appends land in the last block, so the iterator has to be parked in that same block for
+        // this to exercise anything; the assertion catches a codec whose block size changes.
+        assert_eq!(
+            ii.number_of_blocks(),
+            1,
+            "the fixture must fit in a single block"
+        );
+
+        // Park the iterator mid-block.
+        for expected in &self.doc_ids[..2] {
+            let doc = it
+                .read()
+                .expect("failed to read")
+                .expect("should not be at EOF");
+            assert_eq!(doc.doc_id, *expected);
+        }
+
+        // Append documents the iterator has not reached, then move the buffer they live in.
+        // Appending alone would leave it to the allocator whether the address changes at all — see
+        // `inverted_index::test_utils::relocate_block_buffer`.
+        let base_before = ii.block_ref(0).unwrap().data().as_ptr();
+        let appended: Vec<DocId> = (1..=3)
+            .map(|i| self.doc_ids.last().unwrap() + 2 * i)
+            .collect();
+        for doc_id in &appended {
+            ii.add_record(&make_record(*doc_id)).expect("append failed");
+        }
+        assert_eq!(
+            ii.number_of_blocks(),
+            1,
+            "the appends must stay in the block the iterator is parked in"
+        );
+
+        let base_after = inverted_index::test_utils::relocate_block_buffer(ii, 0);
+        assert_ne!(base_before, base_after, "the buffer did not move");
+        let gc_marker_before = ii.gc_marker();
+
+        // Removing a document the iterator already passed leaves the expected set below
+        // untouched, and bumps the GC marker on top of the moved buffer.
+        if interleave_gc {
+            self.remove_document(ii, self.doc_ids[0]);
+            assert_ne!(ii.gc_marker(), gc_marker_before, "GC did not run");
+        } else {
+            assert_eq!(
+                ii.gc_marker(),
+                gc_marker_before,
+                "a plain append must not touch the GC marker — that is what makes it undetected"
+            );
+        }
+
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
+        assert_eq!(
+            status,
+            RQEValidateStatus::Ok,
+            "the iterator's position still exists, so revalidation must preserve it"
+        );
+
+        // Everything the iterator had not yielded yet, still in order and without repeats.
+        let mut expected = self.doc_ids[2..].to_vec();
+        expected.extend_from_slice(&appended);
+
+        let mut read = Vec::new();
+        while let Some(doc) = it.read().expect("failed to read") {
+            read.push(doc.doc_id);
+        }
+        assert_eq!(read, expected);
+    }
+
     /// Remove the document with the given id from the inverted index.
     pub fn remove_document<E: Encoder + DecodedBy>(
         &self,

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -1044,3 +1044,64 @@ def test_cursor_gc_reschedules_sweep_on_main_thread():
     with TimeLimit(10, "idle cursor was not reaped at MAXIDLE after cluster FT.CURSOR GC"):
         while getCursorStats(env)['global_total']:
             sleep(0.05)
+
+
+@skip(cluster=True)
+def testCursorReadsDocumentsWrittenBetweenReads(env):
+    """Writes between `FT.CURSOR READ` calls must not cost a cursor its results.
+
+    Query iterators stay parked between reads with the index lock released, so a write can append
+    to the very posting list a leaf is reading and move that block's buffer to a fresh allocation.
+    A leaf that does not notice keeps decoding the old address, and the cursor either drops
+    documents it should still have returned or fails once the freed bytes decode to nonsense.
+
+    Small posting lists are the exposed shape, so the tag matched here holds a handful of documents
+    and the scan stays inside the one block being appended to.
+
+    Whether a given write actually moves the buffer is the allocator's call, so this cannot force
+    the condition from outside the server and does not try to: it asserts that no document is lost,
+    which holds either way. Forcing the move is the job of the Rust tests, which relocate a block
+    buffer directly (`inverted_index::test_utils::relocate_block_buffer`).
+
+    Standalone only: the defect is shard-local, and a coordinator cursor reaches the same leaf
+    through an extra fan-in that contributes nothing to reproducing it.
+    """
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc:',
+               'SCHEMA', 'seller', 'TAG', 'status', 'TAG').ok()
+    waitForIndex(env, 'idx')
+    con = env.getClusterConnectionIfNeeded()
+
+    seeded = 20
+    for i in range(seeded):
+        con.execute_command('HSET', f'doc:{i}', 'seller', 's1', 'status', 'open')
+
+    # COUNT 1 maximises the number of suspensions, and hence the chances of catching a buffer
+    # that moved while parked.
+    res, cid = env.cmd('FT.AGGREGATE', 'idx', '@seller:{s1}', 'LOAD', 1, '@__key',
+                       'WITHCURSOR', 'COUNT', 1, 'MAXIDLE', 60000)
+    env.assertNotEqual(0, cid)
+
+    returned = [res[1]]
+    # Bounded, because a write per read would keep the posting list one document ahead of the
+    # cursor forever: the refreshed tail makes each new document visible to the same scan.
+    for written in range(seeded):
+        # Append to the same posting list the cursor is parked in. Each write is small, so the
+        # block buffer grows a little at a time and eventually has to be reallocated.
+        con.execute_command('HSET', f'doc:new{written}', 'seller', 's1', 'status', 'open')
+        if not cid:
+            break
+        res, cid = env.cmd('FT.CURSOR', 'READ', 'idx', cid)
+        returned.extend(res[1:])
+
+    # Drain what is left without writing, so the cursor can reach its end.
+    while cid:
+        res, cid = env.cmd('FT.CURSOR', 'READ', 'idx', cid)
+        returned.extend(res[1:])
+
+    keys = [to_dict(row)['__key'] for row in returned]
+    # Every document the cursor did report, it reported once.
+    env.assertEqual(len(keys), len(set(keys)))
+    # Documents written after the query started may or may not be visible, but the ones that were
+    # already indexed when it started must all come back.
+    env.assertEqual(sorted(f'doc:{i}' for i in range(seeded)),
+                    sorted(k for k in keys if not k.startswith('doc:new')))


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.AGGREGATE ... WITHCURSOR` keeps its iterators alive between `FT.CURSOR READ` calls with the index lock released. A write can then append to the posting list a leaf is parked on and reallocate that block's buffer. `gc_marker` only tracks GC, so nothing tells the leaf: if the buffer moved it reads on through a freed pointer, crashing the shard on a Rust `unreachable!()` or silently dropping and corrupting results; if it grew in place the leaf keeps a short cached length, so it ends the block early and drops the appended entries, and `skip_to` can claim a document is in the current block that the read then cannot find.
2. Change: a suspended leaf now notices that the block buffer it cached has changed and re-seeks, instead of reading on from a stale pointer or length.
3. Outcome: write-heavy indexes no longer lose a shard to a cursor read, and a cursor no longer returns a silently short result set.

#### Which additional issues this PR fixes

1. MOD-17877
2. MOD-13085 — its fix stopped running once the leaves finished moving to Rust and the last C caller of `IndexReader_Revalidate` went away with #8779; this restores the guarantee on the path that is now live.

#### Main objects this PR modified

1. `IndexReader::needs_revalidation` — compares the cached block buffer's address *and* length against the live block, so both outcomes of an append are reported and both take the existing rewind-and-re-seek path. Only the cached pointer's address and length are read, never the pointee, which may already be freed.
2. `IndexReader::refresh_buffer_pointers` — removed, in the second commit. Once the check lives in `needs_revalidation` it has no caller, and folding it in is what #7795's reviewers asked for rather than adding a separate method that a caller can forget. `IndexReader_Revalidate` now just reports `needs_revalidation`.
3. `inverted_index::test_utils` — `relocate_block_buffer` and `reserve_block_buffer`, which force a move and an in-place growth respectively rather than leaving it to the allocator. See *On the tests* below.
4. Tests — reader-level for each outcome (moved buffer, and in-place growth, both with `gc_marker` untouched), iterator-level for a moved buffer with and without an interleaved GC cycle (asserting the complete document set, in order), and a `WITHCURSOR` flow test that writes into the parked posting list between reads.

#### Why one path rather than two

A re-seek is the only sound repair for a moved buffer: re-pointing the cached slice while keeping the read position leaves the leaf's cached `RSIndexResult` holding an `RSOffsetSlice` into the freed allocation, which is a use-after-free as soon as a caller reads `current()`. `ResumableReader::refresh_pointers` documents the same conclusion for the suspend/resume path.

Reporting the in-place case through that same path costs a rewind and `skip_to` where an O(1) pointer refresh would have done. The re-seek is a binary search over the block list plus a decode forward from that block's start, so it is bounded by one block (100 entries for most codecs, 1000 for the doc-ids-only ones), and it runs once per leaf per `FT.CURSOR READ` rather than per document. The GC case already paid exactly this. What is bought is a single mechanism with no second call for a caller to forget, which is how this regressed in the first place.

#### On the tests

Whether an append moves a buffer or extends it in place is the allocator's choice, so the tests force the condition rather than waiting for it: `relocate_block_buffer` allocates the replacement while the original is still alive, so the addresses cannot coincide, then frees the original; `reserve_block_buffer` adds spare capacity up front so an append provably stays put. Each test asserts which outcome it got.

Verified in the other direction too: with the `needs_revalidation` change reverted, the three new tests fail — the two reader-level ones on their assertions, and the iterator-level one on completeness (`[5..21]` against an expected `[5..27]`, i.e. the appended documents silently vanish). The GC-interleaved test still passes without the fix, as it should, since the marker path already covered that.

#### Deliberately not in this PR

A decode error on a leaf still reaches an `unreachable!()` in the FFI shim, which aborts the shard rather than the query. This change removes one way to *provoke* that, but not the landmine itself, and #11002 documents another that has nothing to do with buffers: arming a field-expiry gate mid-cursor panics in the same `skip_to` arm. So a distinct `ITERATOR_ERROR` status, handled by every consumer, is the safety net if some other path can still corrupt a posting list mid-read. It was in this PR and has been split out for its own discussion. Four things that surfaced while it was here belong with it, and are recorded so they are not lost:

- `rpQueryItNext_AsyncDisk()` handles only `RS_RESULT_TIMEDOUT`, so an iterator error leaves `atEOF` false and the processor refills and polls indefinitely.
- `OPT_Read()` returning early abandons the `DocTable_Borrow()` references held by unyielded heap entries; `OptimizerIterator_Free()` does not return them.
- `prepareResults()` keeps walking vector batches after a child has failed unrecoverably.
- `revalidate()` maps a decode error to `VALIDATE_ABORTED`, which reads as normal completion and so truncates results silently.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
