### PR TITLE
[MOD-16400] Trie - ContainsIter owns its search target

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -75,6 +75,9 @@ pub unsafe extern "C" fn TrieMap_Iterate<'tm>(t: *mut TrieMap) -> *mut TrieMapIt
 /// - `t` must not be freed while the iterator lives.
 /// - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
 ///   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
+/// - In `TM_SUFFIX_MODE` and `TM_WILDCARD_MODE`, the buffer behind `prefix` must remain
+///   valid and unmodified until the iterator is freed; the other modes copy what they
+///   need before this function returns.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateWithFilter<'tm>(
     t: *mut TrieMap,

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -75,9 +75,10 @@ pub unsafe extern "C" fn TrieMap_Iterate<'tm>(t: *mut TrieMap) -> *mut TrieMapIt
 /// - `t` must not be freed while the iterator lives.
 /// - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
 ///   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
-/// - In `TM_SUFFIX_MODE` and `TM_WILDCARD_MODE`, the buffer behind `prefix` must remain
-///   valid and unmodified until the iterator is freed; the other modes copy what they
-///   need before this function returns.
+/// - In [`tm_iter_mode::TM_SUFFIX_MODE`] and [`tm_iter_mode::TM_WILDCARD_MODE`], the buffer
+///   behind `prefix` must remain valid and unmodified until the iterator is freed.
+///   [`tm_iter_mode::TM_PREFIX_MODE`] and [`tm_iter_mode::TM_CONTAINS_MODE`] impose no
+///   requirement on `prefix` beyond the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateWithFilter<'tm>(
     t: *mut TrieMap,

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -22,11 +22,7 @@ pub enum TrieMapIteratorImpl<'tm> {
     // Boxing to reduce the size of overall enum, since the contains variant
     // is much larger than the others due to how much space `memchr::memmem::Finder`
     // takes on the stack.
-    //
-    // Both lifetime parameters collapse to `'tm` at the FFI boundary: the
-    // trie reference and the target byte slice originate from the same
-    // C-side scope.
-    Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
+    Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, *mut c_void>>),
     Wildcard(WildcardLendingIter<'tm, 'tm, *mut c_void>),
 }
 
@@ -54,7 +50,7 @@ impl<'tm> LendingIterator for TrieMapIteratorImpl<'tm> {
             TrieMapIteratorImpl::Plain(iter) => LendingIterator::next(iter),
             TrieMapIteratorImpl::Filtered(iter, should_yield) => iter.find(&mut *should_yield),
             TrieMapIteratorImpl::Contains(iter) => {
-                let iter: &mut trie_rs::iter::ContainsLendingIter<'_, '_, *mut c_void> = &mut *iter;
+                let iter: &mut trie_rs::iter::ContainsLendingIter<'_, *mut c_void> = &mut *iter;
                 LendingIterator::next(iter)
             }
             TrieMapIteratorImpl::Wildcard(iter) => LendingIterator::next(iter),

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -313,9 +313,10 @@ void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minle
  * - `t` must not be freed while the iterator lives.
  * - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
  *   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
- * - In `TM_SUFFIX_MODE` and `TM_WILDCARD_MODE`, the buffer behind `prefix` must remain
- *   valid and unmodified until the iterator is freed; the other modes copy what they
- *   need before this function returns.
+ * - In [`tm_iter_mode::TM_SUFFIX_MODE`] and [`tm_iter_mode::TM_WILDCARD_MODE`], the buffer
+ *   behind `prefix` must remain valid and unmodified until the iterator is freed.
+ *   [`tm_iter_mode::TM_PREFIX_MODE`] and [`tm_iter_mode::TM_CONTAINS_MODE`] impose no
+ *   requirement on `prefix` beyond the duration of this call.
  */
 struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char *prefix, tm_len_t prefix_len, enum tm_iter_mode iter_mode);
 

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -313,6 +313,9 @@ void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minle
  * - `t` must not be freed while the iterator lives.
  * - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
  *   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
+ * - In `TM_SUFFIX_MODE` and `TM_WILDCARD_MODE`, the buffer behind `prefix` must remain
+ *   valid and unmodified until the iterator is freed; the other modes copy what they
+ *   need before this function returns.
  */
 struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char *prefix, tm_len_t prefix_len, enum tm_iter_mode iter_mode);
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -16,15 +16,15 @@ use crate::{TrieMap, iter, str_trie_map::iter::unfiltered::key_to_string};
 /// every key.
 ///
 /// See [`crate::iter::ContainsIter`] for the underlying traversal.
-pub struct ContainsIter<'tm, 'p, Data: 'tm>(iter::ContainsIter<'tm, 'p, Data>);
+pub struct ContainsIter<'tm, Data: 'tm>(iter::ContainsIter<'tm, Data>);
 
-impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
-    pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
+impl<'tm, Data: 'tm> ContainsIter<'tm, Data> {
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &str) -> Self {
         Self(trie.contains_iter(target.as_bytes()))
     }
 }
 
-impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {
+impl<'tm, Data: 'tm> Iterator for ContainsIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -122,9 +122,6 @@ impl<Data> StrTrieMap<Data> {
     /// Yield every entry whose key contains `target` as a substring.
     /// Empty `target` yields every entry — the empty string is a substring
     /// of every key.
-    ///
-    /// The iterator owns a copy of `target`, so the borrow ends when this
-    /// call returns.
     pub fn contains_iter(&self, target: &str) -> iter::ContainsIter<'_, Data> {
         iter::ContainsIter::new(&self.inner, target)
     }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -122,7 +122,10 @@ impl<Data> StrTrieMap<Data> {
     /// Yield every entry whose key contains `target` as a substring.
     /// Empty `target` yields every entry — the empty string is a substring
     /// of every key.
-    pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> iter::ContainsIter<'tm, 'p, Data> {
+    ///
+    /// The iterator owns a copy of `target`, so the borrow ends when this
+    /// call returns.
+    pub fn contains_iter(&self, target: &str) -> iter::ContainsIter<'_, Data> {
         iter::ContainsIter::new(&self.inner, target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -17,14 +17,15 @@ use timeout::TimeoutCheckResult;
 /// in lexicographical order.
 ///
 /// Invoke [`TrieMap::contains_iter`](crate::TrieMap::contains_iter) to create an instance of this iterator.
-pub struct ContainsIter<'tm, 't, Data> {
+pub struct ContainsIter<'tm, Data> {
     /// Stack of nodes and whether they have been visited.
     stack: Vec<StackItem<'tm, Data>>,
     /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<u8>,
-    /// The target fragment we are looking for.
-    finder: Finder<'t>,
+    /// The target fragment we are looking for. Owned, so the iterator does
+    /// not borrow the caller's target buffer.
+    finder: Finder<'static>,
     /// The timeout
     timeout: IteratorTimeoutState,
 }
@@ -39,10 +40,10 @@ struct StackItem<'tm, Data> {
     skip_check: bool,
 }
 
-impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
+impl<'tm, Data> ContainsIter<'tm, Data> {
     /// Creates a new contains iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'t [u8]) -> Self {
-        let finder = Finder::new(target);
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &[u8]) -> Self {
+        let finder = Finder::new(target).into_owned();
         Self {
             stack: root
                 .into_iter()
@@ -63,7 +64,7 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     }
 }
 
-impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
+impl<'tm, Data> ContainsIter<'tm, Data> {
     /// The current key, obtained by concatenating the labels of the nodes
     /// between the root and the current node.
     pub(crate) fn key(&self) -> &[u8] {
@@ -120,7 +121,7 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     }
 }
 
-impl<'tm, 't, Data> Iterator for ContainsIter<'tm, 't, Data> {
+impl<'tm, Data> Iterator for ContainsIter<'tm, Data> {
     type Item = (Vec<u8>, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -16,6 +16,9 @@ use timeout::TimeoutCheckResult;
 /// Iterates over all the entries in a [`TrieMap`](crate::TrieMap) that contain the target fragment,
 /// in lexicographical order.
 ///
+/// The target fragment is copied on construction, so the iterator's
+/// lifetime is independent of the caller's buffer.
+///
 /// Invoke [`TrieMap::contains_iter`](crate::TrieMap::contains_iter) to create an instance of this iterator.
 pub struct ContainsIter<'tm, Data> {
     /// Stack of nodes and whether they have been visited.

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -23,8 +23,7 @@ pub struct ContainsIter<'tm, Data> {
     /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<u8>,
-    /// The target fragment we are looking for. Owned, so the iterator does
-    /// not borrow the caller's target buffer.
+    /// The target fragment we are looking for.
     finder: Finder<'static>,
     /// The timeout
     timeout: IteratorTimeoutState,

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
@@ -16,15 +16,15 @@ use lending_iterator::prelude::*;
 /// in lexicographical order.
 ///
 /// Unlike [`ContainsIter`], this iterator lets you borrow the current key, rather than having to clone it.
-pub struct ContainsLendingIter<'tm, 't, Data>(ContainsIter<'tm, 't, Data>);
+pub struct ContainsLendingIter<'tm, Data>(ContainsIter<'tm, Data>);
 
-impl<'tm, 't, Data> From<ContainsIter<'tm, 't, Data>> for ContainsLendingIter<'tm, 't, Data> {
-    fn from(iter: ContainsIter<'tm, 't, Data>) -> Self {
+impl<'tm, Data> From<ContainsIter<'tm, Data>> for ContainsLendingIter<'tm, Data> {
+    fn from(iter: ContainsIter<'tm, Data>) -> Self {
         ContainsLendingIter(iter)
     }
 }
 
-impl<'tm, 't, Data> ContainsLendingIter<'tm, 't, Data> {
+impl<'tm, Data> ContainsLendingIter<'tm, Data> {
     /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.0.set_timeout(timeout)
@@ -33,7 +33,7 @@ impl<'tm, 't, Data> ContainsLendingIter<'tm, 't, Data> {
 
 // See `LendingIter` for why this is a `LendingIterator` rather than an `Iterator`.
 #[gat]
-impl<'tm, 't, Data> LendingIterator for ContainsLendingIter<'tm, 't, Data> {
+impl<'tm, Data> LendingIterator for ContainsLendingIter<'tm, Data> {
     type Item<'next>
     where
         Self: 'next,

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -282,7 +282,10 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over the entries that contain the target fragment, in lexicographical key order.
-    pub fn contains_iter<'tm, 't>(&'tm self, target: &'t [u8]) -> ContainsIter<'tm, 't, Data> {
+    ///
+    /// The iterator owns a copy of `target`, so the borrow ends when this
+    /// call returns.
+    pub fn contains_iter(&self, target: &[u8]) -> ContainsIter<'_, Data> {
         ContainsIter::new(self.root.as_ref(), target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -283,8 +283,7 @@ impl<Data> TrieMap<Data> {
 
     /// Iterate over the entries that contain the target fragment, in lexicographical key order.
     ///
-    /// The iterator owns a copy of `target`, so the borrow ends when this
-    /// call returns.
+    /// The returned [`ContainsIter`] does not borrow `target`.
     pub fn contains_iter(&self, target: &[u8]) -> ContainsIter<'_, Data> {
         ContainsIter::new(self.root.as_ref(), target)
     }

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/contains.rs
@@ -63,8 +63,7 @@ fn iterator_outlives_the_target_buffer() {
     trie.insert(b"apple", 1);
     trie.insert(b"banana", 2);
 
-    // The iterator owns a copy of the target, so it stays usable after the
-    // caller's buffer is gone.
+    // The inner scope drops the target before the iterator is used.
     let iter = {
         let target = b"an".to_vec();
         trie.contains_iter(&target)

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/contains.rs
@@ -57,6 +57,22 @@ fn non_empty_contains() {
     assert_eq!(contains(&trie, b"ban"), vec!["ban".as_bytes(), b"banana"]);
 }
 
+#[test]
+fn iterator_outlives_the_target_buffer() {
+    let mut trie = TrieMap::new();
+    trie.insert(b"apple", 1);
+    trie.insert(b"banana", 2);
+
+    // The iterator owns a copy of the target, so it stays usable after the
+    // caller's buffer is gone.
+    let iter = {
+        let target = b"an".to_vec();
+        trie.contains_iter(&target)
+    };
+    let keys: Vec<Vec<u8>> = iter.map(|(k, _)| k).collect();
+    assert_eq!(keys, vec![b"banana".to_vec()]);
+}
+
 mod property_based {
     #![cfg(not(miri))]
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `ContainsIter` borrows the caller's target buffer for the iterator's whole lifetime, so every wrapper type has to carry a pattern lifetime parameter and callers cannot construct the iterator from a temporary buffer.
2. Change: the iterator owns a copy of the target (`memmem::Finder::into_owned`), dropping the pattern lifetime from `ContainsIter`, `ContainsLendingIter`, and the `StrTrieMap` wrapper.
3. Outcome: internal-only — no user-visible change. It simplifies the API for downstream consumers that build the target on the fly (e.g. after case-folding) and removes the need to drain matches eagerly to escape the borrow.

#### Which additional issues this PR fixes

1. MOD-16400

#### Main objects this PR modified

1. `trie_rs::iter::ContainsIter` — owns its `Finder`, pattern lifetime removed
2. `trie_rs::iter::ContainsLendingIter` — lifetime parameter dropped accordingly
3. `StrTrieMap::contains_iter` — signature no longer ties the iterator to the target borrow
4. `triemap_ffi::TrieMapIteratorImpl::Contains` — type updated, stale lifetime-collapse note removed

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
