### PR TITLE
[8.8] fix: make tarball-installed LLVM usable from fresh shells (bootstrap → `make build LTO=1`)

### DIFF
--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -54,7 +54,51 @@ install_from_tarball() {
     rm -rf "$tmpdir"
 
     export_path_gha
+    link_tools_for_fresh_shells
     echo ">>> LLVM ${LLVM_FULL_VER} installed to ${INSTALL_DIR}"
+}
+
+# Fresh-shell usability for the tarball install: export_path_gha only covers
+# GitHub Actions steps (via $GITHUB_PATH/$GITHUB_ENV) and the shell that ran
+# this script. A user following the manual flow — `make bootstrap` now,
+# `make build LTO=1` from a later shell — has no ${INSTALL_DIR}/bin on PATH,
+# so build.sh cannot find clang-${LLVM_VER} and LTO refuses to enable. The
+# package-manager install paths don't have this problem (they land versioned
+# binaries in /usr/bin), so mirror that: symlink the tools build.sh looks up
+# — and llvm-config, through which bindgen's clang-sys locates libclang
+# (`llvm-config --libdir`) without needing a persisted LIBCLANG_PATH — into
+# /usr/local/bin, which is on the default PATH of every supported distro.
+# Same pattern rocky_linux_8.sh uses for its gcc-toolset shims.
+link_tools_for_fresh_shells() {
+    local bindir="${INSTALL_DIR}/bin"
+    local destdir="/usr/local/bin"
+    local tool target
+
+    if ! $MODE mkdir -p "$destdir"; then
+        echo "ERROR: cannot create ${destdir}; rerun with sudo or add ${bindir} to PATH manually" >&2
+        return 1
+    fi
+
+    # ld.lld-${LLVM_VER} matters beyond fresh shells: once lld-${LLVM_VER} is
+    # on PATH, build.sh links with -fuse-ld=lld-${LLVM_VER}, and clang
+    # resolves that name by looking for an executable literally called
+    # ld.lld-${LLVM_VER} — distro packages ship one, the tarball only ships
+    # unversioned ld.lld.
+    for tool in "clang-${LLVM_VER}" "clang++-${LLVM_VER}" "lld-${LLVM_VER}" "ld.lld-${LLVM_VER}" ld.lld llvm-config; do
+        # The tarball ships some of these only under their unversioned
+        # names; resolve to whichever exists.
+        target="${bindir}/${tool}"
+        [[ -e "$target" ]] || target="${bindir}/${tool%-${LLVM_VER}}"
+        if [[ ! -e "$target" ]]; then
+            echo "ERROR: expected LLVM tool '${tool}' not found under ${bindir}" >&2
+            return 1
+        fi
+
+        if ! $MODE ln -sf "$target" "${destdir}/${tool}"; then
+            echo "ERROR: failed to link ${destdir}/${tool} -> ${target}" >&2
+            return 1
+        fi
+    done
 }
 
 # Wire up $INSTALL_DIR/bin for GitHub Actions and the current shell.
