### PR TITLE
[2.10] [MOD-15023] Re-skip flaky test_pending_jobs_metrics_search

### DIFF
--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1450,12 +1450,9 @@ def _test_pending_jobs_metrics(env, command_type):
 
     wait_for_condition(check_reset_metrics, "wait_for_workers_pending_jobs_metric_reset")
 
-# MOD-15023: the previous skip_until("2026-07-01") lapsed, and this test went back to
-# failing intermittently in cluster mode (wait_for_high_priority_jobs_pending times out
-# when the fanout does not queue num_queries high-priority jobs on every shard).
-# Master only carries diagnostics for this flake (#9344), not a fix, and those were never
-# backported here. Keep it skipped on 2.10 until the root cause is fixed on master and
-# backported.
+# MOD-15023: flaky in cluster mode - one of the num_queries queries is lost before fanout,
+# so wait_for_high_priority_jobs_pending times out. Not fixed on master (#9344 only added
+# diagnostics), so keep it skipped until the root cause is fixed there and backported.
 @skip_until("2027-01-01", reason="Flaky test, see MOD-15023")
 def test_pending_jobs_metrics_search():
   env = Env(moduleArgs='DEFAULT_DIALECT 2')

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1450,7 +1450,13 @@ def _test_pending_jobs_metrics(env, command_type):
 
     wait_for_condition(check_reset_metrics, "wait_for_workers_pending_jobs_metric_reset")
 
-@skip_until("2026-07-01", reason="Flaky test, see MOD-15023")
+# MOD-15023: the previous skip_until("2026-07-01") lapsed, and this test went back to
+# failing intermittently in cluster mode (wait_for_high_priority_jobs_pending times out
+# when the fanout does not queue num_queries high-priority jobs on every shard).
+# Master only carries diagnostics for this flake (#9344), not a fix, and those were never
+# backported here. Keep it skipped on 2.10 until the root cause is fixed on master and
+# backported.
+@skip_until("2027-01-01", reason="Flaky test, see MOD-15023")
 def test_pending_jobs_metrics_search():
   env = Env(moduleArgs='DEFAULT_DIALECT 2')
   _test_pending_jobs_metrics(env, 'SEARCH')


### PR DESCRIPTION
**Describe the changes in the pull request**

1. **Current state** — `test_info_modules:test_pending_jobs_metrics_search` was muted on `2.10` by #9277 with `@skip_until("2026-07-01", reason="Flaky test, see MOD-15023")`. `skip_until` only raises `SkipTest` while `today < date`, so that mute silently lapsed on **2026-07-01** and the known-flaky test has been running again on `2.10` ever since.
2. **What is the change** — extend the skip to `2027-01-01` and add a comment recording why it is still skipped and what has to happen before it is removed.
3. **Outcome** — the test is skipped again on `2.10`, so it stops taking down merge-queue validations, and the next expiry is far enough out to allow a real fix instead of another quick re-mute.

**Why not just remove the skip / fix it here**

MOD-15023 is **not fixed on master**. #9344 (`MOD-12831 MOD-15023 MOD-15103: improve diagnostics for flaky test_pending_jobs_metrics`) *removed* the skip on master and added diagnostics only — no `src/` change exists for MOD-15023, MOD-15103, MOD-12831 or MOD-13322. Those diagnostics were never backported, so `2.10` currently runs the flake with strictly less observability than master. The intent here is to keep `2.10` quiet until the root cause is found and fixed on master and then backported.

**Most recent occurrence**

Run [32579834323](https://github.com/RediSearch/RediSearch/actions/runs/32579834323/job/97047467131) — merge-queue validation of #10805, job *Test Amazon Linux 2023 ARM64, Redis 7.4.11*. Only `Flow tests (coordinator)` failed (`COORD=1` → `--env oss-cluster --shards-count 3`); the standalone run of the same test passed on the same job. The failure is `wait_for_high_priority_jobs_pending` timing out: the test pauses the worker pool, fires `num_queries = 3` background `FT.SEARCH`, then requires `search_workers_high_priority_pending_jobs == 3` on *every* shard within 120s. The same PR passed the identical job on 2026-08-20 and again on 2026-08-23, so it is timing-dependent, not deterministic.

**Which issues this PR fixes**
1. MOD-15023 (mitigates on `2.10`; does not fix the underlying race)

**Main objects this PR modified**
1. `tests/pytests/test_info_modules.py` — `test_pending_jobs_metrics_search` skip date

**Note / follow-ups (not in this PR)**

- `test_pending_jobs_metrics_aggregate` runs the same `_test_pending_jobs_metrics` helper and is **not** skipped on `2.10`, so it is exposed to the same race.
- Backporting #9344's diagnostics to `2.10` would make the next occurrence diagnosable. Master's other hardening (`allShards_set_info_on_zero_indexes`) is not backportable — `2.10` has no such config.
- On the failure path the test never reaches STEP 7's `WORKERS RESUME`, so shards are left with a paused worker pool, which can cascade into later tests in the same env.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
