### PR TITLE
[MOD-17995] CONTRIBUTING: state the pointer policy per side of the FFI boundary

### DIFF
--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -2,7 +2,17 @@
 
 ## General Guidelines
 
-- `Option<NonNull<T>>` over `*mut T` especially in FFI signatures
+- Pointers are shaped by which side of the boundary the crate is on:
+  - `extern "C"` signatures in `c_entrypoint/*_ffi` take raw `*const T` / `*mut T`.
+    Convert on entry (`NonNull::new`, `as_ref`) and state the null contract in the
+    `# Safety` doc, so the generated C prototype keeps its `const` qualifiers and
+    matches the Rust signature one-to-one.
+  - Pure Rust crates use references, `NonNull<T>`, or `Option<NonNull<T>>` in their
+    public APIs, never raw pointers — except for `as_ptr` / `into_raw` / `from_raw`
+    style conversions, which follow the `std` convention, and `extern "C"` callbacks,
+    which are FFI signatures wherever they live.
+  - `c_wrappers/*` are exempt: they mirror C structs, so raw pointer accessors and
+    setters are the interface.
 - Safety Comments: Number invariants in the safety doc comment and refer to these invariants in your safety in-line comments throughout that function.
 - debug_assert invariants in FFI functions
 - RediSearch deals with potentially invalid UTF-8 strings so **never assume** `str` /`String` are fine for user input. Prefer `[u8]`, `Vec<u8>`, `CStr`, or `CString`.

--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -9,8 +9,10 @@
     matches the Rust signature one-to-one.
   - Pure Rust crates use references, `NonNull<T>`, or `Option<NonNull<T>>` in their
     public APIs, never raw pointers — except for `as_ptr` / `into_raw` / `from_raw`
-    style conversions, which follow the `std` convention, and `extern "C"` callbacks,
-    which are FFI signatures wherever they live.
+    style conversions, which follow the `std` convention; `extern "C"` callbacks,
+    which are FFI signatures wherever they live; and the fields of `#[repr(C)]` types
+    that mirror a C layout or are exported by cheadergen, which keep raw pointers so
+    the generated header keeps the pointee qualifiers.
   - `c_wrappers/*` are exempt: they mirror C structs, so raw pointer accessors and
     setters are the interface.
 - Safety Comments: Number invariants in the safety doc comment and refer to these invariants in your safety in-line comments throughout that function.


### PR DESCRIPTION
Update `CONTRIBUTING.md` as per our discussion in internal sync a couple weeks ago. I also have a couple of follow-up PRs doing the mechanical cleanup.

## Describe the changes in the pull request

1. Current: `src/redisearch_rs/CONTRIBUTING.md` states a single blanket preference for `Option<NonNull<T>>` over `*mut T`, "especially in FFI signatures". That is the opposite of what the FFI layer can actually express: `cheadergen` cannot emit a `const`-qualified C parameter from a `NonNull`, and `extern "C"` signatures and function-pointer fields have to mirror the C ABI verbatim.
2. Change: Split the rule by side of the boundary. Raw pointers at the `extern "C"` surface of `c_entrypoint/*_ffi`, in fn-pointer fields, and in `#[repr(C)]` C-layout mirrors; `NonNull`/`Option<NonNull>` in pure Rust crates, except at `as_ptr`/`into_raw`/`from_raw` and in `extern "C"` callbacks. `c_wrappers/*` stays exempt.
3. Outcome: Internal-only, docs only. Removes a guideline that contradicts what the header generator supports, so the two follow-up PRs in this stack have a rule to point at.

#### Which additional issues this PR fixes

1. MOD-17995

#### Main objects this PR modified

- `src/redisearch_rs/CONTRIBUTING.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

