### PR TITLE
[MOD-17909] Reduce result destruction overhead

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2722,8 +2722,11 @@ dependencies = [
  "ffi",
  "index_result",
  "inverted_index",
+ "redis_mock",
+ "redisearch_rs",
  "rlookup",
  "rqe_core",
+ "value",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -19,5 +19,11 @@ enumflags2.workspace = true
 workspace_hack.workspace = true
 document_metadata.workspace = true
 
+[dev-dependencies]
+redis_mock.workspace = true
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }
+rlookup = { path = "../rlookup", features = ["unittest"] }
+value.workspace = true
+
 [lints]
 workspace = true

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -65,9 +65,12 @@ pub struct SearchResult<'index> {
 
 impl Drop for SearchResult<'_> {
     fn drop(&mut self) {
-        self.clear();
-
+        self.clear_before_row();
         self._row_data.reset_dyn_values();
+        self._row_data.set_sorting_vector(None);
+
+        // Keep the row-before-DMD destruction order of the old C implementation.
+        let _ = self._document_metadata.take();
     }
 }
 
@@ -104,10 +107,7 @@ impl<'index> SearchResult<'index> {
         self._flags.remove(SearchResultFlag::OwnsIndexResult);
     }
 
-    /// Clears the search result, removing all values from the [`RLookupRow`][ffi::RLookupRow].
-    /// This has no effect on the allocated capacity of the lookup row.
-    #[inline]
-    pub fn clear(&mut self) {
+    fn clear_before_row(&mut self) {
         self._score = 0.0;
 
         if let Some(score_explain) = self._score_explain.take() {
@@ -118,9 +118,14 @@ impl<'index> SearchResult<'index> {
         }
 
         self.clear_index_result();
-
         self._flags = SearchResultFlags::empty();
+    }
 
+    /// Clears the search result, removing all values from the [`RLookupRow`][ffi::RLookupRow].
+    /// This has no effect on the allocated capacity of the lookup row.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.clear_before_row();
         self._row_data.wipe();
 
         // explicitly drop the DMD here to make clear we maintain the

--- a/src/redisearch_rs/search_result/tests/drop.rs
+++ b/src/redisearch_rs/search_result/tests/drop.rs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+extern crate redisearch_rs;
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use rlookup::{RLookupKey, RLookupKeyFlags};
+use search_result::SearchResult;
+use value::SharedValue;
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn drop_releases_dynamic_row_values() {
+    let value = SharedValue::new_num(42.0);
+    let key = RLookupKey::new(c"field", RLookupKeyFlags::empty());
+
+    {
+        let mut result = SearchResult::new();
+        result.row_data_mut().write_key(&key, value.clone());
+        assert_eq!(SharedValue::refcount(&value), 2);
+    }
+
+    assert_eq!(SharedValue::refcount(&value), 1);
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Destroying a search result uses the reusable row-clearing path and then resets the dynamic-value vector, adding a redundant traversal during final destruction.
2. Change: Destruction releases non-row state and resets dynamic values directly, while reusable `clear` behavior keeps its existing capacity semantics.
3. Outcome: The lifecycle is simpler and avoids the redundant final traversal without changing reply behavior, ownership, or the `SharedValue` drops and vector deallocation that destruction must still perform.

#### Which additional issues this PR fixes

1. https://redislabs.atlassian.net/browse/MOD-17909

#### Main objects this PR modified

1. `SearchResult` lifecycle — separate reusable clearing from final destruction.
2. Dynamic result rows — reset their backing values directly during `Drop`.
3. Document metadata and sorting state — preserve established destruction ordering.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

#### Performance validation

The original profile showed inclusive `SearchResult_Destroy` falling from 6.19% to 0.01%, but the follow-up whole-stack analysis found that the same internal value drops and row deallocation remain and are attributed beneath the reply-serialization path after inlining. No reliable end-to-end performance benefit was established. This PR is therefore retained as a small lifecycle cleanup, not as a demonstrated performance optimization.
