### PR TITLE
[MOD-14988] tag_index: gc

### DIFF
--- a/src/redisearch_rs/inverted_index/src/index/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/index/mod.rs
@@ -16,6 +16,7 @@ mod with_mask;
 
 pub use self::core::*;
 pub(crate) use expiration_bits::ExpirationBits;
+pub use unique_id::IndexUniqueId;
 pub use with_entries::EntriesTrackingIndex;
 pub use with_mask::FieldMaskTrackingIndex;
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -160,7 +160,10 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
 #[cfg(feature = "test-utils")]
 use inverted_index::RepairContext;
-use inverted_index::{DocId, IndexReader, InvertedIndex, doc_ids_only::DocIdsOnly};
+use inverted_index::{
+    DocId, GcApplyInfo, GcScanDelta, IndexReader, IndexUniqueId, InvertedIndex,
+    doc_ids_only::DocIdsOnly,
+};
 use query_term::RSQueryTerm;
 use rqe_iterators::{
     FieldExpirationChecker,
@@ -529,6 +532,65 @@ impl TagIndex<InMemoryMode> {
         // is `TagIterator::new`'s own requirement on `lookup`.
         Some(unsafe { TagIterator::new(reader, sctx, lookup, term, weight, checker) })
     }
+
+    /// Apply a garbage-collection `delta` (computed by a fork GC scan) to the
+    /// inverted index stored for `tag`. If no document is left afterwards,
+    /// the tag is dropped from the values trie and from the
+    /// [suffix index](TagSuffixIndex), when enabled.
+    ///
+    /// `unique_id` is the [`IndexUniqueId`] of the inverted index the GC scan ran
+    /// against, read via [`InvertedIndex::unique_id`] at scan time: when the tag
+    /// was removed or its index replaced in the meantime, the delta is stale and
+    /// `None` is returned without applying anything.
+    ///
+    /// A pointer to the scanned index would not do here in place of `unique_id`: the
+    /// scan and this call are the two ends of a fork-GC cycle, so the tag's
+    /// `Box<InvertedIndex<DocIdsOnly>>` can be freed and a new one allocated at the
+    /// same address in between (the tag emptied, then re-added) — an ABA problem a
+    /// raw pointer comparison cannot detect, but a monotonically-assigned unique ID
+    /// can. See [`IndexUniqueId`] and [`RawIndexReaderCore::points_to_ii`], which
+    /// guards the equivalent reader-revalidation case the same way.
+    ///
+    /// On success, returns the [`GcApplyInfo`] describing the applied changes.
+    /// Its [`bytes_freed`](GcApplyInfo::bytes_freed) and
+    /// [`block_count_delta`](GcApplyInfo::block_count_delta) already account for
+    /// the whole posting list being dropped when the tag became empty.
+    ///
+    /// [`RawIndexReaderCore::points_to_ii`]: inverted_index::reader::RawIndexReaderCore::points_to_ii
+    pub fn gc(
+        &mut self,
+        tag: &[u8],
+        unique_id: IndexUniqueId,
+        delta: GcScanDelta,
+    ) -> Option<GcApplyInfo> {
+        let ii = self.mode.values.find_mut(tag)?;
+        // Detects the tag being removed or its index replaced meanwhile.
+        if ii.unique_id() != unique_id {
+            return None;
+        }
+
+        let mut info = ii.apply_gc(delta);
+
+        if ii.unique_docs() == 0 {
+            info.bytes_freed += ii.memory_usage();
+            info.block_count_delta -= ii.number_of_blocks() as i64;
+
+            self.remove_tag_value(tag);
+
+            if let Some(suffix) = &mut self.suffix
+                && !tag.is_empty()
+            {
+                suffix.delete(tag);
+            }
+        }
+
+        Some(info)
+    }
+
+    /// Remove `tag` (and its postings) from the values trie.
+    fn remove_tag_value(&mut self, tag: &[u8]) {
+        self.mode.values.remove(tag);
+    }
 }
 
 // More methods to access internals for test purposes.
@@ -556,20 +618,6 @@ impl TagIndex<InMemoryMode> {
         ii.apply_gc(delta);
     }
 
-    /// Simulate GC dropping `tag` altogether: both the trie entry and the
-    /// inverted index it owned are gone, which is what
-    /// [`TrieLookup::find`](TagLookup::find) must report to abort a reader still
-    /// holding the freed posting list.
-    ///
-    /// Same reason as [`gc_empty_value`](Self::gc_empty_value): no production
-    /// path in this crate removes a tag yet.
-    pub fn gc_remove_value(&mut self, tag: &[u8]) {
-        self.mode
-            .values
-            .remove(tag)
-            .expect("tag was indexed, so it has an entry to remove");
-    }
-
     /// Whether `key` is registered in the [suffix index](TagSuffixIndex) — as a
     /// full tag term or as a suffix of one. `false` when suffix indexing is
     /// disabled.
@@ -577,6 +625,13 @@ impl TagIndex<InMemoryMode> {
         self.suffix
             .as_ref()
             .is_some_and(|suffix| suffix.find(key).is_some())
+    }
+
+    /// Handle over [`remove_tag_value`](Self::remove_tag_value): lets tests
+    /// simulate the garbage collector dropping every document for `tag`. The
+    /// production path is [`gc`](Self::gc).
+    pub fn delete_tag_value(&mut self, tag: &[u8]) {
+        self.remove_tag_value(tag);
     }
 }
 
