### PR TITLE
[MOD-17910] Reduce GROUPBY cleanup overhead

### DIFF
--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -122,12 +122,19 @@ static Group *createGroup(Grouper *g, const RSValue **groupvals, size_t ngrpvals
   return group;
 }
 
-static void writeGroupValues(const Grouper *g, const Group *gr, SearchResult *r) {
+static void moveGroupValues(const Grouper *g, Group *gr, SearchResult *r) {
   for (size_t ii = 0; ii < g->nkeys; ++ii) {
     const RLookupKey *dstkey = g->dstkeys[ii];
-    RSValue *groupval = RLookupRow_Get(dstkey, &gr->rowdata);
-    if (groupval) {
-      RLookup_WriteKey(dstkey, SearchResult_GetRowDataMut(r), groupval);
+    RLookupRow_MoveDynamicKey(dstkey, &gr->rowdata, SearchResult_GetRowDataMut(r));
+  }
+}
+
+static void cleanupGroup(Grouper *g, Group *gr) {
+  RLookupRow_Reset(&gr->rowdata);
+  for (size_t ii = 0; ii < GROUPER_NREDUCERS(g); ++ii) {
+    Reducer *reducer = g->reducers[ii];
+    if (reducer->FreeInstance) {
+      reducer->FreeInstance(reducer, gr->accumdata[ii]);
     }
   }
 }
@@ -142,12 +149,14 @@ static int Grouper_rpYield(ResultProcessor *base, SearchResult *r) {
     }
 
     Group *gr = kh_value(g->groups, g->iter);
-    writeGroupValues(g, gr, r);
+    moveGroupValues(g, gr, r);
     for (size_t ii = 0; ii < GROUPER_NREDUCERS(g); ++ii) {
       Reducer *rd = g->reducers[ii];
       RSValue *v = rd->Finalize(rd, gr->accumdata[ii]);
       RLookup_WriteOwnKey(rd->dstkey, SearchResult_GetRowDataMut(r), v);
     }
+    cleanupGroup(g, gr);
+    kh_del(khid, g->groups, g->iter);
     ++g->iter;
     return RS_RESULT_OK;
   }
@@ -291,29 +300,17 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   }
 }
 
