### PR TITLE
[MOD-17913] Deflake the strict-timeout hybrid cursor canary: assert a delta, not zero

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -2241,6 +2241,31 @@ class TestCoordinatorTimeout:
                 blocked_client_id[0] = cid
             return paused and cid is not None, {'paused': paused, 'client_id': cid}
 
+        def shard_cursor_total():
+            # Node-local: INFO MODULES is answered by this shard alone.
+            info = target_shard.execute_command('INFO', 'MODULES')
+            return info['search_global_total_user'] + info['search_global_total_internal']
+
+        def per_index_cursors():
+            # Diagnostic only. NOTE: in a cluster env FT.INFO is answered by the
+            # coordinator and its cursor_stats are summed across shards
+            # (InfoField_WholeSum in src/coord/info_command.c), so these numbers
+            # are cluster-wide and will not match the node-local total above.
+            stats = {}
+            for idx_name in ('idx', 'hybrid_idx'):
+                try:
+                    info = to_dict(target_shard.execute_command('FT.INFO', idx_name))
+                    stats[idx_name] = to_dict(info.get('cursor_stats', []))
+                except Exception as e:
+                    stats[idx_name] = str(e)
+            return stats
+
+        # Baseline for the drop check at the end of the test. The cursor total is
+        # shard-global and this class never clears cursors between tests, so the
+        # cycle's own disposition has to be measured as a delta against whatever
+        # is already parked here rather than against zero.
+        baseline_cursor_total = shard_cursor_total()
+
         before_shard_info = info_modules_to_dict(target_shard)
         try:
             target_shard.execute_command(
@@ -2296,21 +2321,26 @@ class TestCoordinatorTimeout:
         # Once the resumed worker ends the cycle, the teardown drops the
         # published sub-cursors — the reply exposed no IDs, so none may stay
         # parked or leak on the shard.
-        def shard_cursor_total():
-            info = target_shard.execute_command('INFO', 'MODULES')
-            return info['search_global_total_user'] + info['search_global_total_internal']
-        def per_index_cursors():
-            stats = {}
-            for idx_name in ('idx', 'hybrid_idx'):
-                try:
-                    info = to_dict(target_shard.execute_command('FT.INFO', idx_name))
-                    stats[idx_name] = to_dict(info.get('cursor_stats', []))
-                except Exception as e:
-                    stats[idx_name] = str(e)
-            return stats
+        #
+        # Asserted as a delta against the pre-cycle baseline, not against zero:
+        # the count is shard-global, and the fail_timeout_*hybrid tests that run
+        # earlier in this class leave their own published sub-cursors parked on
+        # the healthy shards (MOD-17913 — the timed-out coordinator aborts its
+        # reads without draining them). Those only expire at CURSOR_MAX_IDLE,
+        # 300s by default, so an absolute-zero check cannot pass inside this
+        # wait no matter what this cycle does.
         def cursors_drained():
             total = shard_cursor_total()
-            return total == 0, {'user+internal': total, 'per_index': per_index_cursors()}
+            # '<=' rather than '==': an unrelated cursor parked before this test
+            # may cross its idle deadline mid-wait and take the total below the
+            # baseline. Only growth means this cycle failed to drop its own.
+            ok = total <= baseline_cursor_total
+            return ok, {
+                'node_local_total': total,
+                'node_local_baseline': baseline_cursor_total,
+                'node_local_delta': total - baseline_cursor_total,
+                'cluster_wide_per_index': per_index_cursors(),
+            }
         wait_for_condition(cursors_drained,
                            'strict-timed-out cycle did not drop its published cursors')
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `TestCoordinatorTimeout.test_return_strict_timeout_replies_existing_hybrid_cursor_mapping` waits for the shard's cursor total to reach **zero** after a strict-timed-out `_FT.HYBRID` cycle. That total is shard-global and the class never clears cursors between tests, so the check measures the whole 150-test class, not the cycle under test. Nine `test_fail_timeout_*hybrid*` tests run earlier (alphabetically `fail` precedes `return`) and leave their own published sub-cursors parked on the healthy shards; those are only reclaimed at `CURSOR_MAX_IDLE` (300 s, `src/config.h:363`) while the canary waits 120 s. It therefore cannot pass inside its own window regardless of what the cycle does, and has failed on every platform running the coordinator suite, on every Periodic Master Validation run, since #10745 landed (~30 consecutive runs).
2. **Change:** Take a baseline of the node-local cursor total before the cycle and assert the total returns to at most that baseline, instead of to zero. Also label the failure payload by scope — it previously printed a node-local `INFO MODULES` total next to `FT.INFO cursor_stats`, which the coordinator sums across shards (`InfoField_WholeSum`, `src/coord/info_command.c`), so the two could never agree and read as an accounting bug.
3. **Outcome:** Internal-only (test) change. Unblocks Periodic Master Validation, which is currently red on this single assertion, while keeping what the canary was for: a cycle whose reply exposed no IDs must not leave its sub-cursors behind, which still shows up as **growth over the baseline**.

#### Which additional issues this PR fixes

1. MOD-17913

#### Main objects this PR modified

1. `tests/pytests/test_blocked_client_timeout.py` — `TestCoordinatorTimeout.test_return_strict_timeout_replies_existing_hybrid_cursor_mapping`: the end-of-test cursor-drop canary is now a delta against a pre-cycle baseline rather than an absolute-zero check.
2. Same test — `shard_cursor_total()` / `per_index_cursors()` hoisted above the cycle so the baseline can be taken before any of this test's cursors exist; both now carry a comment stating their scope (node-local vs coordinator-aggregated).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

## Background

`<=` rather than `==` because a cursor parked before this test may cross its 300 s idle deadline mid-wait and take the total *below* the baseline; only growth means this cycle failed to drop its own.

The observed payload confirms the residue belongs to other tests — every lingering cursor is *parked*, and all of them are on the hybrid index:

```
{'user+internal': 8,
 'idx':        {global_idle: 20, global_total: 20, index_total: 0},
 'hybrid_idx': {global_idle: 20, global_total: 20, index_total: 20}}
```

`global_idle == global_total` (nothing active) with `idx.index_total == 0`. And `index_capacity: 384` = 128 × 3 shards is the tell for the cross-shard aggregation behind the misleading `8` vs `20`.

This was known at merge time — #10745's commit message says: *"Note a pre-existing flake this exposes: the fail_timeout\*hybrid tests leave the healthy shards' published sub-cursors parked ... and when they outlive this canary's 120s wait the canary fails. Reproduced identically on the pre-change baseline."*

## Verifying this

⚠️ **The test is currently flaky-marked on `master`** (run [32625858108](https://github.com/RediSearch/RediSearch/actions/runs/32625858108), expires 2026-09-22), set to unblock master validation. The mark is applied at test-*selection* time — `flaky_db.py filter` builds a TESTFILE with marked tests removed — so **this PR's own CI will not run the test this PR fixes.** To validate, unmark via `task-flaky-unmark.yml` first, or use the resolve-step override.

I have **not** run the suite locally — it needs a build plus a 3-shard cluster, and the coordinator suite takes ~1h in CI. The diagnosis is from CI logs and source inspection. Please treat CI-with-the-mark-lifted as the real gate.

## Scope / what this does not do

This deflakes the test. It does **not** fix the underlying bug it was tripping over: under `ON_TIMEOUT FAIL`, a timed-out `FT.HYBRID` leaves published sub-cursors parked on the healthy shards for up to 5 minutes, consuming per-index cursor capacity (128 per index per shard). That is a real pre-existing leak in a customer-visible path and stays open on MOD-17913.

A stronger alternative would be to clear cursors in the class's `setUp`/`tearDown` so a global assertion becomes meaningful again. I didn't take it: it changes shared fixture behaviour for all 150 tests in the class and could mask genuine leaks in the others — that's a call for the owning team.

Known limitation of the delta approach: if an earlier parked cursor expires mid-wait by exactly the amount this cycle leaks, the offset could mask a small leak. There's no per-cycle cursor accounting exposed to test against, so a delta is the practical option; flagging it rather than claiming it's airtight.

Jira: [MOD-17913](https://redislabs.atlassian.net/browse/MOD-17913)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-17913]: https://redislabs.atlassian.net/browse/MOD-17913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