@@ -652,6 +707,69 @@ impl TagLookup<DocIdsOnly> for TrieLookup {
         let tag_index = unsafe { self.0.as_ref() };
 
         tag_index.mode.values.find(tag).map(Box::as_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rqe_iterators::{NoOpChecker, RQEIterator, RQEValidateStatus};
+    use rqe_iterators_test_utils::MockContext;
+
+    /// The iterator built by [`TagIndex::open_reader`] must abort
+    /// revalidation once the garbage collector removed the tag's postings —
+    /// [`TrieLookup`] no longer resolves the tag, so the reader is stale.
+    ///
+    /// The index is reached through raw pointers because the GC mutates it while
+    /// the iterator is parked. That is the interleaving [`TrieLookup::new`]'s
+    /// provenance contract exists for.
+    #[test]
+    fn revalidate_aborts_after_tag_removed() {
+        let mock = MockContext::new(3, 3);
+        let mut idx = TagIndex::<InMemoryMode>::new(false);
+        let tags = &[Tag::new(b"team").unwrap()];
+        for doc_id in 1..=3 {
+            // `doc_id` is non-decreasing across loop iterations, as `index` requires.
+            idx.index(tags, doc_id, false);
+        }
+        // Heap-allocate the index and go through raw pointers so it can be
+        // mutated while the iterator holds a lookup back-pointer, as the query
+        // layer does across GC cycles.
+        let idx = Box::into_raw(Box::new(idx));
+
+        // SAFETY: `idx` was just allocated and is not mutated while `ii` is in use.
+        let ii = unsafe { &*idx }
+            .find_value(b"team")
+            .expect("tag was indexed");
+        let term = RSQueryTerm::new_bytes(b"team", 0, 0);
+        // SAFETY: `mock` provides a valid sctx/spec and `idx` stays valid for
+        // the iterator's lifetime; it is only mutated between revalidations.
+        let mut it = unsafe {
+            TagIterator::new(
+                ii.reader(),
+                mock.sctx(),
+                TrieLookup(NonNull::new(idx).expect("just allocated")),
+                term,
+                1.0,
+                NoOpChecker,
+            )
+        };
+
+        let status = it.revalidate(&mock.spec_read()).expect("revalidate failed");
+        assert_eq!(status, RQEValidateStatus::Ok);
+
+        // Simulate the garbage collector removing the tag's postings entirely.
+        // SAFETY: the iterator is not touched during the mutation, per the
+        // revalidation protocol.
+        unsafe { (*idx).delete_tag_value(b"team") };
+
+        let status = it.revalidate(&mock.spec_read()).expect("revalidate failed");
+        assert_eq!(status, RQEValidateStatus::Aborted);
+
+        drop(it);
+        // SAFETY: allocated with `Box::into_raw` above; the iterator borrowing
+        // into it has been dropped.
+        drop(unsafe { Box::from_raw(idx) });
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -545,8 +545,8 @@ impl TagIndex<InMemoryMode> {
     /// [`IndexUniqueId`] and [`RawIndexReaderCore::points_to_ii`], which guards the
     /// equivalent reader-revalidation case the same way.
     ///
-    /// On success, returns the [`GcApplyInfo`] describing the applied changes, and
-    /// `None` when the delta is stale — the tag is gone, or its index was replaced.
+    /// Returns the [`GcApplyInfo`] describing the applied changes, or `None` when the
+    /// delta is stale (the tag is gone or its index was replaced).
     /// [`bytes_freed`](GcApplyInfo::bytes_freed) and
     /// [`block_count_delta`](GcApplyInfo::block_count_delta) already account for
     /// the whole posting list being dropped when the tag became empty.

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -538,20 +538,15 @@ impl TagIndex<InMemoryMode> {
     /// the tag is dropped from the values trie and from the
     /// [suffix index](TagSuffixIndex), when enabled.
     ///
-    /// `unique_id` is the [`IndexUniqueId`] of the inverted index the GC scan ran
-    /// against, read via [`InvertedIndex::unique_id`] at scan time. It stands in for
-    /// a pointer to that index to avoid the ABA problem: a raw pointer comparison
-    /// cannot detect it, but a monotonically-assigned unique ID can. See
-    /// [`IndexUniqueId`] and [`RawIndexReaderCore::points_to_ii`], which guards the
-    /// equivalent reader-revalidation case the same way.
+    /// `unique_id` identifies the one index the scan ran against, read via
+    /// [`InvertedIndex::unique_id`] at scan time: `tag` may hold a different index by
+    /// now, and a delta computed elsewhere must not be applied to it.
     ///
     /// Returns the [`GcApplyInfo`] describing the applied changes, or `None` when the
     /// delta is stale (the tag is gone or its index was replaced).
     /// [`bytes_freed`](GcApplyInfo::bytes_freed) and
     /// [`block_count_delta`](GcApplyInfo::block_count_delta) already account for
     /// the whole posting list being dropped when the tag became empty.
-    ///
-    /// [`RawIndexReaderCore::points_to_ii`]: inverted_index::reader::RawIndexReaderCore::points_to_ii
     pub fn gc(
         &mut self,
         tag: Tag<'_>,

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -539,31 +539,26 @@ impl TagIndex<InMemoryMode> {
     /// [suffix index](TagSuffixIndex), when enabled.
     ///
     /// `unique_id` is the [`IndexUniqueId`] of the inverted index the GC scan ran
-    /// against, read via [`InvertedIndex::unique_id`] at scan time: when the tag
-    /// was removed or its index replaced in the meantime, the delta is stale and
-    /// `None` is returned without applying anything.
+    /// against, read via [`InvertedIndex::unique_id`] at scan time. It stands in for
+    /// a pointer to that index to avoid the ABA problem: a raw pointer comparison
+    /// cannot detect it, but a monotonically-assigned unique ID can. See
+    /// [`IndexUniqueId`] and [`RawIndexReaderCore::points_to_ii`], which guards the
+    /// equivalent reader-revalidation case the same way.
     ///
-    /// A pointer to the scanned index would not do here in place of `unique_id`: the
-    /// scan and this call are the two ends of a fork-GC cycle, so the tag's
-    /// `Box<InvertedIndex<DocIdsOnly>>` can be freed and a new one allocated at the
-    /// same address in between (the tag emptied, then re-added) — an ABA problem a
-    /// raw pointer comparison cannot detect, but a monotonically-assigned unique ID
-    /// can. See [`IndexUniqueId`] and [`RawIndexReaderCore::points_to_ii`], which
-    /// guards the equivalent reader-revalidation case the same way.
-    ///
-    /// On success, returns the [`GcApplyInfo`] describing the applied changes.
-    /// Its [`bytes_freed`](GcApplyInfo::bytes_freed) and
+    /// On success, returns the [`GcApplyInfo`] describing the applied changes, and
+    /// `None` when the delta is stale — the tag is gone, or its index was replaced.
+    /// [`bytes_freed`](GcApplyInfo::bytes_freed) and
     /// [`block_count_delta`](GcApplyInfo::block_count_delta) already account for
     /// the whole posting list being dropped when the tag became empty.
     ///
     /// [`RawIndexReaderCore::points_to_ii`]: inverted_index::reader::RawIndexReaderCore::points_to_ii
     pub fn gc(
         &mut self,
-        tag: &[u8],
+        tag: Tag<'_>,
         unique_id: IndexUniqueId,
         delta: GcScanDelta,
     ) -> Option<GcApplyInfo> {
-        let ii = self.mode.values.find_mut(tag)?;
+        let ii = self.mode.values.find_mut(tag.as_bytes())?;
         // Detects the tag being removed or its index replaced meanwhile.
         if ii.unique_id() != unique_id {
             return None;
@@ -578,7 +573,7 @@ impl TagIndex<InMemoryMode> {
             self.remove_tag_value(tag);
 
             if let Some(suffix) = &mut self.suffix
-                && !tag.is_empty()
+                && !tag.as_bytes().is_empty()
             {
                 suffix.delete(tag);
             }
@@ -588,8 +583,8 @@ impl TagIndex<InMemoryMode> {
     }
 
     /// Remove `tag` (and its postings) from the values trie.
-    fn remove_tag_value(&mut self, tag: &[u8]) {
-        self.mode.values.remove(tag);
+    fn remove_tag_value(&mut self, tag: Tag<'_>) {
+        self.mode.values.remove(tag.as_bytes());
     }
 }
 
@@ -604,13 +599,12 @@ impl TagIndex<InMemoryMode> {
 
     /// Drop every posting under `tag` while leaving its (now empty) inverted index
     /// registered in the values trie.
-    ///
-    /// No public path produces this state — [`gc`](Self::gc) drops a tag that lost
-    /// its last document — so it has to be forced here. It exists to reach
-    /// [`open_reader`](Self::open_reader)'s guard against an empty posting list,
-    /// which is kept for fidelity with C's `TagIndex_OpenReader`.
-    pub fn force_empty_value(&mut self, tag: &[u8]) {
-        let ii = self.mode.values.find_mut(tag).expect("tag was indexed");
+    pub fn force_empty_value(&mut self, tag: Tag<'_>) {
+        let ii = self
+            .mode
+            .values
+            .find_mut(tag.as_bytes())
+            .expect("tag was indexed");
         let delta = ii
             .scan_gc(|_| false, None::<fn(&RSIndexResult, &RepairContext<'_>)>)
             .expect("scan_gc must not fail")
@@ -630,7 +624,7 @@ impl TagIndex<InMemoryMode> {
     /// Handle over [`remove_tag_value`](Self::remove_tag_value): lets tests remove
     /// `tag` outright, standing in for a tag that vanished between a GC scan and the
     /// delta being applied. Tests that want a whole GC pass call [`gc`](Self::gc).
-    pub fn delete_tag_value(&mut self, tag: &[u8]) {
+    pub fn delete_tag_value(&mut self, tag: Tag<'_>) {
         self.remove_tag_value(tag);
     }
 }
@@ -771,7 +765,7 @@ mod tests {
             // into the index, `ii` included.
             let id = ii.unique_id();
             (*idx)
-                .gc(b"team", id, delta)
+                .gc(tags[0], id, delta)
                 .expect("the delta was just scanned, so it cannot be stale");
         }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -602,37 +602,20 @@ impl TagIndex<InMemoryMode> {
         self.mode.values.find(tag).map(Box::as_ref)
     }
 
-    /// Simulate GC removing every posting under `tag`, leaving an empty (but
-    /// still registered) inverted index behind — the state GC leaves once
-    /// every document under a tag has been removed.
-    pub fn gc_empty_value(&mut self, tag: &[u8]) {
+    /// Drop every posting under `tag` while leaving its (now empty) inverted index
+    /// registered in the values trie.
+    ///
+    /// No public path produces this state — [`gc`](Self::gc) drops a tag that lost
+    /// its last document — so it has to be forced here. It exists to reach
+    /// [`open_reader`](Self::open_reader)'s guard against an empty posting list,
+    /// which is kept for fidelity with C's `TagIndex_OpenReader`.
+    pub fn force_empty_value(&mut self, tag: &[u8]) {
         let ii = self.mode.values.find_mut(tag).expect("tag was indexed");
         let delta = ii
             .scan_gc(|_| false, None::<fn(&RSIndexResult, &RepairContext<'_>)>)
             .expect("scan_gc must not fail")
             .expect("every document was removed, so a delta is produced");
         ii.apply_gc(delta);
-    }
-
-    /// Simulate GC collecting a single document under `tag`, rewriting the
-    /// inverted index in place. The index keeps its address and its unique id, so
-    /// a reader suspended over it is *not* aborted on resume — it re-seeks
-    /// instead, which is the branch [`gc_empty_value`](Self::gc_empty_value) and
-    /// [`delete_tag_value`](Self::delete_tag_value) cannot reach.
-    pub fn gc_remove_doc(&mut self, tag: &[u8], doc_id: DocId) {
-        let ii = self.mode.values.find_mut(tag).expect("tag was indexed");
-        let delta = ii
-            .scan_gc(
-                |d| d != doc_id,
-                None::<fn(&RSIndexResult, &RepairContext<'_>)>,
-            )
-            .expect("scan_gc must not fail")
-            .expect("a document was removed, so a delta is produced");
-        assert_eq!(
-            ii.apply_gc(delta).entries_removed,
-            1,
-            "the document must have been indexed under this tag"
-        );
     }
 
     /// Whether `key` is registered in the [suffix index](TagSuffixIndex) — as a
@@ -644,9 +627,9 @@ impl TagIndex<InMemoryMode> {
             .is_some_and(|suffix| suffix.find(key).is_some())
     }
 
-    /// Handle over [`remove_tag_value`](Self::remove_tag_value): lets tests
-    /// simulate the garbage collector dropping every document for `tag`. The
-    /// production path is [`gc`](Self::gc).
+    /// Handle over [`remove_tag_value`](Self::remove_tag_value): lets tests remove
+    /// `tag` outright, standing in for a tag that vanished between a GC scan and the
+    /// delta being applied. Tests that want a whole GC pass call [`gc`](Self::gc).
     pub fn delete_tag_value(&mut self, tag: &[u8]) {
         self.remove_tag_value(tag);
     }
@@ -775,10 +758,22 @@ mod tests {
         let status = it.revalidate(&mock.spec_read()).expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
-        // Simulate the garbage collector removing the tag's postings entirely.
+        // Run a GC pass in which no document survives: the tag loses its last
+        // posting and `gc` drops it from the values trie.
         // SAFETY: the iterator is not touched during the mutation, per the
         // revalidation protocol.
-        unsafe { (*idx).delete_tag_value(b"team") };
+        unsafe {
+            let delta = ii
+                .scan_gc(|_| false, None::<fn(&RSIndexResult, &RepairContext<'_>)>)
+                .expect("scan_gc must not fail")
+                .expect("every document was removed, so a delta is produced");
+            // Read before the `&mut` below: it invalidates every shared reference
+            // into the index, `ii` included.
+            let id = ii.unique_id();
+            (*idx)
+                .gc(b"team", id, delta)
+                .expect("the delta was just scanned, so it cannot be stale");
+        }
 
         let status = it.revalidate(&mock.spec_read()).expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -605,10 +605,6 @@ impl TagIndex<InMemoryMode> {
     /// Simulate GC removing every posting under `tag`, leaving an empty (but
     /// still registered) inverted index behind — the state GC leaves once
     /// every document under a tag has been removed.
-    ///
-    /// The crate exposes no document removal of its own, so this is the only way
-    /// a test can reach the empty-index arm of
-    /// [`open_reader`](Self::open_reader).
     pub fn gc_empty_value(&mut self, tag: &[u8]) {
         let ii = self.mode.values.find_mut(tag).expect("tag was indexed");
         let delta = ii
@@ -616,6 +612,27 @@ impl TagIndex<InMemoryMode> {
             .expect("scan_gc must not fail")
             .expect("every document was removed, so a delta is produced");
         ii.apply_gc(delta);
+    }
+
+    /// Simulate GC collecting a single document under `tag`, rewriting the
+    /// inverted index in place. The index keeps its address and its unique id, so
+    /// a reader suspended over it is *not* aborted on resume — it re-seeks
+    /// instead, which is the branch [`gc_empty_value`](Self::gc_empty_value) and
+    /// [`delete_tag_value`](Self::delete_tag_value) cannot reach.
+    pub fn gc_remove_doc(&mut self, tag: &[u8], doc_id: DocId) {
+        let ii = self.mode.values.find_mut(tag).expect("tag was indexed");
+        let delta = ii
+            .scan_gc(
+                |d| d != doc_id,
+                None::<fn(&RSIndexResult, &RepairContext<'_>)>,
+            )
+            .expect("scan_gc must not fail")
+            .expect("a document was removed, so a delta is produced");
+        assert_eq!(
+            ii.apply_gc(delta).entries_removed,
+            1,
+            "the document must have been indexed under this tag"
+        );
     }
 
     /// Whether `key` is registered in the [suffix index](TagSuffixIndex) — as a

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -133,6 +133,10 @@ impl Drop for OwnedTerm {
 pub(crate) struct TermPtr(NonNull<u8>);
 
 impl TermPtr {
+    fn belong_to(&self, owned: &OwnedTerm) -> bool {
+        self.0 == owned.0
+    }
+
     /// Full allocation size in bytes (term bytes + the trailing NUL).
     ///
     /// # Safety
@@ -288,6 +292,47 @@ impl TagSuffixIndex {
         pattern: WildcardPattern<'p>,
     ) -> WildcardIter<'tm, 'p, SuffixData> {
         self.entries.wildcard_iter(pattern)
+    }
+
+    /// Remove `tag` and all of its suffixes from the trie, dropping the entries
+    /// that no other term still relies on.
+    ///
+    /// `tag` is the NUL-free tag value (the values-trie key), matching the keys
+    /// stored by [`add`](Self::add).
+    pub fn delete(&mut self, tag: &[u8]) {
+        debug_assert!(
+            !tag.is_empty(),
+            "empty string is likely a caller-level mistake"
+        );
+
+        // Taken from the `tag` entry on the first iteration and dropped when this
+        // call returns, once no suffix entry points at it any more.
+        let mut deleted_term = None;
+
+        for j in 0..tag.len() {
+            let data = self.entries.find_mut(&tag[j..]);
+            debug_assert!(data.is_some(), "all suffixes must exist");
+            // A missing entry means this trie and the values trie disagree; skip
+            // it rather than panicking inside the garbage collector.
+            let Some(data) = data else { continue };
+
+            if j == 0 {
+                deleted_term = data.full_term.take();
+            }
+
+            // Drop the pointers to the term being deleted, keeping every one that
+            // belongs to a different term. On the first iteration that also unlinks
+            // the entry's own pointer at the term it just gave up, since `members`
+            // holds it alongside the references; with no term to delete there is
+            // nothing to match.
+            if let Some(deleted) = &deleted_term {
+                data.members.retain(|b| !b.belong_to(deleted));
+            }
+
+            if data.full_term.is_none() && data.members.is_empty() {
+                self.entries.remove(&tag[j..]);
+            }
+        }
     }
 
     /// The entry keyed by exactly `key`, if any.
@@ -584,5 +629,43 @@ mod tests {
         );
         assert_counter_is_exact(&short_idx);
         assert_counter_is_exact(&long_idx);
+    }
+
+    /// Deleting a tag that is merely a *suffix* of an indexed term must not
+    /// panic: the entry exists but owns no term, so there is nothing to unlink.
+    #[test]
+    fn delete_of_a_suffix_only_entry_changes_nothing() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"cat");
+
+        idx.delete(b"at");
+
+        assert!(idx.find(b"cat").is_some(), "`cat` is untouched");
+        assert_eq!(
+            idx.find(b"at").expect("kept for `cat`").members().count(),
+            1,
+            "`at` still references `cat`"
+        );
+    }
+
+    /// Deleting a term drops only the references pointing at that term, keeping
+    /// the suffix entries that other terms still rely on.
+    #[test]
+    fn delete_keeps_suffixes_still_used_by_other_terms() {
+        let mut idx = TagSuffixIndex::new();
+        // "cat" and "bat" share the suffixes "at" and "t".
+        add(&mut idx, b"cat");
+        add(&mut idx, b"bat");
+
+        idx.delete(b"cat");
+
+        // "cat" and its unique full-term entry are gone...
+        assert!(idx.find(b"cat").is_none());
+        // ...but the shared suffixes survive, now referencing only "bat".
+        assert!(idx.find(b"bat").is_some());
+        let at = idx.find(b"at").expect("shared suffix kept for `bat`");
+        assert_eq!(at.members().count(), 1);
+        let t = idx.find(b"t").expect("shared suffix kept for `bat`");
+        assert_eq!(t.members().count(), 1);
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -297,16 +297,16 @@ impl TagSuffixIndex {
     /// Remove `tag` and all of its suffixes from the trie, dropping the entries
     /// that no other term still relies on.
     ///
-    /// `tag` is the NUL-free tag value (the values-trie key), matching the keys
-    /// stored by [`add`](Self::add).
-    pub fn delete(&mut self, tag: &[u8]) {
+    /// `tag` is the tag value (the values-trie key), matching the keys stored by
+    /// [`add`](Self::add).
+    pub fn delete(&mut self, tag: Tag<'_>) {
+        let tag = tag.as_bytes();
         debug_assert!(
             !tag.is_empty(),
             "empty string is likely a caller-level mistake"
         );
 
-        // Taken from the `tag` entry on the first iteration and dropped when this
-        // call returns, once no suffix entry points at it any more.
+        // Taken from the `tag` entry on the first iteration.
         let mut deleted_term = None;
 
         for j in 0..tag.len() {
@@ -321,18 +321,20 @@ impl TagSuffixIndex {
             }
 
             // Drop the pointers to the term being deleted, keeping every one that
-            // belongs to a different term. On the first iteration that also unlinks
-            // the entry's own pointer at the term it just gave up, since `members`
-            // holds it alongside the references; with no term to delete there is
-            // nothing to match.
+            // belongs to a different term.
             if let Some(deleted) = &deleted_term {
                 data.members.retain(|b| !b.belong_to(deleted));
             }
 
+            // Don't keep empty `members`.
             if data.full_term.is_none() && data.members.is_empty() {
                 self.entries.remove(&tag[j..]);
             }
         }
+
+        // Freed only here: every entry that pointed at this allocation has given up
+        // its `TermPtr`, so dropping it can no longer leave a dangling one behind.
+        drop(deleted_term);
     }
 
     /// The entry keyed by exactly `key`, if any.
@@ -360,6 +362,11 @@ mod tests {
     /// [`TagSuffixIndex::add`], with the same wrapping.
     fn add(idx: &mut TagSuffixIndex, term: &[u8]) {
         idx.add(Tag::new(term).expect("test literal is NUL-free"))
+    }
+
+    /// [`TagSuffixIndex::delete`], with the same wrapping.
+    fn delete(idx: &mut TagSuffixIndex, term: &[u8]) {
+        idx.delete(Tag::new(term).expect("test literal is NUL-free"))
     }
 
     /// Read back the bytes stored in an [`OwnedTerm`], terminator included.
@@ -638,7 +645,7 @@ mod tests {
         let mut idx = TagSuffixIndex::new();
         add(&mut idx, b"cat");
 
-        idx.delete(b"at");
+        delete(&mut idx, b"at");
 
         assert!(idx.find(b"cat").is_some(), "`cat` is untouched");
         assert_eq!(
@@ -657,7 +664,7 @@ mod tests {
         add(&mut idx, b"cat");
         add(&mut idx, b"bat");
 
-        idx.delete(b"cat");
+        delete(&mut idx, b"cat");
 
         // "cat" and its unique full-term entry are gone...
         assert!(idx.find(b"cat").is_none());

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -322,8 +322,10 @@ impl TagSuffixIndex {
 
             // Drop the pointers to the term being deleted, keeping every one that
             // belongs to a different term.
-            if let Some(deleted) = &deleted_term {
-                data.members.retain(|b| !b.belong_to(deleted));
+            if let Some(deleted) = &deleted_term
+                && let Some(deleted_index) = data.members.iter().position(|b| b.belong_to(deleted))
+            {
+                data.members.swap_remove(deleted_index);
             }
 
             // Don't keep empty `members`.

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -189,6 +189,15 @@ pub(crate) struct TagSuffixIndex {
     /// The suffix entries
     entries: TrieMap<SuffixData>,
     /// Total [`SuffixData::nested_mem_usage`] over every entry.
+    ///
+    /// Tracked here because [`TrieMap::mem_usage`] cannot report it: the trie's own counter
+    /// moves only when a node is added or removed, whereas an entry's payload allocations
+    /// change while its node stays put — [`add`](Self::add) pushes onto the member list of
+    /// an entry a shorter term already created, and [`delete`](Self::delete) takes a term
+    /// away without emptying the entry.
+    ///
+    /// Written by [`insert_tracked`](Self::insert_tracked) and [`delete`](Self::delete),
+    /// which are therefore the only two places allowed to mutate [`entries`](Self::entries).
     nested_mem_usage: usize,
 }
 
@@ -310,11 +319,17 @@ impl TagSuffixIndex {
         let mut deleted_term = None;
 
         for j in 0..tag.len() {
-            let data = self.entries.find_mut(&tag[j..]);
+            let key = &tag[j..];
+            let data = self.entries.find_mut(key);
             debug_assert!(data.is_some(), "all suffixes must exist");
             // A missing entry means this trie and the values trie disagree; skip
             // it rather than panicking inside the garbage collector.
             let Some(data) = data else { continue };
+
+            // Measured around the mutation, as `insert_tracked` does, rather than
+            // derived from `tag.len()`: whatever the payload gives up is whatever it
+            // stops reporting.
+            let before = data.nested_mem_usage();
 
             if j == 0 {
                 deleted_term = data.full_term.take();
@@ -328,9 +343,22 @@ impl TagSuffixIndex {
                 data.members.swap_remove(deleted_index);
             }
 
+            // Read while `data` is still borrowed, so the borrow can end before the
+            // removal below needs `self.entries` again.
+            let is_now_empty = data.full_term.is_none() && data.members.is_empty();
+            let after = data.nested_mem_usage();
+            debug_assert!(
+                after <= before,
+                "deleting only ever makes a payload give allocations up"
+            );
+            self.nested_mem_usage -= before - after;
+
             // Don't keep empty `members`.
-            if data.full_term.is_none() && data.members.is_empty() {
-                self.entries.remove(&tag[j..]);
+            if is_now_empty {
+                let removed = self.entries.remove(key).expect("found just above");
+                // Down to the member list: the guard above established that the term
+                // is already gone, and `after` did not count it either.
+                self.nested_mem_usage -= removed.nested_mem_usage();
             }
         }
 
@@ -605,8 +633,8 @@ mod tests {
         );
     }
 
-    /// The early return for an already-indexed term must not count its allocations twice
-    /// — nor, since it allocates a term it then drops, count them at all.
+    /// The early return for an already-indexed term allocates nothing — it sits above
+    /// `OwnedTerm::new` — so it must leave the figure exactly where it was.
     #[test]
     fn a_duplicate_add_leaves_the_figure_untouched() {
         let mut idx = TagSuffixIndex::new();
@@ -655,6 +683,7 @@ mod tests {
             1,
             "`at` still references `cat`"
         );
+        assert_counter_is_exact(&idx);
     }
 
     /// Deleting a term drops only the references pointing at that term, keeping
@@ -676,5 +705,97 @@ mod tests {
         assert_eq!(at.members().count(), 1);
         let t = idx.find(b"t").expect("shared suffix kept for `bat`");
         assert_eq!(t.members().count(), 1);
+        assert_counter_is_exact(&idx);
+    }
+
+    /// Deleting the only indexed term must give every byte back: each entry is removed,
+    /// so both the trie's own counter and the payload counter return to their baselines.
+    /// Any decrement `delete` forgets leaves a residue here.
+    #[test]
+    fn add_then_delete_round_trips_the_figure() {
+        let mut idx = TagSuffixIndex::new();
+        let empty = idx.mem_usage();
+
+        add(&mut idx, b"hello");
+        assert!(idx.mem_usage() > empty, "indexing has to cost something");
+
+        delete(&mut idx, b"hello");
+
+        assert_eq!(
+            idx.mem_usage(),
+            empty,
+            "every entry is gone, so the figure must be back where it started"
+        );
+        assert_eq!(idx.nested_mem_usage, 0);
+        assert_counter_is_exact(&idx);
+    }
+
+    /// Deleting a term whose suffixes other terms still share frees its own term
+    /// allocation and the entries unique to it, but not the shared entries' member lists.
+    #[test]
+    fn deleting_a_shared_term_gives_up_its_term_bytes() {
+        let mut idx = TagSuffixIndex::new();
+        // "cat" and "bat" share the suffixes "at" and "t".
+        add(&mut idx, b"cat");
+        let payload_with_cat_alone = idx.nested_mem_usage;
+        add(&mut idx, b"bat");
+        let with_both = idx.mem_usage();
+
+        delete(&mut idx, b"cat");
+
+        let freed = with_both - idx.mem_usage();
+        assert!(
+            freed >= b"cat\0".len(),
+            "the term allocation alone accounts for {} bytes, but only {freed} were freed",
+            b"cat\0".len()
+        );
+        // Compared against the payload counter rather than the whole figure: `remove` does
+        // not re-merge trie nodes, so the node bytes left behind by holding both terms do
+        // not have to match a trie that only ever held one. The payloads do — "bat" is as
+        // long as "cat", and the shared entries never exceeded their initial capacity.
+        assert_eq!(
+            idx.nested_mem_usage, payload_with_cat_alone,
+            "one three-byte term and three member lists, whichever term it is"
+        );
+        assert_counter_is_exact(&idx);
+    }
+
+    /// Deleting a key that is only a suffix of an indexed term frees nothing: the entry
+    /// owns no term, and its member still belongs to the term that is staying.
+    #[test]
+    fn deleting_a_suffix_only_entry_frees_nothing() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"cat");
+        let before = idx.mem_usage();
+
+        delete(&mut idx, b"at");
+
+        assert_eq!(idx.mem_usage(), before);
+        assert_counter_is_exact(&idx);
+    }
+
+    /// The shape of a counter that decrements by too little: a figure that creeps up over
+    /// repeated churn even though the index keeps returning to the same contents.
+    #[test]
+    fn repeated_add_and_delete_cycles_do_not_drift() {
+        let mut idx = TagSuffixIndex::new();
+        // A second, untouched term so the cycles run against a non-empty trie.
+        add(&mut idx, b"resident");
+
+        add(&mut idx, b"transient");
+        delete(&mut idx, b"transient");
+        let after_first_cycle = idx.mem_usage();
+
+        for _ in 0..3 {
+            add(&mut idx, b"transient");
+            delete(&mut idx, b"transient");
+
+            assert_eq!(
+                idx.mem_usage(),
+                after_first_cycle,
+                "the reported figure drifted across an add/delete cycle"
+            );
+            assert_counter_is_exact(&idx);
+        }
     }
 }

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for `TagIndex::gc`, the parent-process half of a fork-GC cycle.
+//!
+//! The child scans a tag's postings against the doc table and ships a
+//! `GcScanDelta`; the parent applies it. These tests cover what is specific to
+//! the *tag* index: the identity check that rejects a stale delta, dropping a tag
+//! that lost its last document from both the values trie and the suffix trie, and
+//! folding the discarded posting list into the reported totals.
+//!
+//! The block-level repair mechanics the delta describes — deleting a whole block,
+//! repairing one partially, and ignoring a last block that changed since the scan
+//! — belong to `InvertedIndex::apply_gc` and are covered by `inverted_index`'s own
+//! `tests/gc.rs`. They are not repeated here.
+
+use index_result::RSIndexResult;
+use inverted_index::{DocId, GcScanDelta, IndexUniqueId, RepairContext};
+use tag_index::{InMemoryMode, TagIndex};
+
+use crate::util::{commit_mem, index_mem};
+
+/// Build a memory-mode index holding `tags`, each carrying documents `1..=n`.
+/// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
+/// trie is populated too.
+fn indexed(tags: &[&[u8]], n: DocId, with_suffix: bool) -> TagIndex<InMemoryMode> {
+    let mut idx = TagIndex::<InMemoryMode>::new(with_suffix);
+    for doc_id in 1..=n {
+        index_mem(&mut idx, tags, doc_id);
+    }
+    if with_suffix {
+        commit_mem(&mut idx, tags);
+    }
+    idx
+}
+
+/// The [`IndexUniqueId`] of `tag`'s posting list — what the GC child ships back and
+/// [`TagIndex::gc`] checks the delta against.
+fn unique_id(idx: &TagIndex<InMemoryMode>, tag: &[u8]) -> IndexUniqueId {
+    idx.find_value(tag).expect("tag is indexed").unique_id()
+}
+
+/// Scan `tag`'s postings the way the GC child does, keeping only the documents
+/// `doc_exists` accepts. `None` when nothing needs repairing.
+fn scan(
+    idx: &TagIndex<InMemoryMode>,
+    tag: &[u8],
+    doc_exists: impl Fn(DocId) -> bool,
+) -> Option<GcScanDelta> {
+    idx.find_value(tag)
+        .expect("tag is indexed")
+        .scan_gc(
+            doc_exists,
+            None::<for<'i> fn(&RSIndexResult<'i>, &RepairContext<'i>)>,
+        )
+        .expect("scanning a tag's postings should not fail")
+}
+
+/// Collect the keys currently in the suffix trie.
+fn suffix_keys(idx: &TagIndex<InMemoryMode>) -> Vec<Vec<u8>> {
+    let mut it = idx
+        .suffix_value_iter()
+        .expect("index was created with a suffix trie");
+    let mut keys = Vec::new();
+    while let Some(key) = it.advance() {
+        keys.push(key.as_bytes().to_vec());
+    }
+    keys
+}
+
+/// Applying a delta drops the deleted documents and reports how many entries
+/// went, leaving the tag in place because documents remain.
+#[test]
+fn gc_removes_deleted_documents() {
+    let mut idx = indexed(&[b"team"], 5, false);
+
+    // Documents 2 and 4 are gone from the doc table.
+    let delta = scan(&idx, b"team", |doc_id| doc_id != 2 && doc_id != 4)
+        .expect("two deleted documents need repairing");
+    let id = unique_id(&idx, b"team");
+
+    let info = idx.gc(b"team", id, delta).expect("the delta is current");
+
+    assert_eq!(info.entries_removed, 2);
+    assert_eq!(
+        idx.find_value(b"team")
+            .expect("the tag still has documents")
+            .unique_docs(),
+        3
+    );
+}
+
+/// When the last document goes, the tag is dropped from the values trie *and*
+/// from the suffix trie, and the whole discarded posting list is folded into the
+/// reported totals.
+#[test]
+fn gc_drops_a_tag_that_lost_every_document() {
+    let mut idx = indexed(&[b"team"], 3, true);
+    assert_eq!(
+        suffix_keys(&idx),
+        [
+            b"am".to_vec(),
+            b"eam".to_vec(),
+            b"m".to_vec(),
+            b"team".to_vec()
+        ],
+        "the tag and each of its suffixes are indexed"
+    );
+
+    let delta = scan(&idx, b"team", |_| false).expect("every document is gone");
+    let id = unique_id(&idx, b"team");
+    let memory_before = idx
+        .find_value(b"team")
+        .expect("tag is indexed")
+        .memory_usage();
+
+    let info = idx.gc(b"team", id, delta).expect("the delta is current");
+
+    assert!(idx.find_value(b"team").is_none(), "the tag is dropped");
+    assert_eq!(idx.n_tags(), 0);
+    assert!(
+        suffix_keys(&idx).is_empty(),
+        "the suffix trie drops the tag and all of its suffixes"
+    );
+    assert!(
+        info.bytes_freed >= memory_before,
+        "the whole posting list must be accounted as freed, not just the repaired blocks"
+    );
+    assert!(
+        info.block_count_delta < 0,
+        "the dropped list's blocks must be subtracted from the spec's block count"
+    );
+}
+
+/// The empty tag (INDEXEMPTY) never entered the suffix trie, so dropping it must
+/// not try to delete it from there — `TagSuffixIndex::delete` would assert.
+#[test]
+fn gc_drops_the_empty_tag_without_touching_the_suffix_trie() {
+    let mut idx = indexed(&[b""], 2, true);
+    assert!(
+        suffix_keys(&idx).is_empty(),
+        "the empty tag is never indexed in the suffix trie"
+    );
+
+    let delta = scan(&idx, b"", |_| false).expect("every document is gone");
+    let id = unique_id(&idx, b"");
+
+    idx.gc(b"", id, delta).expect("the delta is current");
+
+    assert!(idx.find_value(b"").is_none(), "the empty tag is dropped");
+}
+
+/// A delta scanned against a different posting list than the tag currently holds
+/// is stale: the GC ran while the tag was being rewritten, so applying it would
+/// corrupt the live list.
+#[test]
+fn gc_rejects_a_delta_scanned_against_another_index() {
+    let mut idx = indexed(&[b"team", b"other"], 3, false);
+
+    let delta = scan(&idx, b"team", |doc_id| doc_id != 2).expect("one document is gone");
+    // Stand in for the tag's index having been replaced since the scan.
+    let other = unique_id(&idx, b"other");
+
+    assert!(
+        idx.gc(b"team", other, delta).is_none(),
+        "a delta that does not match the tag's current index must not be applied"
+    );
+    assert_eq!(
+        idx.find_value(b"team")
+            .expect("the tag is untouched")
+            .unique_docs(),
+        3,
+        "rejecting the delta must leave the postings alone"
+    );
+}
+
+/// A tag the GC removed in an earlier pass is simply not there any more, so its
+/// delta is dropped rather than resurrecting the tag.
+#[test]
+fn gc_rejects_a_delta_for_a_tag_that_is_gone() {
+    let mut idx = indexed(&[b"team"], 3, false);
+
+    let delta = scan(&idx, b"team", |doc_id| doc_id != 2).expect("one document is gone");
+    let id = unique_id(&idx, b"team");
+    idx.delete_tag_value(b"team");
+
+    assert!(idx.gc(b"team", id, delta).is_none());
+    assert_eq!(idx.n_tags(), 0);
+}
+
+/// A tag removed and then indexed again gets a brand new posting list, and
+/// therefore a brand new [`IndexUniqueId`], even though the tag string resolves to
+/// something again. A raw pointer comparison could be fooled here if the freed
+/// allocation happened to be reused for the new one — the ID check rejects it
+/// unconditionally, regardless of what the allocator does with the address.
+#[test]
+fn gc_rejects_a_stale_id_after_the_tag_was_removed_and_reindexed() {
+    let mut idx = indexed(&[b"team"], 3, false);
+
+    let delta = scan(&idx, b"team", |doc_id| doc_id != 2).expect("one document is gone");
+    let stale_id = unique_id(&idx, b"team");
+
+    idx.delete_tag_value(b"team");
+    index_mem(&mut idx, &[b"team"], 1);
+
+    assert!(
+        idx.gc(b"team", stale_id, delta).is_none(),
+        "the delta was scanned against a posting list that no longer exists, even \
+         though the tag string resolves again"
+    );
+    assert_eq!(
+        idx.find_value(b"team")
+            .expect("the tag was reindexed")
+            .unique_docs(),
+        1,
+        "rejecting the stale delta must leave the freshly reindexed postings alone"
+    );
+}

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -20,11 +20,10 @@
 //! — belong to `InvertedIndex::apply_gc` and are covered by `inverted_index`'s own
 //! `tests/gc.rs`. They are not repeated here.
 
-use index_result::RSIndexResult;
-use inverted_index::{DocId, GcScanDelta, IndexUniqueId, RepairContext};
+use inverted_index::DocId;
 use tag_index::{InMemoryMode, TagIndex};
 
-use crate::util::{commit_mem, index_mem};
+use crate::util::{commit_mem, index_mem, scan, unique_id};
 
 /// Build a memory-mode index holding `tags`, each carrying documents `1..=n`.
 /// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
@@ -38,28 +37,6 @@ fn indexed(tags: &[&[u8]], n: DocId, with_suffix: bool) -> TagIndex<InMemoryMode
         commit_mem(&mut idx, tags);
     }
     idx
-}
-
-/// The [`IndexUniqueId`] of `tag`'s posting list — what the GC child ships back and
-/// [`TagIndex::gc`] checks the delta against.
-fn unique_id(idx: &TagIndex<InMemoryMode>, tag: &[u8]) -> IndexUniqueId {
-    idx.find_value(tag).expect("tag is indexed").unique_id()
-}
-
-/// Scan `tag`'s postings the way the GC child does, keeping only the documents
-/// `doc_exists` accepts. `None` when nothing needs repairing.
-fn scan(
-    idx: &TagIndex<InMemoryMode>,
-    tag: &[u8],
-    doc_exists: impl Fn(DocId) -> bool,
-) -> Option<GcScanDelta> {
-    idx.find_value(tag)
-        .expect("tag is indexed")
-        .scan_gc(
-            doc_exists,
-            None::<for<'i> fn(&RSIndexResult<'i>, &RepairContext<'i>)>,
-        )
-        .expect("scanning a tag's postings should not fail")
 }
 
 /// Collect the keys currently in the suffix trie.

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -23,7 +23,7 @@
 use inverted_index::DocId;
 use tag_index::{InMemoryMode, TagIndex};
 
-use crate::util::{commit_mem, index_mem, scan, unique_id};
+use crate::util::{as_tag, commit_mem, index_mem, scan, unique_id};
 
 /// Build a memory-mode index holding `tags`, each carrying documents `1..=n`.
 /// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
@@ -62,7 +62,9 @@ fn gc_removes_deleted_documents() {
         .expect("two deleted documents need repairing");
     let id = unique_id(&idx, b"team");
 
-    let info = idx.gc(b"team", id, delta).expect("the delta is current");
+    let info = idx
+        .gc(as_tag(b"team"), id, delta)
+        .expect("the delta is current");
 
     assert_eq!(info.entries_removed, 2);
     assert_eq!(
@@ -97,7 +99,9 @@ fn gc_drops_a_tag_that_lost_every_document() {
         .expect("tag is indexed")
         .memory_usage();
 
-    let info = idx.gc(b"team", id, delta).expect("the delta is current");
+    let info = idx
+        .gc(as_tag(b"team"), id, delta)
+        .expect("the delta is current");
 
     assert!(idx.find_value(b"team").is_none(), "the tag is dropped");
     assert_eq!(idx.n_tags(), 0);
@@ -128,7 +132,8 @@ fn gc_drops_the_empty_tag_without_touching_the_suffix_trie() {
     let delta = scan(&idx, b"", |_| false).expect("every document is gone");
     let id = unique_id(&idx, b"");
 
-    idx.gc(b"", id, delta).expect("the delta is current");
+    idx.gc(as_tag(b""), id, delta)
+        .expect("the delta is current");
 
     assert!(idx.find_value(b"").is_none(), "the empty tag is dropped");
 }
@@ -145,7 +150,7 @@ fn gc_rejects_a_delta_scanned_against_another_index() {
     let other = unique_id(&idx, b"other");
 
     assert!(
-        idx.gc(b"team", other, delta).is_none(),
+        idx.gc(as_tag(b"team"), other, delta).is_none(),
         "a delta that does not match the tag's current index must not be applied"
     );
     assert_eq!(
@@ -165,9 +170,9 @@ fn gc_rejects_a_delta_for_a_tag_that_is_gone() {
 
     let delta = scan(&idx, b"team", |doc_id| doc_id != 2).expect("one document is gone");
     let id = unique_id(&idx, b"team");
-    idx.delete_tag_value(b"team");
+    idx.delete_tag_value(as_tag(b"team"));
 
-    assert!(idx.gc(b"team", id, delta).is_none());
+    assert!(idx.gc(as_tag(b"team"), id, delta).is_none());
     assert_eq!(idx.n_tags(), 0);
 }
 
@@ -183,11 +188,11 @@ fn gc_rejects_a_stale_id_after_the_tag_was_removed_and_reindexed() {
     let delta = scan(&idx, b"team", |doc_id| doc_id != 2).expect("one document is gone");
     let stale_id = unique_id(&idx, b"team");
 
-    idx.delete_tag_value(b"team");
+    idx.delete_tag_value(as_tag(b"team"));
     index_mem(&mut idx, &[b"team"], 1);
 
     assert!(
-        idx.gc(b"team", stale_id, delta).is_none(),
+        idx.gc(as_tag(b"team"), stale_id, delta).is_none(),
         "the delta was scanned against a posting list that no longer exists, even \
          though the tag string resolves again"
     );

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -23,7 +23,7 @@
 use inverted_index::DocId;
 use tag_index::{InMemoryMode, TagIndex};
 
-use crate::util::{as_tag, commit_mem, index_mem, scan, unique_id};
+use crate::util::{as_tag, commit_mem, gc_mem, index_mem, scan, unique_id};
 
 /// Build a memory-mode index holding `tags`, each carrying documents `1..=n`.
 /// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
@@ -116,6 +116,57 @@ fn gc_drops_a_tag_that_lost_every_document() {
     assert!(
         info.block_count_delta < 0,
         "the dropped list's blocks must be subtracted from the spec's block count"
+    );
+}
+
+/// Dropping a tag has to give its suffix-trie bytes back. The suffix entries own
+/// allocations outside their trie nodes — the tag term and each entry's member list —
+/// and the trie's own counter cannot see those, so a `delete` that failed to discount
+/// them would leave `mem_usage` permanently overstated after every GC pass.
+#[test]
+fn gc_drops_a_tag_and_gives_its_suffix_bytes_back() {
+    let mut idx = TagIndex::<InMemoryMode>::new(true);
+    let empty = idx.mem_usage();
+
+    index_mem(&mut idx, &[b"team"], 1);
+    commit_mem(&mut idx, &[b"team"]);
+    let indexed = idx.mem_usage();
+    assert!(indexed > empty, "indexing the tag has to cost something");
+
+    gc_mem(&mut idx, b"team", |_| false);
+
+    assert!(idx.find_value(b"team").is_none(), "the tag is dropped");
+    assert_eq!(
+        idx.mem_usage(),
+        empty,
+        "the last tag is gone from both tries, so the reported overhead must be back \
+         where it started"
+    );
+}
+
+/// The same, with a second tag left in place: dropping one tag must reduce the figure
+/// without taking the surviving tag's bytes with it.
+#[test]
+fn gc_dropping_one_of_two_tags_reduces_the_reported_overhead() {
+    let mut idx = TagIndex::<InMemoryMode>::new(true);
+    index_mem(&mut idx, &[b"keep"], 1);
+    commit_mem(&mut idx, &[b"keep"]);
+    let with_survivor_alone = idx.mem_usage();
+
+    index_mem(&mut idx, &[b"drop"], 2);
+    commit_mem(&mut idx, &[b"drop"]);
+    let with_both = idx.mem_usage();
+
+    gc_mem(&mut idx, b"drop", |_| false);
+
+    assert!(idx.find_value(b"keep").is_some(), "the other tag survives");
+    assert!(
+        idx.mem_usage() < with_both,
+        "dropping a tag must reduce the reported overhead"
+    );
+    assert!(
+        idx.mem_usage() >= with_survivor_alone,
+        "the surviving tag's own bytes must not be discounted along with the dropped one"
     );
 }
 

--- a/src/redisearch_rs/tag_index/tests/integration/main.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/main.rs
@@ -18,6 +18,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 mod create;
 mod expansion_timeout;
 mod filtered_iteration;
+mod gc;
 mod indexing;
 mod reader;
 mod suffix_wildcard;

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -17,7 +17,9 @@
 use std::ptr::NonNull;
 
 use field::FieldMaskOrIndex;
-use rqe_iterators::{RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+use rqe_iterators::{
+    RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, RQEValidateStatus, ResumeOutcome,
+};
 use rqe_iterators_test_utils::MockContext;
 use tag_index::{InMemoryMode, TagIndex, TrieLookup};
 
@@ -136,6 +138,54 @@ fn open_reader_absent_tag_returns_none() {
     drop(unsafe { Box::from_raw(tag_index) });
 }
 
+/// Revalidating aborts once the garbage collector has dropped the tag's
+/// postings — the lookup no longer resolves the tag, so the reader is stale.
+///
+/// The lib-level test of this covers a hand-built lookup; this one goes through
+/// `open_reader`, so it exercises the lookup all the way through the reader
+/// construction path.
+#[test]
+fn revalidate_aborts_after_gc() {
+    let mock = MockContext::new(3, 3);
+    let tags: &[&[u8]] = &[b"team"];
+    // `allocate` reaches the index through a raw pointer, so it can be mutated while
+    // the iterator holds its back-pointer — as the query layer does across GC cycles.
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    for doc_id in 1..=3 {
+        // SAFETY: `tag_index` was just allocated and is not yet aliased.
+        index_mem(unsafe { &mut *tag_index }, tags, doc_id);
+    }
+
+    // SAFETY: `tag_index` and `mock` outlive the iterator, `tag_index` is mutated
+    // below only between revalidations, and `lookup` resolves `tag_index`.
+    let mut it =
+        unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"team"), 1.0, FIELD_INDEX, lookup) }
+            .expect("the tag is indexed");
+
+    let status = it
+        .revalidate(&mock.spec_read())
+        .expect("revalidate must not error");
+    assert_eq!(status, RQEValidateStatus::Ok);
+
+    // Simulate the garbage collector dropping every document for the tag.
+    // SAFETY: the iterator is untouched during the mutation, per the
+    // revalidation protocol.
+    unsafe { (*tag_index).delete_tag_value(b"team") };
+
+    // SAFETY: as above; the protocol allows a read only after revalidating.
+    let status = it
+        .revalidate(&mock.spec_read())
+        .expect("revalidate must not error");
+    assert_eq!(
+        status,
+        RQEValidateStatus::Aborted,
+        "a reader whose tag the GC removed must abort"
+    );
+
+    // SAFETY: `allocate` allocated it; the iterator using it is gone.
+    drop(unsafe { Box::from_raw(tag_index) });
+}
+
 /// A tag registered in the trie but holding no documents yields no iterator:
 /// `open_reader` returns `None` rather than a reader that would immediately hit
 /// EOF.
@@ -218,7 +268,7 @@ fn resume_after_the_tag_was_collected_aborts() {
 
     // SAFETY: the reader is suspended, so it holds no reference into the index,
     // and `tag_index` is the owning pointer the lookup was minted from.
-    unsafe { &mut *tag_index }.gc_remove_value(b"hello");
+    unsafe { (*tag_index).delete_tag_value(b"hello") };
 
     let guard = mock.spec_read();
     let outcome = suspended.resume(&guard).expect("resume must not error");

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -23,7 +23,7 @@ use rqe_iterators::{
 use rqe_iterators_test_utils::MockContext;
 use tag_index::{InMemoryMode, TagIndex, TrieLookup};
 
-use crate::util::{as_tag, index_mem};
+use crate::util::{as_tag, gc_mem, index_mem};
 
 /// Field index the reader filters on. These tests index a single field, so any
 /// value works as long as it matches what `index_mem` writes.
@@ -167,10 +167,11 @@ fn revalidate_aborts_after_gc() {
         .expect("revalidate must not error");
     assert_eq!(status, RQEValidateStatus::Ok);
 
-    // Simulate the garbage collector dropping every document for the tag.
+    // A GC pass in which no document survives: the tag loses its last posting, so
+    // `TagIndex::gc` drops it from the values trie.
     // SAFETY: the iterator is untouched during the mutation, per the
     // revalidation protocol.
-    unsafe { (*tag_index).delete_tag_value(b"team") };
+    gc_mem(unsafe { &mut *tag_index }, b"team", |_| false);
 
     // SAFETY: as above; the protocol allows a read only after revalidating.
     let status = it
@@ -192,13 +193,14 @@ fn revalidate_aborts_after_gc() {
 #[test]
 fn open_reader_returns_none_for_empty_inverted_index() {
     let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
-    // Register the tag with one document, then GC it away: the trie keeps the
-    // now-empty inverted index registered, mirroring what removal leaves behind
-    // once every posting under a tag has been removed.
+    // Register the tag, then force its posting list empty without unregistering
+    // the tag. No public path leaves that state — `TagIndex::gc` drops a tag that
+    // lost its last document — so it is forced here to reach the guard, which
+    // `open_reader` keeps for fidelity with C's `TagIndex_OpenReader`.
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"empty"], 1);
     // SAFETY: `tag_index` was indexed into above and is not otherwise aliased.
-    unsafe { &mut *tag_index }.gc_empty_value(b"empty");
+    unsafe { &mut *tag_index }.force_empty_value(b"empty");
 
     let mock = MockContext::new(0, 0);
     // SAFETY: `tag_index` and `mock` outlive the (never created) iterator, and
@@ -266,9 +268,11 @@ fn resume_after_the_tag_was_collected_aborts() {
 
     let suspended = Box::new(it).suspend();
 
+    // A GC pass in which no document survives drops the tag from the values trie,
+    // leaving the lookup nothing to re-resolve on resume.
     // SAFETY: the reader is suspended, so it holds no reference into the index,
     // and `tag_index` is the owning pointer the lookup was minted from.
-    unsafe { (*tag_index).delete_tag_value(b"hello") };
+    gc_mem(unsafe { &mut *tag_index }, b"hello", |_| false);
 
     let guard = mock.spec_read();
     let outcome = suspended.resume(&guard).expect("resume must not error");
@@ -365,7 +369,11 @@ fn resume_after_the_current_document_was_collected_reads_on() {
 
     // SAFETY: the reader is suspended, so it holds no reference into the index,
     // and `tag_index` is the owning pointer the lookup was minted from.
-    unsafe { &mut *tag_index }.gc_remove_doc(b"hello", COLLECTED);
+    let info = gc_mem(unsafe { &mut *tag_index }, b"hello", |d| d != COLLECTED);
+    assert_eq!(
+        info.entries_removed, 1,
+        "only the document parked on must have been collected"
+    );
 
     let guard = mock.spec_read();
     let outcome = suspended.resume(&guard).expect("resume must not error");

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -318,3 +318,75 @@ fn resume_with_the_tag_untouched_reads_on() {
     // SAFETY: `allocate` allocated it; the iterator using it is gone.
     drop(unsafe { Box::from_raw(tag_index) });
 }
+
+/// The branch between the two above: an in-place collection keeps the tag's
+/// inverted index at the same address and with the same unique id, so the lookup
+/// re-resolves to the very index the reader holds and the reader is *not*
+/// aborted — it re-seeks past the collected document and reads on. This is the
+/// only revalidation outcome in which a reader reads through the pointer it held
+/// across a mutation of the index.
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "the reader's stored pointer is derived from the `&self` reborrow taken in \
+              `open_reader` (a SharedReadOnly tag); the `&mut` the collector needs pops that tag \
+              under Stacked Borrows, so the re-seek reading through it is flagged as UB. The \
+              aliasing is the revalidation protocol working as designed (the same pattern the \
+              numeric iterator documents on `variant_resume` in \
+              rqe_iterators/tests/integration/inverted_index/numeric.rs) but Stacked Borrows \
+              cannot model it. The `Aborted` arm above stays in Miri's reach because it never \
+              reads through the pointer."
+)]
+fn resume_after_the_current_document_was_collected_reads_on() {
+    const N: ffi::t_docId = 4;
+    const COLLECTED: ffi::t_docId = 2;
+
+    let mock = MockContext::new(N, N as usize);
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    for doc_id in 1..=N {
+        // SAFETY: `tag_index` was just allocated and is not yet aliased.
+        index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
+    }
+
+    // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
+    // `tag_index`.
+    let mut it = unsafe {
+        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
+    }
+    .expect("the tag is indexed");
+    // Park the reader exactly on the document about to be collected, the position
+    // the resume has to recover from.
+    for _ in 1..=COLLECTED {
+        it.read().expect("read must not error");
+    }
+    assert_eq!(it.last_doc_id(), COLLECTED);
+
+    let suspended = Box::new(it).suspend();
+
+    // SAFETY: the reader is suspended, so it holds no reference into the index,
+    // and `tag_index` is the owning pointer the lookup was minted from.
+    unsafe { &mut *tag_index }.gc_remove_doc(b"hello", COLLECTED);
+
+    let guard = mock.spec_read();
+    let outcome = suspended.resume(&guard).expect("resume must not error");
+    let mut it = match outcome {
+        ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+        ResumeOutcome::Aborted => {
+            panic!("an in-place collection leaves the index the reader holds, so it cannot abort")
+        }
+    };
+
+    // Whatever the outcome variant, the contract is that the iterator reports
+    // where it actually is: on the first document surviving past the collected
+    // one, with the rest still to come.
+    assert_eq!(
+        it.current()
+            .expect("a resumed iterator is still positioned")
+            .doc_id,
+        COLLECTED + 1
+    );
+    assert_eq!(drain(*it), (COLLECTED + 2..=N).collect::<Vec<_>>());
+
+    // SAFETY: `allocate` allocated it; the iterator using it is gone.
+    drop(unsafe { Box::from_raw(tag_index) });
+}

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -200,7 +200,7 @@ fn open_reader_returns_none_for_empty_inverted_index() {
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"empty"], 1);
     // SAFETY: `tag_index` was indexed into above and is not otherwise aliased.
-    unsafe { &mut *tag_index }.force_empty_value(b"empty");
+    unsafe { &mut *tag_index }.force_empty_value(as_tag(b"empty"));
 
     let mock = MockContext::new(0, 0);
     // SAFETY: `tag_index` and `mock` outlive the (never created) iterator, and

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -10,7 +10,8 @@
 //! Helpers shared by the integration test modules.
 
 use ffi::timespec;
-use inverted_index::DocId;
+use index_result::RSIndexResult;
+use inverted_index::{DocId, GcApplyInfo, GcScanDelta, IndexUniqueId, RepairContext};
 use tag_index::{InMemoryMode, MemTagIndexIterator, Tag, TagIndex, WritePostingsDelta};
 
 /// Wrap a NUL-free test literal into a [`Tag`].
@@ -57,4 +58,44 @@ pub fn value_iter_keys(mut it: MemTagIndexIterator<'_>) -> Vec<Vec<u8>> {
         keys.push(key.as_bytes().to_vec());
     }
     keys
+}
+
+/// The [`IndexUniqueId`] of `tag`'s posting list — what the GC child ships back and
+/// [`TagIndex::gc`] checks the delta against.
+pub fn unique_id(idx: &TagIndex<InMemoryMode>, tag: &[u8]) -> IndexUniqueId {
+    idx.find_value(tag).expect("tag is indexed").unique_id()
+}
+
+/// Scan `tag`'s postings the way the GC child does, keeping only the documents
+/// `doc_exists` accepts. `None` when nothing needs repairing.
+pub fn scan(
+    idx: &TagIndex<InMemoryMode>,
+    tag: &[u8],
+    doc_exists: impl Fn(DocId) -> bool,
+) -> Option<GcScanDelta> {
+    idx.find_value(tag)
+        .expect("tag is indexed")
+        .scan_gc(
+            doc_exists,
+            None::<for<'i> fn(&RSIndexResult<'i>, &RepairContext<'i>)>,
+        )
+        .expect("scanning a tag's postings should not fail")
+}
+
+/// Run a whole fork-GC cycle over `tag`: [`scan`] its postings keeping only the
+/// documents `doc_exists` accepts, then apply the resulting delta through
+/// [`TagIndex::gc`].
+///
+/// Tests that need the two halves to disagree — a delta scanned against another
+/// index, or against a tag that has since been removed — drive [`scan`],
+/// [`unique_id`] and [`TagIndex::gc`] separately instead.
+pub fn gc_mem(
+    idx: &mut TagIndex<InMemoryMode>,
+    tag: &[u8],
+    doc_exists: impl Fn(DocId) -> bool,
+) -> GcApplyInfo {
+    let delta = scan(idx, tag, doc_exists).expect("at least one document must need repairing");
+    let id = unique_id(idx, tag);
+    idx.gc(tag, id, delta)
+        .expect("the delta was just scanned, so it cannot be stale")
 }

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -21,7 +21,7 @@ pub fn as_tag(bytes: &[u8]) -> Tag<'_> {
 
 /// Wrap every NUL-free literal `tags` passes as a test fixture into a [`Tag`].
 fn tag_values<'a>(tags: &[&'a [u8]]) -> Vec<Tag<'a>> {
-    tags.iter().map(|t| as_tag(t)).collect()
+    tags.iter().copied().map(as_tag).collect()
 }
 
 /// A deadline that has already elapsed. Any `CLOCK_MONOTONIC_RAW` value one
@@ -96,6 +96,6 @@ pub fn gc_mem(
 ) -> GcApplyInfo {
     let delta = scan(idx, tag, doc_exists).expect("at least one document must need repairing");
     let id = unique_id(idx, tag);
-    idx.gc(tag, id, delta)
+    idx.gc(as_tag(tag), id, delta)
         .expect("the delta was just scanned, so it cannot be stale")
 }


### PR DESCRIPTION
Add the parent-process half of a fork-GC cycle to the Rust tag index: `TagIndex<InMemoryMode>::gc`, plus the `TagSuffixIndex::delete` it needs.

## Describe the changes in the pull request

1. Current: the Rust `tag_index` crate can index and query tags, but nothing can ever remove one.
    There is no counterpart to the parent-side apply loop in src/fork_gc/tags.c, so a tag whose
    documents were all deleted would keep its posting list and its suffix-trie entries forever.
2. Change: `TagIndex<InMemoryMode>::gc(tag, unique_id, delta)` applies a GC scan delta to a tag's
    inverted index and, when the tag lost its last document, drops it from the values trie and from the
    suffix trie (new `TagSuffixIndex::delete`, mirroring C's deleteSuffixTrieMap), folding the                                                       discarded posting list's bytes and blocks into the returned `GcApplyInfo`. The staleness guard C                                                       implements as a raw pointer comparison (idx != value) is an IndexUniqueId comparison here: a                                                        pointer cannot tell the ABA case apart, where the tag is emptied and re-added and the allocator
    hands back the same address.
3. Outcome: internal-only, no user-visible change — the crate is not wired to C yet. It completes the
    removal path the fork GC needs, and it lets the reader tests drive a real GC pass instead of
    stand-in helpers, which brought the previously uncovered revalidation branch into reach: an
    in-place collection leaves the reader's index alive, so the reader is not aborted and re-seeks past
    the collected document.

#### Which additional issues this PR fixes

1. MOD-14988

#### Main objects this PR modified

1. `TagIndex<InMemoryMode>` — new public `gc()`.
2. `TagSuffixIndex` — new `delete()`, unlinking a term from its own entry and from every suffix entry
    that referenced it, and freeing the owned term only once the last `TermPtr` to it is gone.
3. `inverted_index` — `IndexUniqueId` is now exported publicly, so callers outside the crate can
    carry a posting list's identity across a GC cycle.
4. Tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
