### PR TITLE
[8.8-rse] [MOD-16263] Mirror RediSearchEnterprise@8.8 in src/version.h (8.8.5)

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -11,9 +11,7 @@
 // If declared with -D in compile time, this file is ignored
 //
 // On an `-rse` branch this mirrors RediSearchEnterprise@8.8's own
-// src/version.h — the enterprise release that ships this code line. Keeping
-// the two equal is what lets a PR merging here declare its fix version
-// without a cross-repo lookup; the enterprise release flow bumps both.
+// src/version.h — the enterprise release that ships this code line.
 
 #pragma once
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,12 +9,17 @@
 
 // This is where the modules build/version is declared.
 // If declared with -D in compile time, this file is ignored
+//
+// On an `-rse` branch this mirrors RediSearchEnterprise@8.8's own
+// src/version.h — the enterprise release that ships this code line. Keeping
+// the two equal is what lets a PR merging here declare its fix version
+// without a cross-repo lookup; the enterprise release flow bumps both.
 
 #pragma once
 
-#define REDISEARCH_VERSION_MAJOR 99
-#define REDISEARCH_VERSION_MINOR 99
-#define REDISEARCH_VERSION_PATCH 99
+#define REDISEARCH_VERSION_MAJOR 8
+#define REDISEARCH_VERSION_MINOR 8
+#define REDISEARCH_VERSION_PATCH 5
 
 #ifndef REDISEARCH_MODULE_NAME
 #define REDISEARCH_MODULE_NAME "search"


### PR DESCRIPTION
Sets `src/version.h` on `8.8-rse` to **8.8.5**, the version committed on
`RediSearchEnterprise@8.8`, replacing the `99.99.99` sentinel.

## Why

`8.8-rse` is the RediSearch code line consumed by RediSearchEnterprise 8.8, but its
`version.h` says nothing about which enterprise release ships it.

Making the file reflect the enterprise release it ships in gives the `-rse` line a single
source of truth.


Ref: MOD-16263 · [Design doc][doc]

[doc]: https://redislabs.atlassian.net/wiki/spaces/DX/pages/6346178605/Jira+Fix-Version+Automation+Agent+for+RediSearch+Project+Tickets