-static void cleanCallback(void *ptr, void *arg) {
-  Group *group = ptr;
-  Grouper *parent = arg;
-  // Call the reducer's FreeInstance
-  for (size_t ii = 0; ii < GROUPER_NREDUCERS(parent); ++ii) {
-    Reducer *rr = parent->reducers[ii];
-    if (rr->FreeInstance) {
-      rr->FreeInstance(rr, group->accumdata[ii]);
-    }
-  }
-}
-
 static void Grouper_rpFree(ResultProcessor *grrp) {
   Grouper *g = (Grouper *)grrp;
-  for (khiter_t it = kh_begin(g->groups); it != kh_end(g->groups); ++it) {
-    if (!kh_exist(g->groups, it)) {
-      continue;
+  if (kh_size(g->groups) > 0) {
+    for (khiter_t iter = kh_begin(g->groups); iter != kh_end(g->groups); ++iter) {
+      if (kh_exist(g->groups, iter)) {
+        cleanupGroup(g, kh_value(g->groups, iter));
+      }
     }
-    Group *gr = kh_value(g->groups, it);
-    RLookupRow_Reset(&gr->rowdata);
   }
   kh_destroy(khid, g->groups);
-  BlkAlloc_FreeAll(&g->groupsAlloc, cleanCallback, g, GROUP_BYTESIZE(g));
+  BlkAlloc_FreeAll(&g->groupsAlloc, NULL, NULL, 0);
 
   for (size_t i = 0; i < GROUPER_NREDUCERS(g); i++) {
     g->reducers[i]->Free(g->reducers[i]);

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn RLookupRow_MoveDynamicKey(
     // SAFETY: ensured by caller (2.)
     let src =
         unsafe { RLookupRow::from_opaque_non_null(src_row.expect("`src_row` must not be null")) };
-    // SAFETY: ensured by caller (3.)
+    // SAFETY: ensured by caller (3., 4.)
     let dst =
         unsafe { RLookupRow::from_opaque_non_null(dst_row.expect("`dst_row` must not be null")) };
 

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -151,6 +151,42 @@ pub unsafe extern "C" fn RLookupRow_MoveFieldsFrom(
     dst.move_fields_from(src, lookup);
 }
 
+/// Moves one dynamic key from the source row to the destination row without
+/// changing its reference count. A missing dynamic value is ignored.
+///
+/// # Safety
+///
+/// 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
+/// 2. `src_row` must be a [valid], non-null pointer to an [`RLookupRow`] that is exclusively
+///    accessible for the duration of this call.
+/// 3. `dst_row` must be a [valid], non-null pointer to an [`RLookupRow`] that is exclusively
+///    accessible for the duration of this call.
+/// 4. `src_row` and `dst_row` must not be the same lookup row.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RLookupRow_MoveDynamicKey(
+    key: *const RLookupKey,
+    src_row: Option<NonNull<OpaqueRLookupRow>>,
+    dst_row: Option<NonNull<OpaqueRLookupRow>>,
+) {
+    debug_assert_ne!(
+        src_row, dst_row,
+        "`src_row` and `dst_row` must not be the same"
+    );
+
+    // SAFETY: ensured by caller (1.)
+    let key = unsafe { key.as_ref() }.expect("`key` must not be null");
+    // SAFETY: ensured by caller (2.)
+    let src =
+        unsafe { RLookupRow::from_opaque_non_null(src_row.expect("`src_row` must not be null")) };
+    // SAFETY: ensured by caller (3.)
+    let dst =
+        unsafe { RLookupRow::from_opaque_non_null(dst_row.expect("`dst_row` must not be null")) };
+
+    src.move_dynamic_key_to(key, dst);
+}
+
 /// Write a value by-name to the lookup table. This is useful for 'dynamic' keys
 /// for which it is not necessary to use the boilerplate of getting an explicit
 /// key.

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -146,6 +146,23 @@ struct RSValue *RLookupRow_Get(const RLookupKey *key, const struct RLookupRow *r
 struct RSSortingVectorSlice RLookupRow_GetSortingVector(const struct RLookupRow *row);
 
 /**
+ * Moves one dynamic key from the source row to the destination row without
+ * changing its reference count. A missing dynamic value is ignored.
+ *
+ * # Safety
+ *
+ * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
+ * 2. `src_row` must be a [valid], non-null pointer to an [`RLookupRow`] that is exclusively
+ *    accessible for the duration of this call.
+ * 3. `dst_row` must be a [valid], non-null pointer to an [`RLookupRow`] that is exclusively
+ *    accessible for the duration of this call.
+ * 4. `src_row` and `dst_row` must not be the same lookup row.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookupRow_MoveDynamicKey(const RLookupKey *key, struct RLookupRow *src_row, struct RLookupRow *dst_row);
+
+/**
  * Move data from the source row to the destination row. The source row is cleared.
  *
  * # Safety

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -269,6 +269,18 @@ impl<'a> RLookupRow<'a> {
         prev
     }
 
+    /// Moves a dynamic value for `key` into `dst` without changing its reference count.
+    pub fn move_dynamic_key_to(&mut self, key: &RLookupKey, dst: &mut Self) {
+        if let Some(value) = self
+            .dyn_values
+            .get_mut(key.dstidx as usize)
+            .and_then(Option::take)
+        {
+            self.num_dyn_values -= 1;
+            dst.write_key(key, value);
+        }
+    }
+
     /// Write a value to the lookup table *by-name*. This is useful for 'dynamic' keys
     /// for which it is not necessary to use the boilerplate of getting an explicit
     /// key.

--- a/src/redisearch_rs/rlookup/tests/row.rs
+++ b/src/redisearch_rs/rlookup/tests/row.rs
@@ -147,6 +147,26 @@ fn insert_overwrite() {
     assert_eq!(SharedValue::refcount(&mock_to_be_overwritten), 2); // we have both mock_to_be_overwritten and prev
 }
 
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn move_dynamic_key_transfers_ownership() {
+    let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
+    let value = SharedValue::new_num(42.0);
+    let mut src = RLookupRow::new();
+    let mut dst = RLookupRow::new();
+    src.write_key(&key, value.clone());
+
+    src.move_dynamic_key_to(&key, &mut dst);
+
+    assert_eq!(src.num_dyn_values(), 0);
+    assert!(src.get(&key).is_none());
+    assert_eq!(dst.get(&key).and_then(|value| value.as_num()), Some(42.0));
+    assert_eq!(SharedValue::refcount(&value), 2);
+}
+
 struct WriteKeyMock<'a> {
     row: RLookupRow<'a>,
     num_resize: usize,


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: GROUPBY copies yielded group keys into the outgoing row, then retains the source values, row allocation, reducer instances, and khash entries until the entire processor is freed.
2. Change: Yielding a group moves its dynamic key values into the outgoing row, releases its reducer state, resets the now-empty row while it is cache-hot, and removes the group from khash. Groups not reached because of an error or partial execution retain fallback cleanup during processor destruction.
3. Outcome: Wide, high-cardinality GROUPBY pipelines avoid key retain/drop churn and a cold end-of-query sweep over consumed group rows.

#### Which additional issues this PR fixes

1. https://redislabs.atlassian.net/browse/MOD-17910

#### Main objects this PR modified

1. GROUPBY result processor — consume finalized group state during yield and remove consumed khash entries.
2. RLookup rows — transfer one dynamic key without reference-count churn.
3. Reducer instances and block allocation — clean yielded groups immediately while preserving fallback cleanup for remaining groups.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

#### Performance validation

The benchmark used 1M HASH documents, three primary shards, two workers per shard, `ON_TIMEOUT RETURN-STRICT`, 10K unique groups with 100 group keys, and `SORTBY @id ASC LIMIT 0 100`. The sorter must consume all 10K groups before applying the final limit.

Applied over the planned reply/RLookup stack (the future-master baseline), exact current #11057 improved paired geometric-mean throughput by **3.78%** with a bootstrap 95% confidence interval of **[+0.67%, +6.97%]**. Median RPS increased from 2.65 to 2.75; median p50 latency fell from 368.895 ms to 354.175 ms, and median p95 fell from 387.583 ms to 369.791 ms. Each build had 12 AC-powered, CPU-pinned samples in a balanced AB/BA order.

An isolated component matrix showed that the benefit requires the combined behavior:

| Variant | Paired RPS vs baseline |
|---|---:|
| Cleanup only | +0.65% [-0.87%, +1.82%] |
| Move only | +1.24% [-0.30%, +2.81%] |
| Move + cleanup | +2.95% [+0.60%, +5.21%] |

Whole-stack perf attribution explains the interaction. Baseline group cleanup accounted for 3.184% of process CPU during final cleanup: 2.213% in `SharedValue` drops and 0.971% in row-vector reset/deallocation. Exact current #11057 performs 0% group cleanup in the final free path and 0.141% while yielding; the entire `Grouper_rpYield` path accounts for 0.387%. Moving avoids retain/drop work, while immediate reset deallocates the now-empty row vector while its group is hot. The gain is therefore not merely `Grouper_rpFree` work moving to another frame.

The result is scoped to wide, high-cardinality GROUPBY pipelines whose downstream processor drains the full group set; it does not establish a general improvement for every GROUPBY query.