@@ -123,8 +167,12 @@ install_llvm() {
         apt_get_cmd "$MODE" update -qq
 
         # 1) Try native distro packages first (e.g. Ubuntu 26.04 ships clang-21).
+        # llvm-${LLVM_VER} supplies llvm-ar/llvm-ranlib, which CMake's IPO
+        # (LTO) archive rules need; with --no-install-recommends
+        # clang-${LLVM_VER} doesn't pull it in.
         if apt_get_cmd "$MODE" install -y --no-install-recommends \
-                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "libclang-${LLVM_VER}-dev" 2>/dev/null; then
+                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "libclang-${LLVM_VER}-dev" \
+                "llvm-${LLVM_VER}" 2>/dev/null; then
             echo ">>> Installed clang-${LLVM_VER} from native apt repos"
         else
             # 2) Fall back to apt.llvm.org third-party repo.

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -2,7 +2,21 @@
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
 
-$MODE tdnf install -yq build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
+# tdnf intermittently fails on Azure Linux mirrors with
+# "TDNFVerifySignature 2004" / "Failed to synchronize cache". Retry, and
+# within each attempt fall back to skipping the repo-metadata GPG plugin
+# (per-package GPG checks still apply).
+tdnf_install() {
+    local i
+    for i in 1 2 3; do
+        $MODE tdnf install -y "$@" && return 0
+        $MODE tdnf --disableplugin=tdnfrepogpgcheck install -y "$@" && return 0
+        [ "$i" -lt 3 ] && sleep 10
+    done
+    return 1
+}
+
+tdnf_install -q build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
 
 # Install LLVM for LTO
 source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
@@ -11,5 +25,5 @@ source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
 # source, since it only started providing wheels for aarch64
 # in version 6.w.z.
 if [ "$(uname -m)" = "aarch64" ]; then
-    $MODE tdnf install -y python3-devel
+    tdnf_install python3-devel
 fi

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -16,7 +16,7 @@ $MODE dnf install epel-release -yqq
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
     gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync \
-    clang curl clang-devel gdb --nobest --skip-broken
+    clang curl clang-devel lld gdb --nobest --skip-broken
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/build.sh
+++ b/build.sh
@@ -360,6 +360,21 @@ prepare_cmake_arguments() {
   # Initialize with base arguments
   CMAKE_BASIC_ARGS="-DCOORD_TYPE=$COORD"
 
+  # A reused build directory keeps the LTO configuration it was created with:
+  # the CMake cache retains CMAKE_INTERPROCEDURAL_OPTIMIZATION=true and the
+  # static libraries already built from it contain LLVM bitcode, which
+  # non-LTO consumers reject at link time (the Rust test binaries linking
+  # libredisearch_all.a through the default cc/bfd linker fail with
+  # "file format not recognized"). Inherit LTO from the cache so a re-drive
+  # without the LTO argument (e.g. `make test` after an LTO `make build`)
+  # keeps the matching clang/lld toolchain. FORCE wipes the directory in
+  # run_cmake(), so a forced clean build is exempt.
+  if [[ "$LTO" != "1" && "$FORCE" != "1" && -f "$BINDIR/CMakeCache.txt" ]] && \
+      grep -qE '^CMAKE_INTERPROCEDURAL_OPTIMIZATION:[^=]*=(true|TRUE|ON|1)$' "$BINDIR/CMakeCache.txt"; then
+    echo "Reusing LTO-configured build directory: enabling LTO"
+    LTO=1
+  fi
+
   if [[ "$LTO" == "1" ]]; then
     # LTO is only supported on Linux
     if [[ "$OS_NAME" != "linux" ]]; then
@@ -514,8 +529,13 @@ prepare_cmake_arguments() {
     # Pass LTO C/CXX flags to CMake via CFLAGS/CXXFLAGS env vars so CMake picks them
     # up without word-splitting issues.
     # Note: we assume there are no spaces in system C++ include paths.
-    export CFLAGS="${CFLAGS:+${CFLAGS} }${GCC_COMMON_FLAGS}"
-    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
+    # The environment may carry GCC-only -W options (e.g. CI exports
+    # -Wno-error=maybe-uninitialized for the gcc-built redis core). This
+    # branch always compiles with clang, which flags those as
+    # -Wunknown-warning-option — a hard error in vendored targets that add
+    # -Werror (e.g. VectorSimilarity spaces). Silence that diagnostic.
+    export CFLAGS="${CFLAGS:+${CFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}"
+    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
     # Export CC/CXX so that Rust's cc crate also uses clang, matching the
     # clang-specific flags in CFLAGS/CXXFLAGS (e.g. --gcc-install-dir).
     export CC="$C_COMPILER"


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #10373 to `8.8`.

1. **Current:** `install_llvm.sh`'s tarball fallback unpacks LLVM into `/usr/local/llvm` and puts that on `PATH` only via `$GITHUB_PATH` and the shell that ran the script. On `8.8` this breaks CI, not just the manual bootstrap flow: the `Dockerfile` sets `ENV PATH="/usr/local/llvm/bin:…"`, but Debian's `/etc/profile` unconditionally rewrites `PATH` for root, so every `bash -l` step in `task-test.yml` loses it. Whenever the bookworm/trixie image build falls back from apt.llvm.org to the tarball, the test job's `make build` dies instantly:

   ```
   build.sh: line 426: clang: command not found
   Error: Could not detect LLVM versions for rustc and clang.
   Rust LLVM version: 21
   Clang LLVM version:
   make: *** [Makefile:219: build] Error 1
   ```

   That is exactly what took down the merge-queue run for #10799 — [`debian:bookworm (aarch64)` in run 32579897595](https://github.com/RediSearch/RediSearch/actions/runs/32579897595/job/97051205279), where the [image build log](https://github.com/RediSearch/RediSearch/actions/runs/32579897595/job/97049565784) shows `>>> apt.llvm.org failed — falling back to official tarball` followed by a successful install to `/usr/local/llvm`. `fail-fast` then cancelled the rest of the matrix. `master` has been immune since #10373.

2. **Change:** cherry-pick #10373. `link_tools_for_fresh_shells()` symlinks the tools `build.sh` looks up (`clang-$VER`, `clang++-$VER`, `lld-$VER`, `ld.lld-$VER`, `ld.lld`) plus `llvm-config` into `/usr/local/bin`, which survives the `/etc/profile` reset on every supported distro. Also carried over from the original PR: `llvm-$VER` on the apt native path (`llvm-ar`/`llvm-ranlib` for CMake's IPO archive rules), `lld` on Rocky 8, a tdnf retry/`repogpgcheck` fallback on Azure Linux, and two `build.sh` LTO fixes (`-Wno-unknown-warning-option` in the clang branch; inherit `LTO=1` when reusing a build dir whose CMake cache has IPO enabled).

3. **Outcome:** the tarball fallback no longer leaves clang invisible to login shells, so a bookworm/trixie image built without apt.llvm.org still builds with `LTO=1`, and `make bootstrap` → `make build LTO=1` from a fresh shell works on the tarball distros.

## Original PR

- Title: fix: make tarball-installed LLVM usable from fresh shells (bootstrap → `make build LTO=1`)
- Link: #10373
- Merge commit: `543b79b0f3b261803f4febbd350ce6c0661d6770`

## Changes from original

One hunk dropped: **`.install/alpine_linux_3.sh`**. Upstream it edits the static-LLVM / bindgen-static block (`ar rcT` thin archive → `GROUP()` linker script, plus `compiler-rt`). That block does not exist on `8.8` — alpine here installs LLVM through apk and has no bindgen-static musl target to serve — so there is nothing for the hunk to apply to. Pulling the block in would add unrelated `master`-only surface. The other four files cherry-picked cleanly.

#### Which additional issues this PR fixes
1. Merge-queue failure on `8.8` when the Debian CI image falls back to the LLVM tarball (run 32579897595).

#### Main objects this PR modified
1. `.install/install_llvm.sh` — `link_tools_for_fresh_shells()`; `llvm-$VER` on the apt native path
2. `build.sh` — `-Wno-unknown-warning-option` in the LTO branch; inherit `LTO=1` from an IPO-enabled CMake cache
3. `.install/rocky_linux_8.sh` — install `lld`
4. `.install/microsoft_azure_linux_3.0.sh` — tdnf retry with `repogpgcheck` fallback

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Build/CI tooling only; no user-visible change.

## Validation

- `bash -n` clean on all four changed files (`build.sh` under `-O extglob`).
- Verified the `8.8` preconditions the fix depends on: `build.sh` links with `-fuse-ld=$LINKER` where `LINKER=lld-$VER` (so the `ld.lld-$VER` symlink is required here too), `BINDIR`/`FORCE` are set before `prepare_cmake_arguments` runs, and `libredisearch_all.a` is still the bundle name the new comment cites.
- Not exercised locally: the tarball path is Linux-only and the failure mode needs apt.llvm.org to be down, so CI on this PR will take the apt path and won't reproduce the original break. The `/usr/local/bin` symlinks have been live on `master` since #10373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
