### PR TITLE
[MOD-17908] Reduce cluster reply conversion overhead

### DIFF
--- a/src/coord/rmr/reply.c
+++ b/src/coord/rmr/reply.c
@@ -222,6 +222,17 @@ inline const char *MRReply_String(const MRReply *reply, size_t *len) {
   return reply->str;
 }
 
+inline char *MRReply_TakeString(MRReply *reply, size_t *len) {
+  RS_ASSERT(reply->type == MR_REPLY_STRING || reply->type == MR_REPLY_STATUS);
+  if (len) {
+    *len = reply->len;
+  }
+  char *str = reply->str;
+  reply->str = NULL;
+  reply->len = 0;
+  return str;
+}
+
 inline MRReply *MRReply_ArrayElement(const MRReply *reply, size_t idx) {
   RS_ASSERT(reply->elements > idx);
   return reply->element[idx];

--- a/src/coord/rmr/reply.h
+++ b/src/coord/rmr/reply.h
@@ -50,6 +50,10 @@ int MRReply_StringEquals(MRReply *r, const char *s, int caseSensitive);
 
 const char *MRReply_String(const MRReply *reply, size_t *len);
 
+// Takes ownership of a string reply's buffer. The reply remains valid and must
+// still be freed, but no longer owns the returned buffer.
+char *MRReply_TakeString(MRReply *reply, size_t *len);
+
 MRReply *MRReply_ArrayElement(const MRReply *reply, size_t idx);
 // Same as `MRReply_ArrayElement`, but takes ownership of the element.
 MRReply *MRReply_TakeArrayElement(const MRReply *reply, size_t idx);

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -36,6 +36,8 @@
 
 #define CURSOR_EOF 0
 
+// Converts an MRReply to an RSValue, consuming the reply. String buffers can be
+// transferred directly because hiredis uses the Redis module allocator.
 static RSValue *MRReply_ToValue(MRReply *r) {
   if (!r) return RSValue_NullStatic();
   RSValue *v = NULL;
@@ -43,9 +45,9 @@ static RSValue *MRReply_ToValue(MRReply *r) {
     case MR_REPLY_STATUS:
     case MR_REPLY_STRING: {
       size_t l;
-      const char *s = MRReply_String(r, &l);
+      char *s = MRReply_TakeString(r, &l);
       RS_ASSERT(l <= UINT32_MAX);
-      v = RSValue_NewCopiedString(s, l);
+      v = RSValue_NewString(s, (uint32_t)l);
       break;
     }
     case MR_REPLY_ERROR: {
@@ -66,9 +68,9 @@ static RSValue *MRReply_ToValue(MRReply *r) {
       size_t map_len = n / 2;
       RSValueMapBuilder *map = RSValue_NewMapBuilder(map_len);
       for (size_t i = 0; i < map_len; i++) {
-        MRReply *e_k = MRReply_ArrayElement(r, i * 2);
+        MRReply *e_k = MRReply_TakeArrayElement(r, i * 2);
         RS_LOG_ASSERT(MRReply_Type(e_k) == MR_REPLY_STRING, "non-string map key");
-        MRReply *e_v = MRReply_ArrayElement(r, (i * 2) + 1);
+        MRReply *e_v = MRReply_TakeArrayElement(r, (i * 2) + 1);
         RSValue_MapBuilderSetEntry(map, i,  MRReply_ToValue(e_k), MRReply_ToValue(e_v));
       }
       v = RSValue_NewMapFromBuilder(map);
@@ -78,7 +80,7 @@ static RSValue *MRReply_ToValue(MRReply *r) {
       size_t n = MRReply_Length(r);
       RSValue **arr = RSValue_NewArrayBuilder(n);
       for (size_t i = 0; i < n; ++i) {
-        arr[i] = MRReply_ToValue(MRReply_ArrayElement(r, i));
+        arr[i] = MRReply_ToValue(MRReply_TakeArrayElement(r, i));
       }
       v = RSValue_NewArrayFromBuilder(arr, n);
       break;
@@ -90,6 +92,7 @@ static RSValue *MRReply_ToValue(MRReply *r) {
       v = RSValue_NullStatic();
       break;
   }
+  MRReply_Free(r);
   return v;
 }
 
@@ -542,7 +545,7 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   for (size_t i = 0; i < fields_length; i += 2) {
     size_t len;
     const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
-    MRReply *val = MRReply_ArrayElement(fields, i + 1);
+    MRReply *val = MRReply_TakeArrayElement(fields, i + 1);
     RSValue *v = MRReply_ToValue(val);
     RLookupRow_WriteByNameOwned(nc->lookup, field, len, SearchResult_GetRowDataMut(r), v);
   }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Distributed aggregation copies every shard reply string while converting it into coordinator row values, making wide cluster replies allocation-heavy.
2. Change: Reply conversion now consumes reply values and transfers compatible hiredis string buffers into owned result values.
3. Outcome: Cluster queries spend less CPU and allocate less while decoding shard rows, without changing RESP2/RESP3 reply shapes.

#### Which additional issues this PR fixes

1. https://redislabs.atlassian.net/browse/MOD-17908

#### Main objects this PR modified

1. Coordinator reply conversion — consume nested values and string storage.
2. Map-reduce replies — expose explicit string-buffer ownership transfer.
3. RPNet row loading — detach values before writing coordinator rows.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

In a 1M-document, three-shard `ON_TIMEOUT RETURN-STRICT` profile, inclusive `MRReply_ToValue` CPU fell from 20.30% to 3.47% for 100-field rows and from 17.03% to 3.03% for a 100-key GROUPBY case. The internal wire protocol and user-visible replies are unchanged.
