### PR TITLE
redisearch_rs: carry the non-null pointer contract in the type

### DIFF
--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -2,7 +2,17 @@
 
 ## General Guidelines
 
-- `Option<NonNull<T>>` over `*mut T` especially in FFI signatures
+- Pointers are shaped by which side of the boundary the crate is on:
+  - `extern "C"` signatures in `c_entrypoint/*_ffi` take raw `*const T` / `*mut T`.
+    Convert on entry (`NonNull::new`, `as_ref`) and state the null contract in the
+    `# Safety` doc, so the generated C prototype keeps its `const` qualifiers and
+    matches the Rust signature one-to-one.
+  - Pure Rust crates use references, `NonNull<T>`, or `Option<NonNull<T>>` in their
+    public APIs, never raw pointers — except for `as_ptr` / `into_raw` / `from_raw`
+    style conversions, which follow the `std` convention, and `extern "C"` callbacks,
+    which are FFI signatures wherever they live.
+  - `c_wrappers/*` are exempt: they mirror C structs, so raw pointer accessors and
+    setters are the interface.
 - Safety Comments: Number invariants in the safety doc comment and refer to these invariants in your safety in-line comments throughout that function.
 - debug_assert invariants in FFI functions
 - RediSearch deals with potentially invalid UTF-8 strings so **never assume** `str` /`String` are fine for user input. Prefer `[u8]`, `Vec<u8>`, `CStr`, or `CString`.

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     io_result_ext::IoResultExt,
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -38,7 +39,7 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -66,7 +67,7 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_existing_docs(fgc), "existing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -18,6 +18,7 @@
 use std::{
     ffi::{c_char, c_int, c_void},
     io::{Read, Write},
+    ptr::NonNull,
 };
 
 use fork_gc::{ForkGC, Frame, io_result_ext::IoResultExt};
@@ -69,7 +70,7 @@ pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_voi
     debug_assert!(len > 0, "buffer length cannot be 0");
 
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let slice = unsafe { std::slice::from_raw_parts(buff.cast::<u8>(), len) };
 
@@ -92,7 +93,7 @@ pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_voi
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_void, len: usize) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     let slice = if len > 0 {
         // SAFETY: caller guarantees (2).
@@ -119,7 +120,7 @@ pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_vo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendTerminator(fgc: *mut ffi::ForkGC) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     Frame::Terminator.encode(&mut fgc.writer()).unwrap_or_exit();
 }
@@ -142,7 +143,7 @@ pub unsafe extern "C" fn FGC_recvFixed(
     len: usize,
 ) -> c_int {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let slice = unsafe { std::slice::from_raw_parts_mut(buf.cast::<u8>(), len) };
 
@@ -182,7 +183,7 @@ pub unsafe extern "C" fn FGC_recvBuffer(
     len: *mut usize,
 ) -> c_int {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     let frame = match Frame::decode_nul_terminated(&mut fgc.reader()) {
         Ok(frame) => frame,
@@ -225,7 +226,7 @@ pub unsafe extern "C" fn recvFieldHeader(
     id_ptr: *mut u64,
 ) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     let mut reader = fgc.reader();
 
     let frame = match Frame::decode_nul_terminated(&mut reader) {

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     missing_docs::{collect_missing_docs, handle_missing_docs},
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -39,7 +40,7 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -69,7 +70,7 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_missing_docs(fgc), "missing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     numeric::{collect_numeric, handle_numeric},
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -39,7 +40,7 @@ pub unsafe extern "C" fn FGC_childCollectNumeric(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -69,7 +70,7 @@ pub unsafe extern "C" fn FGC_childCollectNumeric(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleNumeric(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_numeric(fgc), "numeric")
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
@@ -14,6 +14,7 @@
 //! the iterator runs on its first read.
 
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
 use ffi::QueryIterator;
 use index_result::RSIndexResult;
@@ -87,20 +88,17 @@ unsafe fn c_producer(
         let results = unsafe { (produce)(guard.ctx) };
         // Take ownership of any arrays the producer handed back *before* inspecting `timed_out`, so
         // they are freed even on the timeout path (where the iterator drops these `OwnedSlice`s).
-        let ids = if results.ids.is_null() {
-            OwnedSlice::default()
-        } else {
+        let ids = match NonNull::new(results.ids) {
             // SAFETY: the producer guarantees `ids` points to `num` initialized `DocId`s
             // allocated with the Redis allocator, and transfers ownership to us.
-            unsafe { OwnedSlice::from_c(results.ids, results.num) }
+            Some(ids) => unsafe { OwnedSlice::from_c(ids, results.num) },
+            None => OwnedSlice::default(),
         };
-        let metrics = if results.metrics.is_null() {
-            None
-        } else {
+        let metrics = NonNull::new(results.metrics).map(|metrics| {
             // SAFETY: the producer guarantees `metrics` points to `num` initialized `f64`s
             // allocated with the Redis allocator, and transfers ownership to us.
-            Some(unsafe { OwnedSlice::from_c(results.metrics, results.num) })
-        };
+            unsafe { OwnedSlice::from_c(metrics, results.num) }
+        });
         if results.timed_out {
             // `ids`/`metrics` drop here, freeing anything the producer allocated alongside the flag.
             return Err(RQEIteratorError::TimedOut);
@@ -144,19 +142,23 @@ pub unsafe extern "C" fn NewLazyVectorRangeIterator(
     match (yields_metric, sorted_by_id) {
         (true, true) => {
             RQEIteratorWrapper::boxed_new(MetricLazy::<true>::new(producer, num_estimated, type_))
+                .as_ptr()
         }
         (true, false) => {
             RQEIteratorWrapper::boxed_new(MetricLazy::<false>::new(producer, num_estimated, type_))
+                .as_ptr()
         }
         (false, true) => RQEIteratorWrapper::boxed_new(IdListLazy::<true>::new(
             producer,
             num_estimated,
             RSIndexResult::build_virt().weight(1.0).build(),
-        )),
+        ))
+        .as_ptr(),
         (false, false) => RQEIteratorWrapper::boxed_new(IdListLazy::<false>::new(
             producer,
             num_estimated,
             RSIndexResult::build_virt().weight(1.0).build(),
-        )),
+        ))
+        .as_ptr(),
     }
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/empty.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/empty.rs
@@ -14,5 +14,5 @@ use rqe_iterators::interop::RQEIteratorWrapper;
 #[unsafe(no_mangle)]
 /// Creates a new empty iterator.
 pub extern "C" fn NewEmptyIterator() -> *mut QueryIterator {
-    RQEIteratorWrapper::boxed_new(Empty)
+    RQEIteratorWrapper::boxed_new(Empty).as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn NewGeometryQueryIterator(
     // deadline never overlap a probe (see `TimeoutContextDeadline::new`).
     let timeout_ctx = unsafe { AnyTimeoutContext::from_sctx(sctx_nn, TIMEOUT_CHECK_GRANULARITY) };
 
-    let ids_list = if !ids.is_null() {
+    let ids_list = if let Some(ids) = NonNull::new(ids) {
         // SAFETY: precondition 3.
         unsafe { OwnedSlice::from_c(ids, num) }
     } else {
@@ -140,12 +140,14 @@ pub unsafe extern "C" fn NewGeometryQueryIterator(
                 expiration_checker,
                 mem_tracker,
             ))
+            .as_ptr()
         }
         None => RQEIteratorWrapper::boxed_new(GeoShape::new(
             ids_list,
             timeout_ctx,
             expiration_checker,
             NoTracker,
-        )),
+        ))
+        .as_ptr(),
     }
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use ffi::QueryIterator;
 use index_result::RSIndexResult;
 use rqe_core::DocId;
@@ -61,7 +63,7 @@ unsafe fn new_id_list_iterator<const SORTED: bool>(
     num: u64,
     weight: f64,
 ) -> *mut QueryIterator {
-    let ids_list = if !ids.is_null() {
+    let ids_list = if let Some(ids) = NonNull::new(ids) {
         // SAFETY: Safe thanks to 1
         unsafe { OwnedSlice::from_c(ids, num as usize) }
     } else {
@@ -77,4 +79,5 @@ unsafe fn new_id_list_iterator<const SORTED: bool>(
         ids_list,
         RSIndexResult::build_virt().weight(weight).build(),
     ))
+    .as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -133,7 +133,9 @@ pub unsafe extern "C" fn AddIntersectionIteratorChild(
     header: *mut QueryIterator,
     child: *mut QueryIterator,
 ) {
-    let header = NonNull::new(header).expect("`header` must not be null");
+    debug_assert!(!header.is_null());
+    // SAFETY: `header` is non-null per 1.
+    let header = unsafe { NonNull::new_unchecked(header) };
     debug_assert_eq!(
         // SAFETY: safe thanks to 1
         unsafe { header.as_ref().type_ },

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn NewIntersectionIterator(
                 max_slop,
                 in_order,
             );
-            RQEIteratorWrapper::boxed_new_compound(intersection)
+            RQEIteratorWrapper::boxed_new_compound(intersection).as_ptr()
         }
     };
 
@@ -133,10 +133,10 @@ pub unsafe extern "C" fn AddIntersectionIteratorChild(
     header: *mut QueryIterator,
     child: *mut QueryIterator,
 ) {
-    debug_assert!(!header.is_null());
+    let header = NonNull::new(header).expect("`header` must not be null");
     debug_assert_eq!(
         // SAFETY: safe thanks to 1
-        unsafe { (*header).type_ },
+        unsafe { header.as_ref().type_ },
         IteratorType::Intersect,
         "Expected an INTERSECT_ITERATOR"
     );

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -62,5 +62,5 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn GeoFilter_FreeNumericFilters(filters: *mut *mut ffi::NumericFilter) {
     // SAFETY: the safety contract is forwarded to `free_geo_numeric_filters`.
-    unsafe { free_geo_numeric_filters(filters.cast()) };
+    unsafe { free_geo_numeric_filters(NonNull::new(filters.cast())) };
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -55,5 +55,5 @@ pub unsafe extern "C" fn NewInvIndIterator_MissingQuery(
     // SAFETY: 3.-6. guarantee sctx, spec, field_index, and
     // missingFieldDict validity.
     let it = unsafe { new_missing_iterator(ii_ref, sctx_nn, field_index) };
-    RQEIteratorWrapper::boxed_new(it)
+    RQEIteratorWrapper::boxed_new(it).as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -260,7 +260,7 @@ pub unsafe extern "C" fn NewInvIndIterator_TagQuery(
         ),
     };
 
-    RQEIteratorWrapper::boxed_new(iterator)
+    RQEIteratorWrapper::boxed_new(iterator).as_ptr()
 }
 
 impl profile_print::ProfilePrint for TagIterator<'_> {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -51,7 +51,9 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     debug_assert!(!sctx.is_null(), "sctx must not be null");
     debug_assert!(!term.is_null(), "term must not be null");
 
-    let idx = NonNull::new(idx.cast_mut()).expect("`idx` must not be null");
+    debug_assert!(!idx.is_null(), "idx must not be null");
+    // SAFETY: 1. guarantees `idx` is valid and non-null.
+    let idx = unsafe { NonNull::new_unchecked(idx.cast_mut()) };
     // SAFETY: 3. guarantees `sctx` is valid and non-null.
     let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -48,10 +48,10 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     term: *mut RSQueryTerm,
     weight: f64,
 ) -> *mut ffi::QueryIterator {
-    debug_assert!(!idx.is_null(), "idx must not be null");
     debug_assert!(!sctx.is_null(), "sctx must not be null");
     debug_assert!(!term.is_null(), "term must not be null");
 
+    let idx = NonNull::new(idx.cast_mut()).expect("`idx` must not be null");
     // SAFETY: 3. guarantees `sctx` is valid and non-null.
     let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 
@@ -64,5 +64,5 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     // `term`.
     let iterator = unsafe { build_term_iterator(idx, sctx, field_mask_or_index, term, weight) };
 
-    RQEIteratorWrapper::boxed_new(iterator)
+    RQEIteratorWrapper::boxed_new(iterator).as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -182,5 +182,5 @@ pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery(
         ),
     };
 
-    RQEIteratorWrapper::boxed_new(iterator)
+    RQEIteratorWrapper::boxed_new(iterator).as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -86,6 +86,8 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
             "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null."
         );
 
+        let ids = NonNull::new(ids).expect("`ids` must not be null");
+        let metrics = NonNull::new(metrics).expect("`metrics` must not be null");
         // SAFETY: Safe thanks to 1.
         let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
         // SAFETY: Safe thanks to 2.
@@ -94,7 +96,7 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
         (ids_list, metrics_list)
     };
 
-    RQEIteratorWrapper::boxed_new(Metric::<SORTED_BY_ID>::new(ids_list, metrics_list))
+    RQEIteratorWrapper::boxed_new(Metric::<SORTED_BY_ID>::new(ids_list, metrics_list)).as_ptr()
 }
 
 /// Sets the [`RLookupKeyHandle`] for this metric iterator.
@@ -117,7 +119,7 @@ pub unsafe extern "C" fn SetMetricRLookupHandle(
 
     // SAFETY: 1 + 2 give the callee its live iterator, 3 its exclusive access,
     // and 4 the handle that outlasts the iterator writing through it.
-    unsafe { metric::set_key_handle(header, key_handle) };
+    unsafe { metric::set_key_handle(header, NonNull::new(key_handle)) };
 }
 
 /// Get a pointer to the [`RLookupKey`] slot inside this metric iterator.
@@ -135,7 +137,7 @@ pub unsafe extern "C" fn GetMetricOwnKeyRef(header: *mut QueryIterator) -> *mut 
     // discarding it: it is inferred to a lifetime local to this function and
     // erased by the cast below, so no key typed with it escapes to C — which
     // has none to offer and reads no borrowed string through this pointer.
-    let slot: *mut *mut rlookup::RLookupKey<'_> = unsafe { metric::own_key_ref(header) };
+    let slot = unsafe { metric::own_key_ref(header) };
 
-    slot.cast::<*mut RLookupKey>()
+    slot.as_ptr().cast::<*mut RLookupKey>()
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -73,9 +73,12 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     _type: MetricType,
 ) -> *mut QueryIterator {
     let (ids_list, metrics_list) = if let Some(ids) = NonNull::new(ids) {
-        let metrics = NonNull::new(metrics).expect(
-            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null.",
+        debug_assert!(
+            !metrics.is_null(),
+            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null."
         );
+        // SAFETY: 3. guarantees `metrics` is non-null whenever `ids` is.
+        let metrics = unsafe { NonNull::new_unchecked(metrics) };
         // SAFETY: Safe thanks to 1.
         let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
         // SAFETY: Safe thanks to 2.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -72,7 +72,17 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     num: usize,
     _type: MetricType,
 ) -> *mut QueryIterator {
-    let (ids_list, metrics_list) = if ids.is_null() {
+    let (ids_list, metrics_list) = if let Some(ids) = NonNull::new(ids) {
+        let metrics = NonNull::new(metrics).expect(
+            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null.",
+        );
+        // SAFETY: Safe thanks to 1.
+        let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
+        // SAFETY: Safe thanks to 2.
+        let metrics_list = unsafe { OwnedSlice::from_c(metrics, num) };
+
+        (ids_list, metrics_list)
+    } else {
         // SAFETY: Safe thanks to 3.
         debug_assert_eq!(
             num, 0,
@@ -80,20 +90,6 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
         );
 
         (OwnedSlice::default(), OwnedSlice::default())
-    } else {
-        debug_assert!(
-            !metrics.is_null(),
-            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null."
-        );
-
-        let ids = NonNull::new(ids).expect("`ids` must not be null");
-        let metrics = NonNull::new(metrics).expect("`metrics` must not be null");
-        // SAFETY: Safe thanks to 1.
-        let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
-        // SAFETY: Safe thanks to 2.
-        let metrics_list = unsafe { OwnedSlice::from_c(metrics, num) };
-
-        (ids_list, metrics_list)
     };
 
     RQEIteratorWrapper::boxed_new(Metric::<SORTED_BY_ID>::new(ids_list, metrics_list)).as_ptr()

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -246,8 +246,8 @@ pub unsafe extern "C" fn NewNotIterator(
         // SAFETY: caller guarantees preconditions (3–7).
         let result = unsafe { new_not_iterator(empty, max_doc_id, weight, timeout_ctx, query) };
         return match result {
-            NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc),
-            NewNotIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty),
+            NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc).as_ptr(),
+            NewNotIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty).as_ptr(),
             // Empty child always reduces; these arms are unreachable.
             NewNotIterator::Not(_) | NewNotIterator::NotOptimized(_) => {
                 panic!("Empty not child always reduces")
@@ -262,13 +262,13 @@ pub unsafe extern "C" fn NewNotIterator(
     let result = unsafe { new_not_iterator(child, max_doc_id, weight, timeout_ctx, query) };
 
     match result {
-        NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc),
-        NewNotIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty),
+        NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc).as_ptr(),
+        NewNotIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty).as_ptr(),
         NewNotIterator::Not(iter) => {
-            RQEIteratorWrapper::boxed_new_compound(NotIteratorEnum::Not(iter))
+            RQEIteratorWrapper::boxed_new_compound(NotIteratorEnum::Not(iter)).as_ptr()
         }
         NewNotIterator::NotOptimized(iter) => {
-            RQEIteratorWrapper::boxed_new_compound(NotIteratorEnum::NotOptimized(iter))
+            RQEIteratorWrapper::boxed_new_compound(NotIteratorEnum::NotOptimized(iter)).as_ptr()
         }
     }
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn NewOptionalIterator(
         // SAFETY: thanks to 2. `new_wildcard_iterator` pulls the disk snapshot
         // (if any) from `query.sctx.diskSnapshot` itself.
         let wc = unsafe { rqe_iterators::wildcard::new_wildcard_iterator(query, 0.0) };
-        return RQEIteratorWrapper::boxed_new(wc);
+        return RQEIteratorWrapper::boxed_new(wc).as_ptr();
     };
 
     // SAFETY: thanks to 1.
@@ -52,11 +52,13 @@ pub unsafe extern "C" fn NewOptionalIterator(
     let result = unsafe { new_optional_iterator(child, weight, query, max_doc_id) };
 
     match result {
-        OptionalIteratorOutcome::WildcardFallback(wc) => RQEIteratorWrapper::boxed_new(wc),
+        OptionalIteratorOutcome::WildcardFallback(wc) => RQEIteratorWrapper::boxed_new(wc).as_ptr(),
         OptionalIteratorOutcome::WildcardPassthrough(child) => child.into_raw().as_ptr(),
-        OptionalIteratorOutcome::Optional(opt) => RQEIteratorWrapper::boxed_new_compound(opt),
+        OptionalIteratorOutcome::Optional(opt) => {
+            RQEIteratorWrapper::boxed_new_compound(opt).as_ptr()
+        }
         OptionalIteratorOutcome::OptionalOptimized(opt_opt) => {
-            RQEIteratorWrapper::boxed_new_compound(opt_opt)
+            RQEIteratorWrapper::boxed_new_compound(opt_opt).as_ptr()
         }
     }
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
@@ -150,6 +150,7 @@ pub unsafe extern "C" fn Profile_PrintIterators(
         return;
     };
 
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: precondition 1.
     let mut replier = unsafe { Replier::new(ctx) };
     let mut profile_ctx = ProfilePrintCtx::new(limited, print_profile_clock);

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -139,9 +139,9 @@ pub unsafe extern "C" fn NewUnionIterator(
 ///    created via [`NewUnionIterator`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrimUnionIterator(it: *mut QueryIterator, limit: usize, asc: bool) {
-    debug_assert!(!it.is_null());
+    let it = NonNull::new(it).expect("`it` must not be null");
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).
-    debug_assert_eq!(unsafe { (*it).type_ }, IteratorType::Union);
+    debug_assert_eq!(unsafe { it.as_ref().type_ }, IteratorType::Union);
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).
     let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(it) };
     let dispatch = &mut wrapper.inner;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -139,7 +139,9 @@ pub unsafe extern "C" fn NewUnionIterator(
 ///    created via [`NewUnionIterator`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrimUnionIterator(it: *mut QueryIterator, limit: usize, asc: bool) {
-    let it = NonNull::new(it).expect("`it` must not be null");
+    debug_assert!(!it.is_null());
+    // SAFETY: `it` is non-null per 1.
+    let it = unsafe { NonNull::new_unchecked(it) };
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).
     debug_assert_eq!(unsafe { it.as_ref().type_ }, IteratorType::Union);
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -21,7 +21,7 @@ pub extern "C" fn NewWildcardIterator_NonOptimized(
     weight: f64,
 ) -> *mut QueryIterator {
     let it = NewWildcardIterator::NotOptimized(Wildcard::new(max_id, weight));
-    RQEIteratorWrapper::boxed_new(it)
+    RQEIteratorWrapper::boxed_new(it).as_ptr()
 }
 
 /// Returns `true` if `it` is a wildcard iterator (either optimized or non-optimized).
@@ -81,5 +81,5 @@ pub unsafe extern "C" fn NewWildcardIterator(
     let query = NonNull::new(q.cast_mut()).expect("q is null");
     // SAFETY: Caller guarantees all preconditions of `new_wildcard_iterator`.
     let it = unsafe { rqe_iterators::wildcard::new_wildcard_iterator(query, weight) };
-    RQEIteratorWrapper::boxed_new(it)
+    RQEIteratorWrapper::boxed_new(it).as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -40,17 +40,21 @@ unsafe fn parse_level(level: *const c_char) -> LevelFilter {
 ///
 /// `level` is the initial redis `loglevel` config value the filter is set to.
 ///
+/// A null `ctx` is accepted: traces are then logged through a null module
+/// context, which `RedisModule_Log` explicitly permits.
+///
 /// # Safety
 ///
-/// `level` must point to a valid, null-terminated C string.
+/// `level` must point to a valid, null-terminated C string. `ctx` must either
+/// be null or point to a valid `RedisModuleCtx`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TracingRedisModule_Init(
-    ctx: Option<NonNull<redis_module::RedisModuleCtx>>,
+    ctx: *mut redis_module::RedisModuleCtx,
     level: *const c_char,
 ) {
     // Safety: forwarded to the caller's contract on `level`.
     let level = unsafe { parse_level(level) };
-    tracing_redismodule::init(ctx, level);
+    tracing_redismodule::init(NonNull::new(ctx), level);
 }
 
 /// Updates the `tracing` log level filter from a redis `loglevel` config value
@@ -89,14 +93,16 @@ pub extern "C" fn RustPanicHook_Init() {
 /// Add the current backtrace as a new section to the report printed
 /// by RediSearch's INFO command.
 ///
+/// A null `ctx` is a no-op.
+///
 /// # Safety
 ///
-/// `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
+/// `ctx` must either be null or point to a valid `RedisModuleInfoCtx`.
 #[unsafe(no_mangle)]
-pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::RedisModuleInfoCtx>>) {
+pub unsafe extern "C" fn AddToInfo_RustBacktrace(ctx: *mut redis_module::RedisModuleInfoCtx) {
     use std::ffi::CString;
 
-    let Some(ctx) = ctx else {
+    let Some(ctx) = NonNull::new(ctx) else {
         return;
     };
 

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -14,6 +14,8 @@
 //! - DUMP_NUMIDX: Index entries dump
 //! - DUMP_NUMIDXTREE: Tree structure dump
 
+use std::ptr::NonNull;
+
 use numeric_range_tree::NumericRangeTree;
 use redis_module::RedisModuleCtx;
 
@@ -31,7 +33,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -56,7 +58,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     t: *const NumericRangeTree,
     with_headers: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -81,7 +83,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     t: *const NumericRangeTree,
     minimal: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -33,7 +33,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -58,7 +60,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     t: *const NumericRangeTree,
     with_headers: bool,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -83,7 +87,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     t: *const NumericRangeTree,
     minimal: bool,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
         // The returned handle is heap-allocated and self-owning; erasing its
         // borrow is sound because the index data it reads outlives it
         // (precondition 1).
-        Some(it) => it.into_c_iterator(),
+        Some(it) => it.into_c_iterator().as_ptr(),
         None => std::ptr::null_mut(),
     }
 }
@@ -271,5 +271,7 @@ pub unsafe extern "C" fn QAST_Iterate(
     // The returned handle is heap-allocated and self-owning; erasing its borrow
     // of the transient `qectx` is sound because the index data it reads
     // (reachable via `sctx`/`spec`) outlives it.
-    qast_iterate(&mut ctx, node, config).into_c_iterator()
+    qast_iterate(&mut ctx, node, config)
+        .into_c_iterator()
+        .as_ptr()
 }

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -48,10 +48,10 @@ use std::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_AddKeysFrom(
     src: *const OpaqueRLookup,
-    dest: Option<NonNull<OpaqueRLookup>>,
+    dest: *mut OpaqueRLookup,
     flags: u32,
 ) {
-    let dest = dest.unwrap();
+    let dest = NonNull::new(dest).expect("`dest` must not be null");
     assert!(
         !ptr::addr_eq(src, dest.as_ptr().cast_const()),
         "`src` and `dst` must not be the same"
@@ -81,12 +81,10 @@ pub unsafe extern "C" fn RLookup_AddKeysFrom(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookup_DisableOptions(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    options: u32,
-) {
+pub unsafe extern "C" fn RLookup_DisableOptions(lookup: *mut OpaqueRLookup, options: u32) {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_DisableOptions");
 
@@ -104,12 +102,10 @@ pub unsafe extern "C" fn RLookup_DisableOptions(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookup_EnableOptions(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    options: u32,
-) {
+pub unsafe extern "C" fn RLookup_EnableOptions(lookup: *mut OpaqueRLookup, options: u32) {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_EnableOptions");
 
@@ -173,12 +169,13 @@ pub unsafe extern "C" fn RLookup_FindFieldInSpecCache(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_Read<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_Read");
 
@@ -189,7 +186,9 @@ pub unsafe extern "C" fn RLookup_GetKey_Read<'a>(
 
     let (name, flags) = handle_name_alloc_flag(name, flags);
 
-    lookup.get_key_read(name, flags).map(NonNull::from)
+    lookup
+        .get_key_read(name, flags)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Get an RLookup key for a given name.
@@ -216,13 +215,14 @@ pub unsafe extern "C" fn RLookup_GetKey_Read<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_ReadEx<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     name_len: size_t,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_ReadEx");
 
@@ -238,7 +238,9 @@ pub unsafe extern "C" fn RLookup_GetKey_ReadEx<'a>(
 
     let (name, flags) = handle_name_alloc_flag(name, flags);
 
-    lookup.get_key_read(name, flags).map(NonNull::from)
+    lookup
+        .get_key_read(name, flags)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Get an RLookup key for a given name.
@@ -263,12 +265,13 @@ pub unsafe extern "C" fn RLookup_GetKey_ReadEx<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_Write<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_Write");
 
@@ -279,7 +282,9 @@ pub unsafe extern "C" fn RLookup_GetKey_Write<'a>(
 
     let (name, flags) = handle_name_alloc_flag(name, flags);
 
-    lookup.get_key_write(name, flags).map(NonNull::from)
+    lookup
+        .get_key_write(name, flags)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Get an RLookup key for a given name.
@@ -305,13 +310,14 @@ pub unsafe extern "C" fn RLookup_GetKey_Write<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_WriteEx<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     name_len: size_t,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_WriteEx");
 
@@ -327,7 +333,9 @@ pub unsafe extern "C" fn RLookup_GetKey_WriteEx<'a>(
 
     let (name, flags) = handle_name_alloc_flag(name, flags);
 
-    lookup.get_key_write(name, flags).map(NonNull::from)
+    lookup
+        .get_key_write(name, flags)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Get an RLookup key for a given name.
@@ -354,13 +362,14 @@ pub unsafe extern "C" fn RLookup_GetKey_WriteEx<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_Load<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     field_name: *const c_char,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_Load");
 
@@ -376,7 +385,7 @@ pub unsafe extern "C" fn RLookup_GetKey_Load<'a>(
 
     lookup
         .get_key_load(name, field_name, flags)
-        .map(NonNull::from)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Get an RLookup key for a given name.
@@ -404,14 +413,15 @@ pub unsafe extern "C" fn RLookup_GetKey_Load<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_GetKey_LoadEx<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
+    lookup: *mut OpaqueRLookup,
     name: *const c_char,
     name_len: size_t,
     field_name: *const c_char,
     flags: u32,
-) -> Option<NonNull<RLookupKey<'a>>> {
+) -> *mut RLookupKey<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_GetKey_LoadEx");
 
@@ -432,7 +442,7 @@ pub unsafe extern "C" fn RLookup_GetKey_LoadEx<'a>(
 
     lookup
         .get_key_load(name, field_name, flags)
-        .map(NonNull::from)
+        .map_or(ptr::null_mut(), |key| NonNull::from(key).as_ptr())
 }
 
 /// Returns the number of visible fields in this RLookupRow.
@@ -449,7 +459,7 @@ pub unsafe extern "C" fn RLookup_GetKey_LoadEx<'a>(
 pub unsafe extern "C" fn RLookup_GetLength(
     lookup: *const OpaqueRLookup,
     row: *const OpaqueRLookupRow,
-    skip_field_index: Option<NonNull<bool>>,
+    skip_field_index: *mut bool,
     skip_field_index_len: size_t,
     required_flags: u32,
     excluded_flags: u32,
@@ -463,10 +473,11 @@ pub unsafe extern "C" fn RLookup_GetLength(
     // Safety: ensured by caller (2.)
     let row = unsafe { RLookupRow::from_opaque_ptr(row).unwrap() };
 
+    let skip_field_index =
+        NonNull::new(skip_field_index).expect("`skip_field_index` must not be null");
     // Safety: ensured by caller (3.)
-    let skip_field_index = unsafe {
-        slice::from_raw_parts_mut(skip_field_index.unwrap().as_ptr(), skip_field_index_len)
-    };
+    let skip_field_index =
+        unsafe { slice::from_raw_parts_mut(skip_field_index.as_ptr(), skip_field_index_len) };
 
     let required_flags = RLookupKeyFlags::from_bits(required_flags).unwrap();
     let excluded_flags = RLookupKeyFlags::from_bits(excluded_flags).unwrap();
@@ -526,15 +537,16 @@ pub extern "C" fn RLookup_New() -> OpaqueRLookup {
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_SetCache(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    spcache: Option<NonNull<ffi::IndexSpecCache>>,
+    lookup: *mut OpaqueRLookup,
+    spcache: *mut ffi::IndexSpecCache,
 ) {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_SetCache");
 
-    let spcache = spcache.map(|spcache| {
+    let spcache = NonNull::new(spcache).map(|spcache| {
         // Safety: ensured by caller (2. & 3.)
         unsafe { IndexSpecCache::from_raw(spcache) }
     });
@@ -570,9 +582,10 @@ pub unsafe extern "C" fn RLookup_HasIndexSpecCache(lookup: *const OpaqueRLookup)
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookup_Cleanup(lookup: Option<NonNull<OpaqueRLookup>>) {
+pub unsafe extern "C" fn RLookup_Cleanup(lookup: *mut OpaqueRLookup) {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_Cleanup");
 
@@ -603,27 +616,29 @@ pub unsafe extern "C" fn RLookup_Cleanup(lookup: Option<NonNull<OpaqueRLookup>>)
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_LoadRuleFields(
-    search_ctx: Option<NonNull<ffi::RedisSearchCtx>>,
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    dst_row: Option<NonNull<OpaqueRLookupRow>>,
-    index_spec: Option<NonNull<ffi::IndexSpec>>,
+    search_ctx: *mut ffi::RedisSearchCtx,
+    lookup: *mut OpaqueRLookup,
+    dst_row: *mut OpaqueRLookupRow,
+    index_spec: *const ffi::IndexSpec,
     key: *const c_char,
     open_key: *mut redis_module::RedisModuleKey,
-    status: Option<NonNull<OpaqueQueryError>>,
+    status: *mut OpaqueQueryError,
 ) -> i32 {
+    let mut search_ctx = NonNull::new(search_ctx).expect("`search_ctx` must not be null");
     // Safety: ensured by caller (1.)
-    let search_ctx = unsafe { search_ctx.unwrap().as_mut() };
+    let search_ctx = unsafe { search_ctx.as_mut() };
 
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (2.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_LoadRuleFields");
 
+    let dst_row = NonNull::new(dst_row).expect("`dst_row` must not be null");
     // Safety: ensured by caller (3.)
-    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row.unwrap()) };
+    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row) };
 
-    // Safety: ensured by caller (4.)
-    let index_spec = unsafe { index_spec.unwrap().as_ref() };
+    assert!(!index_spec.is_null(), "`index_spec` must not be null");
     // Safety: ensured by caller (4.)
     let index_spec = unsafe { IndexSpec::from_raw(index_spec) };
 
@@ -633,8 +648,9 @@ pub unsafe extern "C" fn RLookup_LoadRuleFields(
     // Safety: ensured by caller (8.)
     let open_key = unsafe { open_key.as_ref() };
 
+    let status = NonNull::new(status).expect("`status` must not be null");
     // Safety: ensured by caller (9.)
-    let status = unsafe { QueryError::from_opaque_non_null(status.unwrap()) };
+    let status = unsafe { QueryError::from_opaque_non_null(status) };
 
     let res = lookup.load_rule_fields(search_ctx, dst_row, index_spec, key, open_key);
 
@@ -709,18 +725,20 @@ pub struct LoadIndividualKeysOptions {
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_LoadDocumentAll(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    dst_row: Option<NonNull<OpaqueRLookupRow>>,
-    opts: Option<NonNull<LoadAllKeysOptions>>,
+    lookup: *mut OpaqueRLookup,
+    dst_row: *mut OpaqueRLookupRow,
+    opts: *const LoadAllKeysOptions,
 ) -> c_int {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
 
+    let dst_row = NonNull::new(dst_row).expect("`dst_row` must not be null");
     // Safety: ensured by caller (2.)
-    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row.unwrap()) };
+    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row) };
 
     // Safety: ensured by caller (3.)
-    let opts = unsafe { opts.unwrap().as_ref() };
+    let opts = unsafe { opts.as_ref() }.expect("`opts` must not be null");
 
     // Safety: caller (3.) — `opts.dmd` is a borrowed, valid, non-null
     // `RSDocumentMetadata` that outlives this call. We only borrow it; ownership
@@ -801,20 +819,22 @@ pub unsafe extern "C" fn RLookup_LoadDocumentAll(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_LoadDocumentIndividual(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-    dst_row: Option<NonNull<OpaqueRLookupRow>>,
-    opts: Option<NonNull<LoadIndividualKeysOptions>>,
+    lookup: *mut OpaqueRLookup,
+    dst_row: *mut OpaqueRLookupRow,
+    opts: *const LoadIndividualKeysOptions,
 ) -> c_int {
+    assert!(!lookup.is_null(), "`lookup` must not be null");
     // Safety: ensured by caller (1.). Only shared access is needed here (key
     // selection reads the lookup), and taking a shared reference avoids a
     // mutable borrow that would alias the key references materialized below.
-    let lookup = unsafe { RLookup::from_opaque_ptr_unchecked(lookup.unwrap().as_ptr()) };
+    let lookup = unsafe { RLookup::from_opaque_ptr_unchecked(lookup) };
 
+    let dst_row = NonNull::new(dst_row).expect("`dst_row` must not be null");
     // Safety: ensured by caller (2.)
-    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row.unwrap()) };
+    let dst_row = unsafe { RLookupRow::from_opaque_non_null(dst_row) };
 
     // Safety: ensured by caller (3.)
-    let opts = unsafe { opts.unwrap().as_ref() };
+    let opts = unsafe { opts.as_ref() }.expect("`opts` must not be null");
 
     // Safety: ensured by caller (3.)
     let search_ctx = unsafe { NonNull::new(opts.sctx).unwrap().as_ref() };
@@ -960,11 +980,10 @@ pub struct RLookupIterator<'a> {
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookup_IterMut<'a>(
-    lookup: Option<NonNull<OpaqueRLookup>>,
-) -> RLookupIteratorMut<'a> {
+pub unsafe extern "C" fn RLookup_IterMut<'a>(lookup: *mut OpaqueRLookup) -> RLookupIteratorMut<'a> {
+    let lookup = NonNull::new(lookup).expect("`lookup` must not be null");
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { RLookup::from_opaque_non_null(lookup.unwrap()) };
+    let lookup = unsafe { RLookup::from_opaque_non_null(lookup) };
     #[cfg(debug_assertions)]
     lookup.assert_valid("RLookup_IterMut");
 

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -14,7 +14,7 @@ use std::{
     cmp::Ordering,
     ffi::{CStr, c_char, c_int},
     mem::{self, ManuallyDrop},
-    ptr::NonNull,
+    ptr::{self, NonNull},
     slice,
 };
 use value::comparison::cmp_fields;
@@ -43,16 +43,21 @@ pub extern "C" fn RLookupRow_New() -> OpaqueRLookupRow {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_WriteKey(
     key: *const RLookupKey,
-    row: Option<NonNull<OpaqueRLookupRow>>,
-    value: Option<NonNull<RSValue>>,
+    row: *mut OpaqueRLookupRow,
+    value: *mut RSValue,
 ) {
     // Safety: ensured by caller (1.)
     let key = unsafe { key.as_ref() }.expect("Key must not be null");
 
     // Safety: ensured by caller (2.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
-    let value = value.expect("value must not be null").as_ptr().cast_const();
+    let value = NonNull::new(value)
+        .expect("value must not be null")
+        .as_ptr()
+        .cast_const();
 
     // Safety: ensured by caller (3.)
     let value = unsafe { as_shared_value(value) };
@@ -72,16 +77,20 @@ pub unsafe extern "C" fn RLookup_WriteKey(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_WriteOwnKey(
     key: *const RLookupKey,
-    row: Option<NonNull<OpaqueRLookupRow>>,
-    value: Option<NonNull<RSValue>>,
+    row: *mut OpaqueRLookupRow,
+    value: *mut RSValue,
 ) {
     // Safety: ensured by caller (1.)
     let key = unsafe { key.as_ref() }.expect("`key` must not be null");
 
     // Safety: ensured by caller (2.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
-    let value = value.expect("value must not be null").as_ptr();
+    let value = NonNull::new(value)
+        .expect("value must not be null")
+        .as_ptr();
 
     // Safety: ensured by caller (3.)
     let value = unsafe { into_shared_value(value) };
@@ -97,9 +106,11 @@ pub unsafe extern "C" fn RLookup_WriteOwnKey(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookupRow_Wipe(row: Option<NonNull<OpaqueRLookupRow>>) {
+pub unsafe extern "C" fn RLookupRow_Wipe(row: *mut OpaqueRLookupRow) {
     // Safety: ensured by caller (1.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
     row.wipe();
 }
@@ -114,9 +125,11 @@ pub unsafe extern "C" fn RLookupRow_Wipe(row: Option<NonNull<OpaqueRLookupRow>>)
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RLookupRow_Reset(row: Option<NonNull<OpaqueRLookupRow>>) {
+pub unsafe extern "C" fn RLookupRow_Reset(row: *mut OpaqueRLookupRow) {
     // Safety: ensured by caller (1.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
     row.reset_dyn_values();
 }
@@ -134,8 +147,8 @@ pub unsafe extern "C" fn RLookupRow_Reset(row: Option<NonNull<OpaqueRLookupRow>>
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookupRow_MoveFieldsFrom(
     lookup: *const RLookup,
-    src_row: Option<NonNull<OpaqueRLookupRow>>,
-    dst_row: Option<NonNull<OpaqueRLookupRow>>,
+    src_row: *mut OpaqueRLookupRow,
+    dst_row: *mut OpaqueRLookupRow,
 ) {
     debug_assert_ne!(src_row, dst_row, "`src` and `dst` must not be the same");
 
@@ -143,10 +156,14 @@ pub unsafe extern "C" fn RLookupRow_MoveFieldsFrom(
     let lookup = unsafe { lookup.as_ref().expect("`lookup` must not be null") };
 
     // Safety: ensured by caller (2.)
-    let src = unsafe { RLookupRow::from_opaque_non_null(src_row.expect("`src` must not be null")) };
+    let src = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(src_row).expect("`src` must not be null"))
+    };
 
     // Safety: ensured by caller (3.)
-    let dst = unsafe { RLookupRow::from_opaque_non_null(dst_row.expect("`dst` must not be null")) };
+    let dst = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(dst_row).expect("`dst` must not be null"))
+    };
 
     dst.move_fields_from(src, lookup);
 }
@@ -175,14 +192,14 @@ pub unsafe extern "C" fn RLookupRow_MoveFieldsFrom(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookupRow_WriteByName<'a>(
-    lookup: Option<NonNull<RLookup<'a>>>,
+    lookup: *mut RLookup<'a>,
     name: *const c_char,
     name_len: size_t,
-    row: Option<NonNull<OpaqueRLookupRow>>,
-    value: Option<NonNull<RSValue>>,
+    row: *mut OpaqueRLookupRow,
+    value: *mut RSValue,
 ) {
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { lookup.expect("lookup must not be null").as_mut() };
+    let lookup = unsafe { lookup.as_mut() }.expect("lookup must not be null");
 
     // Safety: ensured by caller (2., 3.)
     let name = unsafe {
@@ -194,9 +211,13 @@ pub unsafe extern "C" fn RLookupRow_WriteByName<'a>(
     };
 
     // Safety: ensured by caller (4.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
-    let value = value.expect("value must not be null").as_ptr();
+    let value = NonNull::new(value)
+        .expect("value must not be null")
+        .as_ptr();
 
     // Safety: ensured by caller (5.)
     let value = unsafe { into_shared_value(value) };
@@ -233,14 +254,14 @@ pub unsafe extern "C" fn RLookupRow_WriteByName<'a>(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookupRow_WriteByNameOwned<'a>(
-    lookup: Option<NonNull<RLookup<'a>>>,
+    lookup: *mut RLookup<'a>,
     name: *const c_char,
     name_len: size_t,
-    row: Option<NonNull<OpaqueRLookupRow>>,
-    value: Option<NonNull<RSValue>>,
+    row: *mut OpaqueRLookupRow,
+    value: *mut RSValue,
 ) {
     // Safety: ensured by caller (1.)
-    let lookup = unsafe { lookup.expect("lookup must not be null").as_mut() };
+    let lookup = unsafe { lookup.as_mut() }.expect("lookup must not be null");
 
     // Safety: ensured by caller (2., 3.)
     let name = unsafe {
@@ -252,9 +273,13 @@ pub unsafe extern "C" fn RLookupRow_WriteByNameOwned<'a>(
     };
 
     // Safety: ensured by caller (4.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
-    let value = value.expect("value must not be null").as_ptr();
+    let value = NonNull::new(value)
+        .expect("value must not be null")
+        .as_ptr();
 
     // Safety: ensured by caller (5.)
     let value = unsafe { into_shared_value(value) };
@@ -287,14 +312,14 @@ pub unsafe extern "C" fn RLookupRow_WriteByNameOwned<'a>(
 pub unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
     src_row: *const OpaqueRLookupRow,
     src_lookup: *const RLookup<'a>,
-    dst_row: Option<NonNull<OpaqueRLookupRow>>,
-    dst_lookup: Option<NonNull<RLookup<'a>>>,
+    dst_row: *mut OpaqueRLookupRow,
+    dst_lookup: *mut RLookup<'a>,
     create_missing_keys: bool,
 ) {
-    let dst_row = dst_row.unwrap();
+    let dst_row = NonNull::new(dst_row).expect("`dst_row` must not be null");
 
     // Safety: ensured by caller (4.)
-    let dst_lookup = unsafe { dst_lookup.unwrap().as_mut() };
+    let dst_lookup = unsafe { dst_lookup.as_mut() }.expect("`dst_lookup` must not be null");
 
     // We're doing the asserts here in the middle to avoid extra type conversions.
     assert!(
@@ -335,17 +360,15 @@ pub unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
 pub unsafe extern "C" fn RLookupRow_Get(
     key: *const RLookupKey,
     row: *const OpaqueRLookupRow,
-) -> Option<NonNull<RSValue>> {
+) -> *mut RSValue {
     // Safety: ensured by caller (1.)
     let key = unsafe { &*key };
 
     // Safety: ensured by caller (2.)
     let row = unsafe { RLookupRow::from_opaque_ptr_unchecked(row) };
 
-    row.get(key).map(|x| {
-        // Safety: `RSValue` is a valid pointer.
-        unsafe { NonNull::new_unchecked(as_rs_value(x).cast_mut()) }
-    })
+    row.get(key)
+        .map_or(ptr::null_mut(), |x| as_rs_value(x).cast_mut())
 }
 
 /// A read-only view of a sorting vector's values, returned by value to C.
@@ -399,11 +422,13 @@ pub unsafe extern "C" fn RLookupRow_GetSortingVector(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookupRow_SetSortingVector(
-    row: Option<NonNull<OpaqueRLookupRow>>,
+    row: *mut OpaqueRLookupRow,
     sv: *const sorting_vector::RSSortingVector,
 ) {
     // Safety: ensured by caller (1.)
-    let row = unsafe { RLookupRow::from_opaque_non_null(row.expect("`row` must not be null")) };
+    let row = unsafe {
+        RLookupRow::from_opaque_non_null(NonNull::new(row).expect("`row` must not be null"))
+    };
 
     // Safety: ensured by caller (2.)
     let sv_ref = unsafe { sv.as_ref() };

--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
@@ -34,15 +34,15 @@ pub const extern "C" fn SearchResult_New() -> SearchResult {
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SearchResult_Override(
-    dst: Option<NonNull<SearchResult>>,
-    src: Option<NonNull<SearchResult>>,
-) {
+pub unsafe extern "C" fn SearchResult_Override(dst: *mut SearchResult, src: *mut SearchResult) {
+    let mut dst = NonNull::new(dst).expect("dst must not be NULL");
+    let src = NonNull::new(src).expect("src must not be NULL");
+
     // Safety: ensured by caller (1.)
-    let dst = unsafe { dst.unwrap().as_mut() };
+    let dst = unsafe { dst.as_mut() };
 
     // Safety: ensured by caller (2.,3.)
-    let _ = mem::replace(dst, unsafe { src.unwrap().read() });
+    let _ = mem::replace(dst, unsafe { src.read() });
 }
 
 /// Clears the [`SearchResult`] pointed to by `res`, removing all values from its [`RLookupRow`][ffi::RLookupRow].
@@ -54,9 +54,10 @@ pub unsafe extern "C" fn SearchResult_Override(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SearchResult_Clear(res: Option<NonNull<SearchResult>>) {
+pub unsafe extern "C" fn SearchResult_Clear(res: *mut SearchResult) {
+    let mut res = NonNull::new(res).expect("res must not be NULL");
     // Safety: ensured by caller (1.)
-    let res = unsafe { res.unwrap().as_mut() };
+    let res = unsafe { res.as_mut() };
 
     res.clear();
 }
@@ -71,9 +72,10 @@ pub unsafe extern "C" fn SearchResult_Clear(res: Option<NonNull<SearchResult>>) 
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SearchResult_Destroy(res: Option<NonNull<SearchResult>>) {
+pub unsafe extern "C" fn SearchResult_Destroy(res: *mut SearchResult) {
+    let res = NonNull::new(res).expect("res must not be NULL");
     // Safety: ensured by caller (1.,2.)
-    unsafe { res.unwrap().drop_in_place() };
+    unsafe { res.drop_in_place() };
 }
 
 /// Moves the contents the [`SearchResult`] pointed to by `res` into a new heap allocation.
@@ -86,11 +88,10 @@ pub unsafe extern "C" fn SearchResult_Destroy(res: Option<NonNull<SearchResult>>
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SearchResult_AllocateMove(
-    res: Option<NonNull<SearchResult>>,
-) -> *mut SearchResult {
+pub unsafe extern "C" fn SearchResult_AllocateMove(res: *mut SearchResult) -> *mut SearchResult {
+    let res = NonNull::new(res).expect("res must not be NULL");
     // Safety: ensured by caller (1.)
-    let res = unsafe { res.unwrap().read() };
+    let res = unsafe { res.read() };
 
     let res = Box::new(res);
     Box::into_raw(res)
@@ -106,8 +107,9 @@ pub unsafe extern "C" fn SearchResult_AllocateMove(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn SearchResult_DeallocateDestroy(res: Option<NonNull<SearchResult>>) {
+pub unsafe extern "C" fn SearchResult_DeallocateDestroy(res: *mut SearchResult) {
+    let res = NonNull::new(res).expect("res must not be NULL");
     // Safety: ensured by caller (1.,2.)
-    let res = unsafe { Box::from_raw(res.unwrap().as_ptr()) };
+    let res = unsafe { Box::from_raw(res.as_ptr()) };
     drop(res);
 }

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
@@ -69,13 +69,9 @@ pub unsafe extern "C" fn RSSortingVector_GetMemorySize(vec: *const RSSortingVect
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_PutNum(
-    vec: Option<NonNull<RSSortingVector>>,
-    idx: size_t,
-    num: f64,
-) {
+pub unsafe extern "C" fn RSSortingVector_PutNum(vec: *mut RSSortingVector, idx: size_t, num: f64) {
     // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.expect("vec must not be null").as_mut() };
+    let vec = unsafe { NonNull::new(vec).expect("vec must not be null").as_mut() };
 
     vec.try_insert_val(idx, SharedValue::new_num(num))
         .unwrap_or_else(|_| {
@@ -97,12 +93,12 @@ pub unsafe extern "C" fn RSSortingVector_PutNum(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSSortingVector_PutStr(
-    vec: Option<NonNull<RSSortingVector>>,
+    vec: *mut RSSortingVector,
     idx: size_t,
     str: *const c_char,
 ) {
     // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.expect("vec must not be null").as_mut() };
+    let vec = unsafe { NonNull::new(vec).expect("vec must not be null").as_mut() };
 
     // Safety: The caller must ensure str points to a valid C string (2.)
     let str = unsafe { CStr::from_ptr(str) };
@@ -134,19 +130,20 @@ pub unsafe extern "C" fn RSSortingVector_PutStr(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSSortingVector_PutStrNormalize(
-    vec: Option<NonNull<RSSortingVector>>,
+    vec: *mut RSSortingVector,
     idx: libc::size_t,
     str: *const c_char,
-    status: Option<NonNull<OpaqueQueryError>>,
+    status: *mut OpaqueQueryError,
 ) -> bool {
     // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.expect("vec must not be null").as_mut() };
+    let vec = unsafe { NonNull::new(vec).expect("vec must not be null").as_mut() };
 
     // Safety: The caller must ensure str points to a valid C string (2.)
     let str = unsafe { CStr::from_ptr(str) };
 
+    let status = NonNull::new(status).expect("status must not be null");
     // Safety: The caller must ensure status points to a valid query error (3.)
-    let status = unsafe { QueryError::from_opaque_non_null(status.unwrap()) };
+    let status = unsafe { QueryError::from_opaque_non_null(status) };
 
     let Ok(str) = str.to_str() else {
         status.set_code_and_message(QueryErrorCode::BadVal, Some(c"Invalid UTF-8".to_owned()));
@@ -175,14 +172,14 @@ pub unsafe extern "C" fn RSSortingVector_PutStrNormalize(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSSortingVector_PutRSVal(
-    vec: Option<NonNull<RSSortingVector>>,
+    vec: *mut RSSortingVector,
     idx: size_t,
-    val: Option<NonNull<RSValue>>,
+    val: *mut RSValue,
 ) {
     // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.expect("vec must not be null").as_mut() };
+    let vec = unsafe { NonNull::new(vec).expect("vec must not be null").as_mut() };
 
-    let value = val.expect("value must not be null").as_ptr();
+    let value = NonNull::new(val).expect("value must not be null").as_ptr();
 
     // Safety: The caller must ensure that the pointer is valid (2.)
     let val = unsafe { into_shared_value(value) };
@@ -204,12 +201,9 @@ pub unsafe extern "C" fn RSSortingVector_PutRSVal(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_PutNull(
-    vec: Option<NonNull<RSSortingVector>>,
-    idx: libc::size_t,
-) {
+pub unsafe extern "C" fn RSSortingVector_PutNull(vec: *mut RSSortingVector, idx: libc::size_t) {
     // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.expect("vec must not be null").as_mut() };
+    let vec = unsafe { NonNull::new(vec).expect("vec must not be null").as_mut() };
 
     vec.try_insert_null(idx).unwrap_or_else(|_| {
         panic!("Index out of bounds: {} >= {}", idx, vec.len());
@@ -243,8 +237,8 @@ pub extern "C" fn RSSortingVector_New(len: size_t) -> RSSortingVector {
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_ClearAndDeAlloc(vec: Option<NonNull<RSSortingVector>>) {
-    if let Some(mut vec) = vec {
+pub unsafe extern "C" fn RSSortingVector_ClearAndDeAlloc(vec: *mut RSSortingVector) {
+    if let Some(mut vec) = NonNull::new(vec) {
         // Safety: The caller must ensure that the pointer is valid (1.)
         unsafe { vec.as_mut() }.reset();
     }

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
@@ -23,8 +23,8 @@ use varint::VarintEncode;
 /// 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer reader.
 #[unsafe(no_mangle)]
-pub extern "C" fn ReadVarintFieldMask(b: Option<NonNull<BufferReader>>) -> FieldMask {
-    let mut buffer_reader = b.unwrap();
+pub unsafe extern "C" fn ReadVarintFieldMask(b: *mut BufferReader) -> FieldMask {
+    let mut buffer_reader = NonNull::new(b).expect("b must not be NULL");
     // Safety: Safe thanks to invariants 1. and 2.
     let buffer_reader = unsafe { buffer_reader.as_mut() };
     varint::read(buffer_reader).unwrap()
@@ -44,11 +44,11 @@ pub extern "C" fn ReadVarintFieldMask(b: Option<NonNull<BufferReader>>) -> Field
 /// 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer writer.
 #[unsafe(no_mangle)]
-pub extern "C" fn WriteVarintFieldMask(
+pub unsafe extern "C" fn WriteVarintFieldMask(
     value: FieldMask,
-    writer: Option<NonNull<BufferWriter>>,
+    writer: *mut BufferWriter,
 ) -> usize {
-    let mut writer = writer.unwrap();
+    let mut writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: Safe thanks to invariants 1. and 2.
     let writer = unsafe { writer.as_mut() };
     let cap = writer.buffer().capacity();

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/value.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/value.rs
@@ -22,8 +22,8 @@ use varint::VarintEncode;
 /// The following invariants must be upheld when calling this function:
 /// 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer reader.
-pub extern "C" fn ReadVarint(b: Option<NonNull<BufferReader>>) -> u32 {
-    let mut buffer_reader = b.unwrap();
+pub unsafe extern "C" fn ReadVarint(b: *mut BufferReader) -> u32 {
+    let mut buffer_reader = NonNull::new(b).expect("b must not be NULL");
     // Safety: Safe thanks to invariants 1. and 2.
     let buffer_reader = unsafe { buffer_reader.as_mut() };
     varint::read(buffer_reader).unwrap()
@@ -43,8 +43,8 @@ pub extern "C" fn ReadVarint(b: Option<NonNull<BufferReader>>) -> u32 {
 /// 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer writer.
 #[unsafe(no_mangle)]
-pub extern "C" fn WriteVarint(value: u32, writer: Option<NonNull<BufferWriter>>) -> usize {
-    let mut writer = writer.unwrap();
+pub unsafe extern "C" fn WriteVarint(value: u32, writer: *mut BufferWriter) -> usize {
+    let mut writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: Safe thanks to invariants 1. and 2.
     let writer = unsafe { writer.as_mut() };
     let cap = writer.buffer().capacity();

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
@@ -30,8 +30,8 @@ pub extern "C" fn NewVarintVectorWriter(cap: usize) -> *mut VectorWriter {
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
 #[unsafe(no_mangle)]
-pub extern "C" fn VVW_Write(writer: Option<NonNull<VectorWriter>>, value: u32) -> usize {
-    let mut writer = writer.unwrap();
+pub unsafe extern "C" fn VVW_Write(writer: *mut VectorWriter, value: u32) -> usize {
+    let mut writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
     unsafe { writer.as_mut() }.write(value).unwrap_or(0)
 }
@@ -97,8 +97,8 @@ pub const unsafe extern "C" fn VVW_GetCount(writer: *const VectorWriter) -> usiz
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
 #[unsafe(no_mangle)]
-pub extern "C" fn VVW_Reset(writer: Option<NonNull<VectorWriter>>) {
-    let mut writer = writer.unwrap();
+pub unsafe extern "C" fn VVW_Reset(writer: *mut VectorWriter) {
+    let mut writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
     unsafe { writer.as_mut() }.reset()
 }
@@ -113,8 +113,8 @@ pub extern "C" fn VVW_Reset(writer: Option<NonNull<VectorWriter>>) {
 /// The following invariants must be upheld when calling this function:
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
-pub extern "C" fn VVW_Free(writer: Option<NonNull<VectorWriter>>) {
-    let writer = writer.unwrap();
+pub unsafe extern "C" fn VVW_Free(writer: *mut VectorWriter) {
+    let writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: The pointer is leaked in `NewVectorWriter`, so we can safely drop it here.
     drop(unsafe { Box::from_raw(writer.as_ptr()) });
 }
@@ -127,8 +127,8 @@ pub extern "C" fn VVW_Free(writer: Option<NonNull<VectorWriter>>) {
 /// The following invariants must be upheld when calling this function:
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
-pub extern "C" fn VVW_Truncate(writer: Option<NonNull<VectorWriter>>) -> usize {
-    let writer = writer.unwrap();
+pub unsafe extern "C" fn VVW_Truncate(writer: *mut VectorWriter) -> usize {
+    let writer = NonNull::new(writer).expect("writer must not be NULL");
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
     unsafe { &mut *writer.as_ptr() }.shrink_to_fit()
 }
@@ -143,17 +143,15 @@ pub extern "C" fn VVW_Truncate(writer: Option<NonNull<VectorWriter>>) -> usize {
 /// The following invariants must be upheld when calling this function:
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
-/// 3. The caller must have exclusive access to `len`.
-pub unsafe extern "C" fn VVW_TakeByteData(
-    writer: *mut VectorWriter,
-    mut len: NonNull<usize>,
-) -> *mut u8 {
+/// 3. `len` cannot be NULL and the caller must have exclusive access to it.
+pub unsafe extern "C" fn VVW_TakeByteData(writer: *mut VectorWriter, len: *mut usize) -> *mut u8 {
     if writer.is_null() {
         return std::ptr::null_mut();
     }
 
     // Safety: Guaranteed by safety invariant 1. and 2.
     let vector_writer = unsafe { &mut *writer };
+    let mut len = NonNull::new(len).expect("len must not be NULL");
     // Safety: Guaranteed by safety invariant 3.
     let len = unsafe { len.as_mut() };
     let mut bytes = vec![];

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -12,6 +12,7 @@ use std::{
     marker::PhantomData,
     mem::ManuallyDrop,
     os::fd::FromRawFd,
+    ptr::NonNull,
     time::Duration,
 };
 
@@ -34,11 +35,11 @@ impl ForkGC {
     /// 1. `ptr` must point to a valid, initialised [`ffi::ForkGC`].
     /// 2. For the chosen lifetime `'a`, no other reference to the same
     ///    struct may exist.
-    pub unsafe fn from_ptr_mut<'a>(ptr: *mut ffi::ForkGC) -> &'a mut Self {
-        // SAFETY: `#[repr(transparent)]` guarantees `*mut ffi::ForkGC` and
-        // `*mut ForkGC` have identical layout. Validity and aliasing are
+    pub const unsafe fn from_ptr_mut<'a>(ptr: NonNull<ffi::ForkGC>) -> &'a mut Self {
+        // SAFETY: `#[repr(transparent)]` guarantees `NonNull<ffi::ForkGC>` and
+        // `NonNull<ForkGC>` have identical layout. Validity and aliasing are
         // the caller's responsibility per (1) and (2).
-        unsafe { &mut *ptr.cast::<ForkGC>() }
+        unsafe { ptr.cast::<ForkGC>().as_mut() }
     }
 
     /// Return a writable handle to the GC pipe.

--- a/src/redisearch_rs/fork_gc/tests/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/tests/fork_gc.rs
@@ -16,6 +16,7 @@ use std::{
     io::{self, Read, Write},
     mem,
     os::fd::AsRawFd,
+    ptr::NonNull,
     time::Duration,
 };
 
@@ -44,7 +45,7 @@ fn make_fork_gc() -> (ffi::ForkGC, io::PipeReader, io::PipeWriter) {
 fn roundtrip_through_fork_gc() {
     let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
     // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
-    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::from(&mut raw)) };
 
     fgc.writer().write_all(b"hello").unwrap();
 
@@ -57,7 +58,7 @@ fn roundtrip_through_fork_gc() {
 fn times_out_when_no_data_available() {
     let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
     // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
-    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::from(&mut raw)) };
 
     let mut buf = [0u8; 5];
     let err = fgc

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -21,9 +21,11 @@ extern "C" {
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
  *
+ * A null `ctx` is a no-op.
+ *
  * # Safety
  *
- * `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
+ * `ctx` must either be null or point to a valid `RedisModuleInfoCtx`.
  */
 void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
 
@@ -39,9 +41,13 @@ void RustPanicHook_Init(void);
  *
  * `level` is the initial redis `loglevel` config value the filter is set to.
  *
+ * A null `ctx` is accepted: traces are then logged through a null module
+ * context, which `RedisModule_Log` explicitly permits.
+ *
  * # Safety
  *
- * `level` must point to a valid, null-terminated C string.
+ * `level` must point to a valid, null-terminated C string. `ctx` must either
+ * be null or point to a valid `RedisModuleCtx`.
  */
 void TracingRedisModule_Init(struct RedisModuleCtx *ctx, const char *level);
 

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -586,7 +586,7 @@ struct RLookupIteratorMut RLookup_IterMut(struct RLookup *lookup);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int RLookup_LoadDocumentAll(struct RLookup *lookup, struct RLookupRow *dst_row, struct LoadAllKeysOptions *opts);
+int RLookup_LoadDocumentAll(struct RLookup *lookup, struct RLookupRow *dst_row, const struct LoadAllKeysOptions *opts);
 
 /**
  * Load values for all non-present and loadable keys in `rlookup` from the document `dmd` into `dst_row`
@@ -605,7 +605,7 @@ int RLookup_LoadDocumentAll(struct RLookup *lookup, struct RLookupRow *dst_row, 
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int RLookup_LoadDocumentIndividual(struct RLookup *lookup, struct RLookupRow *dst_row, struct LoadIndividualKeysOptions *opts);
+int RLookup_LoadDocumentIndividual(struct RLookup *lookup, struct RLookupRow *dst_row, const struct LoadIndividualKeysOptions *opts);
 
 /**
  * Initialize the lookup with fields from a Redis hash.
@@ -630,7 +630,7 @@ int RLookup_LoadDocumentIndividual(struct RLookup *lookup, struct RLookupRow *ds
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, IndexSpec *index_spec, const char *key, struct RedisModuleKey *open_key, struct QueryError *status);
+int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, const IndexSpec *index_spec, const char *key, struct RedisModuleKey *open_key, struct QueryError *status);
 
 /**
  * Returns a newly created [`RLookup`].

--- a/src/redisearch_rs/headers/varint_ffi.h
+++ b/src/redisearch_rs/headers/varint_ffi.h
@@ -133,7 +133,7 @@ void VVW_Reset(struct VarintVectorWriter *writer);
  * The following invariants must be upheld when calling this function:
  * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
- * 3. The caller must have exclusive access to `len`.
+ * 3. `len` cannot be NULL and the caller must have exclusive access to it.
  */
 uint8_t *VVW_TakeByteData(struct VarintVectorWriter *writer, size_t *len);
 

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -9,7 +9,7 @@
 
 mod proximity;
 
-use std::ptr;
+use std::ptr::{self, NonNull};
 
 use super::aggregate::RawAggregateResult;
 use super::kind::RSResultKind;
@@ -461,16 +461,13 @@ impl<'a> RSIndexResult<'a> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
-    ///    `RSIndexResult<'a>`.
+    /// 1. `slot` is aligned and points to an initialized `RSIndexResult<'a>`.
     /// 2. `slot` must be unaliased for the duration of the call: no other
     ///    reference or pointer may be used to access the slot while this runs,
     ///    since the value is moved out and written back through `slot` alone.
     pub const unsafe fn into_suspended_in_place(
-        slot: *mut Self,
-    ) -> *mut RawIndexResult<'a, Suspended> {
-        debug_assert!(!slot.is_null());
-
+        slot: NonNull<Self>,
+    ) -> NonNull<RawIndexResult<'a, Suspended>> {
         // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
         // moves the value out without dropping, leaving the slot logically uninit
         // until the `write` below re-initializes it.
@@ -565,19 +562,17 @@ impl<'query> RawIndexResult<'query, Suspended> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
+    /// 1. `slot` is aligned and points to an initialized
     ///    `RawIndexResult<Suspended>`.
     /// 2. `slot` must be unaliased for the duration of the call: no other
     ///    reference or pointer may be used to access the slot while this runs,
     ///    since the value is moved out and written back through `slot` alone.
     /// 3. The safety preconditions of [`RawIndexResult::into_active`] must hold
     ///    for the chosen lifetime `'a`.
-    pub const unsafe fn into_active_in_place<'a>(slot: *mut Self) -> *mut RSIndexResult<'a>
+    pub const unsafe fn into_active_in_place<'a>(slot: NonNull<Self>) -> NonNull<RSIndexResult<'a>>
     where
         'query: 'a,
     {
-        debug_assert!(!slot.is_null());
-
         // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
         // moves the value out without dropping, leaving the slot logically uninit
         // until the `write` below re-initializes it.

--- a/src/redisearch_rs/numeric_range_tree/src/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/debug.rs
@@ -12,6 +12,8 @@
 //! This module provides functions to dump tree state for debugging purposes.
 //! These are used by the FT.DEBUG commands (NUMIDX_SUMMARY, DUMP_NUMIDX, DUMP_NUMIDXTREE).
 
+use std::ptr::NonNull;
+
 use index_result::RSIndexResult;
 use inverted_index::IndexReader;
 use redis_reply::{ArrayBuilder, MapBuilder, RedisModuleCtx, Replier};
@@ -33,7 +35,7 @@ struct BlocksEfficiencyStats {
 /// # Safety
 ///
 /// - `ctx` must be a valid Redis module context.
-pub unsafe fn debug_summary(ctx: *mut RedisModuleCtx, tree: Option<&NumericRangeTree>) {
+pub unsafe fn debug_summary(ctx: NonNull<RedisModuleCtx>, tree: Option<&NumericRangeTree>) {
     // SAFETY: ctx is valid per function docs
     let mut replier = unsafe { Replier::new(ctx) };
     let mut arr = replier.array();
@@ -67,7 +69,7 @@ pub unsafe fn debug_summary(ctx: *mut RedisModuleCtx, tree: Option<&NumericRange
 ///
 /// - `ctx` must be a valid Redis module context.
 pub unsafe fn debug_dump_index(
-    ctx: *mut RedisModuleCtx,
+    ctx: NonNull<RedisModuleCtx>,
     tree: Option<&NumericRangeTree>,
     with_headers: bool,
 ) {
@@ -105,7 +107,7 @@ pub unsafe fn debug_dump_index(
 ///
 /// - `ctx` must be a valid Redis module context.
 pub unsafe fn debug_dump_tree(
-    ctx: *mut RedisModuleCtx,
+    ctx: NonNull<RedisModuleCtx>,
     tree: Option<&NumericRangeTree>,
     minimal: bool,
 ) {

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
@@ -13,9 +13,9 @@ use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::debug;
 use redis_mock::reply::{ReplyValue, capture_replies};
 
-fn mock_ctx() -> *mut redis_reply::RedisModuleCtx {
+fn mock_ctx() -> std::ptr::NonNull<redis_reply::RedisModuleCtx> {
     redis_mock::init_redis_module_mock();
-    std::ptr::dangling_mut::<redis_reply::RedisModuleCtx>()
+    std::ptr::NonNull::dangling()
 }
 
 fn capture_single_reply(f: impl FnOnce()) -> ReplyValue {

--- a/src/redisearch_rs/query_eval/src/expansion.rs
+++ b/src/redisearch_rs/query_eval/src/expansion.rs
@@ -48,9 +48,8 @@ fn open_expanded_term_reader_disk(
 
     let it = disk::new_term_iterator(ctx, disk, term, field_mask, weight, needs_offsets)?;
     let ptr = RQEIteratorWrapper::boxed_new(it);
-    let nn = NonNull::new(ptr).expect("disk term iterator must not be null");
-    // SAFETY: `nn` is a valid, owning C `QueryIterator`.
-    Some(unsafe { CRQEIterator::new(nn) })
+    // SAFETY: `ptr` is a valid, owning C `QueryIterator`.
+    Some(unsafe { CRQEIterator::new(ptr) })
 }
 
 /// An [`ffi::RSToken`] naming a borrowed byte slice, for the C lookups that read
@@ -163,7 +162,7 @@ fn open_expanded_term_reader(
     // ownership transfers to the iterator.
     let iter = unsafe {
         build_term_iterator(
-            idx.as_ptr(),
+            idx,
             sctx,
             FieldMaskOrIndex::Mask(field_mask),
             term,
@@ -171,10 +170,9 @@ fn open_expanded_term_reader(
         )
     };
     let ptr = RQEIteratorWrapper::boxed_new(iter);
-    let nn = NonNull::new(ptr).expect("term iterator must not be null");
-    // SAFETY: `nn` is a valid, owning C `QueryIterator` with all callbacks
+    // SAFETY: `ptr` is a valid, owning C `QueryIterator` with all callbacks
     // populated — exactly the precondition of `CRQEIterator::new`.
-    Some(unsafe { CRQEIterator::new(nn) })
+    Some(unsafe { CRQEIterator::new(ptr) })
 }
 
 /// A single pattern expansion in progress: the inputs every walk shares, the

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -130,10 +130,11 @@ impl<'index> Evaluated<'index> {
     /// [`RQEIteratorWrapper::boxed_new`]; an already-lowered handle
     /// ([`Evaluated::C`] or [`Evaluated::RustCompound`]) is returned as-is, so
     /// C-side introspection (optimizer, profiler) keeps seeing the same iterator.
-    pub fn into_c_iterator(self) -> *mut ffi::QueryIterator {
+    pub fn into_c_iterator(self) -> NonNull<ffi::QueryIterator> {
         match self {
-            Evaluated::RustLeaf(it) => RQEIteratorWrapper::boxed_new(it),
-            Evaluated::C(it) | Evaluated::RustCompound(it) => it.as_ptr(),
+            Evaluated::RustLeaf(it) => NonNull::new(RQEIteratorWrapper::boxed_new(it))
+                .expect("`boxed_new` must return a non-null iterator"),
+            Evaluated::C(it) | Evaluated::RustCompound(it) => it,
         }
     }
 
@@ -247,14 +248,12 @@ fn eval_child_iterator(
 ) -> CRQEIterator {
     let ptr = match eval_node(&mut *ctx, child, config) {
         Some(ev) => ev.into_c_iterator(),
-        None => RQEIteratorWrapper::boxed_new(Empty),
+        None => NonNull::new(RQEIteratorWrapper::boxed_new(Empty))
+            .expect("`boxed_new` must return a non-null iterator"),
     };
-    // `into_c_iterator` and `boxed_new` always return a valid, owning, non-null
-    // C `QueryIterator`.
-    let nn = NonNull::new(ptr).expect("evaluated child iterator must not be null");
-    // SAFETY: `nn` is a valid, owning C `QueryIterator` with all callbacks
+    // SAFETY: `ptr` is a valid, owning C `QueryIterator` with all callbacks
     // populated — exactly the precondition of `CRQEIterator::new`.
-    unsafe { CRQEIterator::new(nn) }
+    unsafe { CRQEIterator::new(ptr) }
 }
 
 /// Whether a term disk reader must carry term offsets: required when the node

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -132,8 +132,7 @@ impl<'index> Evaluated<'index> {
     /// C-side introspection (optimizer, profiler) keeps seeing the same iterator.
     pub fn into_c_iterator(self) -> NonNull<ffi::QueryIterator> {
         match self {
-            Evaluated::RustLeaf(it) => NonNull::new(RQEIteratorWrapper::boxed_new(it))
-                .expect("`boxed_new` must return a non-null iterator"),
+            Evaluated::RustLeaf(it) => RQEIteratorWrapper::boxed_new(it),
             Evaluated::C(it) | Evaluated::RustCompound(it) => it,
         }
     }
@@ -248,8 +247,7 @@ fn eval_child_iterator(
 ) -> CRQEIterator {
     let ptr = match eval_node(&mut *ctx, child, config) {
         Some(ev) => ev.into_c_iterator(),
-        None => NonNull::new(RQEIteratorWrapper::boxed_new(Empty))
-            .expect("`boxed_new` must return a non-null iterator"),
+        None => RQEIteratorWrapper::boxed_new(Empty),
     };
     // SAFETY: `ptr` is a valid, owning C `QueryIterator` with all callbacks
     // populated — exactly the precondition of `CRQEIterator::new`.

--- a/src/redisearch_rs/query_eval/src/nodes/not.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/not.rs
@@ -9,8 +9,6 @@
 
 //! Evaluation of `QN_NOT` query nodes.
 
-use std::ptr::NonNull;
-
 use rqe_iterators::{
     interop::RQEIteratorWrapper,
     not_reducer::{NewNotIterator, new_not_iterator},
@@ -74,13 +72,11 @@ pub(crate) fn eval<'index>(
     match outcome {
         NewNotIterator::ReducedWildcard(wc) => Evaluated::RustLeaf(Box::new(wc)),
         NewNotIterator::ReducedEmpty(empty) => Evaluated::RustLeaf(Box::new(empty)),
-        NewNotIterator::Not(it) => Evaluated::RustCompound(
-            NonNull::new(RQEIteratorWrapper::boxed_new_compound(it))
-                .expect("not iterator must not be null"),
-        ),
-        NewNotIterator::NotOptimized(it) => Evaluated::RustCompound(
-            NonNull::new(RQEIteratorWrapper::boxed_new_compound(it))
-                .expect("not iterator must not be null"),
-        ),
+        NewNotIterator::Not(it) => {
+            Evaluated::RustCompound(RQEIteratorWrapper::boxed_new_compound(it))
+        }
+        NewNotIterator::NotOptimized(it) => {
+            Evaluated::RustCompound(RQEIteratorWrapper::boxed_new_compound(it))
+        }
     }
 }

--- a/src/redisearch_rs/query_eval/src/nodes/optional.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/optional.rs
@@ -9,8 +9,6 @@
 
 //! Evaluation of `QN_OPTIONAL` query nodes.
 
-use std::ptr::NonNull;
-
 use rqe_iterators::{
     interop::RQEIteratorWrapper,
     optional_reducer::{NewOptionalIterator, new_optional_iterator},
@@ -67,13 +65,11 @@ pub(crate) fn eval<'index>(
         }
         // Genuine compound iterators: lower via `boxed_new_compound` so the
         // profiler keeps the `ProfileChildren` callback into the child.
-        NewOptionalIterator::Optional(opt) => Evaluated::RustCompound(
-            NonNull::new(RQEIteratorWrapper::boxed_new_compound(opt))
-                .expect("optional iterator must not be null"),
-        ),
-        NewOptionalIterator::OptionalOptimized(opt) => Evaluated::RustCompound(
-            NonNull::new(RQEIteratorWrapper::boxed_new_compound(opt))
-                .expect("optional iterator must not be null"),
-        ),
+        NewOptionalIterator::Optional(opt) => {
+            Evaluated::RustCompound(RQEIteratorWrapper::boxed_new_compound(opt))
+        }
+        NewOptionalIterator::OptionalOptimized(opt) => {
+            Evaluated::RustCompound(RQEIteratorWrapper::boxed_new_compound(opt))
+        }
     }
 }

--- a/src/redisearch_rs/query_eval/src/nodes/phrase.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/phrase.rs
@@ -9,8 +9,6 @@
 
 //! Evaluation of `QN_PHRASE` query nodes.
 
-use std::ptr::NonNull;
-
 use rqe_iterators::{
     Empty,
     interop::RQEIteratorWrapper,
@@ -75,7 +73,7 @@ pub(crate) fn eval<'index>(
 
     let result_ptr = match new_intersection_iterator(children) {
         NewIntersectionIterator::Empty => return Some(Evaluated::RustLeaf(Box::new(Empty))),
-        NewIntersectionIterator::Single(child) => child.into_raw().as_ptr(),
+        NewIntersectionIterator::Single(child) => child.into_raw(),
         NewIntersectionIterator::Proceed(cs) => {
             let intersection = Intersection::new_with_slop_order(
                 cs,
@@ -88,7 +86,5 @@ pub(crate) fn eval<'index>(
         }
     };
 
-    Some(Evaluated::RustCompound(
-        NonNull::new(result_ptr).expect("phrase iterator must not be null"),
-    ))
+    Some(Evaluated::RustCompound(result_ptr))
 }

--- a/src/redisearch_rs/query_eval/src/nodes/token.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/token.rs
@@ -97,7 +97,7 @@ fn open_term_reader<'index>(
     // heap-allocated query term whose ownership transfers to the iterator.
     let iter = unsafe {
         build_term_iterator(
-            idx.as_ptr(),
+            idx,
             sctx,
             FieldMaskOrIndex::Mask(effective_field_mask),
             term,

--- a/src/redisearch_rs/query_eval/tests/integration/geo.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geo.rs
@@ -16,6 +16,8 @@
 //! the C library, which Miri cannot execute.
 #![cfg(not(miri))]
 
+use std::ptr::NonNull;
+
 use query::mock::MockQueryNode;
 use query_error::QueryErrorCode;
 use query_eval::{Config, EvalResult, QueryEvalContext, QueryNodeMut, eval_node};
@@ -106,7 +108,9 @@ impl Drop for GeoFixture {
         // SAFETY: `gf.numericFilters` is NULL or exactly what
         // `build_geo_numeric_filters` stored, and no iterator references it any
         // longer.
-        unsafe { rqe_iterators::free_geo_numeric_filters(self.gf.numericFilters.cast()) };
+        unsafe {
+            rqe_iterators::free_geo_numeric_filters(NonNull::new(self.gf.numericFilters.cast()))
+        };
     }
 }
 

--- a/src/redisearch_rs/redis_json_api/src/key_values.rs
+++ b/src/redisearch_rs/redis_json_api/src/key_values.rs
@@ -25,7 +25,7 @@ pub struct KeyValuesIterator<'a> {
     ) -> i32,
     // Free the iterator
     free: unsafe extern "C" fn(ptr: ffi::JSONKeyValuesIterator),
-    ctx: *mut redis_module::RedisModuleCtx,
+    ctx: NonNull<redis_module::RedisModuleCtx>,
     api: &'a RedisJsonApi,
     // Remaining items. Probed at construction from the source object via
     // `getLen`.
@@ -54,7 +54,7 @@ impl<'a> KeyValuesIterator<'a> {
     /// 2. `ptr` must be a valid ptr obtained from `getKeyValues` if `Some`.
     pub(crate) unsafe fn from_non_null(
         ptr: Option<NonNull<c_void>>,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         api: &'a RedisJsonApi,
         len: usize,
     ) -> Self {
@@ -86,7 +86,7 @@ impl<'a> Iterator for KeyValuesIterator<'a> {
         let status = unsafe { (self.next)(self.ptr?.as_ptr(), &raw mut key, value.ptr) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
-            let key = RedisString::from_redis_module_string(self.ctx.cast(), key.cast());
+            let key = RedisString::from_redis_module_string(self.ctx.as_ptr().cast(), key.cast());
             self.remaining = self.remaining.saturating_sub(1);
             Some((key, value))
         } else {

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -124,11 +124,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key(ctx.as_ptr(), key_name.inner.cast()) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Opens a readable JSON key with the specified name.
@@ -148,11 +144,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key_from_str(ctx.as_ptr(), key_name.as_ptr()) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Opens a readable JSON key with the specified name and flags.
@@ -181,11 +173,7 @@ impl RedisJsonApi {
             )
         };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Gets the JSON root from an already-open [`RedisModuleKey`] handle.
@@ -211,11 +199,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.); the helper tolerates a NULL/non-JSON key.
         let ptr = unsafe { ffi::JSON_GetJsonFromHandleCompat(redis_key) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     pub const fn vtable(&self) -> NonNull<RedisJsonApiVTable> {

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -32,7 +32,7 @@ mod value;
 
 use ffi::RedisJSONAPI as RedisJsonApiVTable;
 use redis_module::{RedisString, key::KeyFlags};
-use std::{error::Error, ffi::CStr, fmt, ptr::NonNull};
+use std::{error::Error, ffi::CStr, fmt, ptr, ptr::NonNull};
 
 pub use key_values::KeyValuesIterator;
 pub use path::JsonPath;
@@ -190,7 +190,7 @@ impl RedisJsonApi {
 
     /// Gets the JSON root from an already-open [`RedisModuleKey`] handle.
     ///
-    /// Returns `None` if the key is `NULL`, is not a module type, or does not hold JSON.
+    /// Returns `None` if the key is absent, is not a module type, or does not hold JSON.
     /// The caller owns the key handle and must keep it open while the returned
     /// [`JsonValueRef`] is in use.
     ///
@@ -199,13 +199,15 @@ impl RedisJsonApi {
     ///
     /// # Safety
     ///
-    /// 1. `redis_key` must be a valid, open `RedisModuleKey` handle (or NULL).
+    /// 1. `redis_key`, when present, must be a valid, open `RedisModuleKey` handle.
     ///
     /// [`RedisModuleKey`]: redis_module::RedisModuleKey
     pub unsafe fn open_from_handle(
         &self,
-        redis_key: *mut redis_module::RedisModuleKey,
+        redis_key: Option<NonNull<redis_module::RedisModuleKey>>,
     ) -> Option<JsonValueRef<'_>> {
+        let redis_key = redis_key.map_or(ptr::null_mut(), NonNull::as_ptr);
+
         // Safety: ensured by caller (1.); the helper tolerates a NULL/non-JSON key.
         let ptr = unsafe { ffi::JSON_GetJsonFromHandleCompat(redis_key) };
 

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -116,13 +116,13 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &RedisString,
     ) -> Option<JsonValueRef<'_>> {
         let open_key = vtable_fn!(self, openKey);
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { open_key(ctx, key_name.inner.cast()) };
+        let ptr = unsafe { open_key(ctx.as_ptr(), key_name.inner.cast()) };
 
         if ptr.is_null() {
             None
@@ -140,13 +140,13 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key_from_str(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &CStr,
     ) -> Option<JsonValueRef<'_>> {
         let open_key_from_str = vtable_fn!(self, openKeyFromStr);
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { open_key_from_str(ctx, key_name.as_ptr()) };
+        let ptr = unsafe { open_key_from_str(ctx.as_ptr(), key_name.as_ptr()) };
 
         if ptr.is_null() {
             None
@@ -166,7 +166,7 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key_with_flags(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &RedisString,
         flags: KeyFlags,
     ) -> Option<JsonValueRef<'_>> {
@@ -175,7 +175,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe {
             open_key_with_flags(
-                ctx,
+                ctx.as_ptr(),
                 key_name.inner.cast(),
                 flags.bits() | redis_module::raw::REDISMODULE_READ as i32,
             )

--- a/src/redisearch_rs/redis_json_api/src/path.rs
+++ b/src/redisearch_rs/redis_json_api/src/path.rs
@@ -42,7 +42,7 @@ impl<'a> JsonPath<'a> {
     /// 1. `ctx` must be a valid Redis module context
     pub unsafe fn parse(
         path: &CStr,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         api: &'a RedisJsonApi,
     ) -> Result<Self, RedisString> {
         let path_parse = vtable_fn!(api, pathParse);
@@ -50,7 +50,7 @@ impl<'a> JsonPath<'a> {
         let mut err_msg: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { path_parse(path.as_ptr(), ctx, &raw mut err_msg) };
+        let ptr = unsafe { path_parse(path.as_ptr(), ctx.as_ptr(), &raw mut err_msg) };
 
         if let Some(ptr) = NonNull::new(ptr as *mut c_void) {
             let path_free = vtable_fn!(api, pathFree);
@@ -62,7 +62,7 @@ impl<'a> JsonPath<'a> {
             })
         } else {
             Err(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 err_msg.cast(),
             ))
         }

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -116,11 +116,9 @@ impl<'a> LendingIterator for ResultsIter<'a> {
         // Safety: `ptr` is valid by construction.
         let raw = unsafe { (self.next)(self.ptr.as_ptr()) };
 
-        if raw.is_null() {
-            None
-        } else {
-            // Safety: we obtained the `raw` from calling `next`.
-            Some(unsafe { JsonValueRef::from_raw(raw, self.api) })
-        }
+        let raw = NonNull::new(raw.cast_mut())?;
+
+        // Safety: we obtained the `raw` from calling `next`.
+        Some(unsafe { JsonValueRef::from_raw(raw, self.api) })
     }
 }

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -85,17 +85,17 @@ impl<'a> ResultsIter<'a> {
     #[inline]
     pub unsafe fn serialize(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Result<RedisString, SerializeError> {
         let get_json_from_iter = vtable_fn!(self.api, getJSONFromIter);
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: `ptr` and `ctx` are valid by construction/caller guarantee
-        let status = unsafe { get_json_from_iter(self.ptr.as_ptr(), ctx, &mut str) };
+        let status = unsafe { get_json_from_iter(self.ptr.as_ptr(), ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 str.cast(),
             ))
         } else {

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -91,7 +91,7 @@ impl From<ffi::JSONType> for JsonType {
 //   will remain valid after it is freed I guess.
 #[derive(Clone, Copy)]
 pub struct JsonValueRef<'a> {
-    pub(crate) ptr: *const c_void, // is non-null
+    pub(crate) ptr: NonNull<c_void>,
     pub(crate) api: &'a RedisJsonApi,
 }
 
@@ -101,7 +101,7 @@ impl<'a> JsonValueRef<'a> {
     /// # Safety
     ///
     /// 1. `ptr` must be a valid ptr obtained from `getKey*`.
-    pub(crate) const unsafe fn from_raw(ptr: *const c_void, api: &'a RedisJsonApi) -> Self {
+    pub(crate) const unsafe fn from_raw(ptr: NonNull<c_void>, api: &'a RedisJsonApi) -> Self {
         Self { ptr, api }
     }
 
@@ -112,7 +112,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: usize = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_len(self.ptr, &raw mut out) };
+        let status = unsafe { get_len(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -131,7 +131,7 @@ impl<'a> JsonValueRef<'a> {
         let get_type = vtable_fn!(self.api, getType);
 
         // Safety: `ptr` is valid by construction.
-        let raw = unsafe { get_type(self.ptr) };
+        let raw = unsafe { get_type(self.ptr.as_ptr()) };
 
         JsonType::from_raw(raw).expect("invalid JSON type")
     }
@@ -143,7 +143,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: i64 = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_int(self.ptr, &raw mut out) };
+        let status = unsafe { get_int(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -159,7 +159,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: f64 = 0.0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_double(self.ptr, &raw mut out) };
+        let status = unsafe { get_double(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -175,7 +175,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: i32 = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_boolean(self.ptr, &raw mut out) };
+        let status = unsafe { get_boolean(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out != 0)
@@ -192,7 +192,7 @@ impl<'a> JsonValueRef<'a> {
         let mut len: usize = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_string(self.ptr, &raw mut str, &raw mut len) };
+        let status = unsafe { get_string(self.ptr.as_ptr(), &raw mut str, &raw mut len) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             // Safety: `getString` returns `OK` it promises to return a valid c string.
@@ -213,7 +213,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out = JsonValue::new(self.api);
 
         // Safety: `ptr` is valid by construction, we correctly allocated the `JsonValue` before.
-        let status = unsafe { get_at(self.ptr, idx, out.as_ptr()) };
+        let status = unsafe { get_at(self.ptr.as_ptr(), idx, out.as_ptr()) };
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
         } else {
@@ -238,7 +238,7 @@ impl<'a> JsonValueRef<'a> {
             let get_key_values = vtable_fn!(self.api, getKeyValues);
 
             // Safety: `ptr` is valid by construction.
-            let ptr = unsafe { get_key_values(self.ptr) };
+            let ptr = unsafe { get_key_values(self.ptr.as_ptr()) };
             // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
             let ptr = NonNull::new(ptr.cast_mut())?;
 
@@ -256,7 +256,7 @@ impl<'a> JsonValueRef<'a> {
         let get = vtable_fn!(self.api, get);
 
         // Safety: `ptr` is valid by construction and CStr ensures `ptr` is a valid c string.
-        let ptr = unsafe { get(self.ptr, path.as_ptr()) };
+        let ptr = unsafe { get(self.ptr.as_ptr(), path.as_ptr()) };
         // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
         let ptr = NonNull::new(ptr.cast_mut())?;
 
@@ -279,7 +279,7 @@ impl<'a> JsonValueRef<'a> {
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.) and ptr is valid by construction.
-        let status = unsafe { get_json(self.ptr, ctx.as_ptr(), &mut str) };
+        let status = unsafe { get_json(self.ptr.as_ptr(), ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
@@ -325,7 +325,8 @@ impl<'a> JsonValue<'a> {
         JsonValueRef {
             // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
             // where we ensure the value is actually initialized before being handed out.
-            ptr: unsafe { *self.ptr },
+            ptr: NonNull::new(unsafe { *self.ptr }.cast_mut())
+                .expect("a populated `JsonValue` holds a non-null value"),
             api: self.api,
         }
     }

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -322,11 +322,14 @@ impl<'a> JsonValue<'a> {
 
     /// Get a non-owning reference to this `JsonValue`.
     pub fn as_ref(&self) -> JsonValueRef<'_> {
+        // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
+        // where we ensure the value is actually initialized before being handed out.
+        let ptr = unsafe { *self.ptr }.cast_mut();
+        debug_assert!(!ptr.is_null());
+
         JsonValueRef {
-            // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
-            // where we ensure the value is actually initialized before being handed out.
-            ptr: NonNull::new(unsafe { *self.ptr }.cast_mut())
-                .expect("a populated `JsonValue` holds a non-null value"),
+            // SAFETY: `new` asserts `allocJson` returned a non-null value.
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
             api: self.api,
         }
     }

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -230,7 +230,7 @@ impl<'a> JsonValueRef<'a> {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn key_values(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Option<KeyValuesIterator<'_>> {
         let (ptr, len) = if let Some(len) = self.len()
             && len > 0
@@ -272,18 +272,18 @@ impl<'a> JsonValueRef<'a> {
     #[inline]
     pub unsafe fn serialize(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Result<RedisString, SerializeError> {
         let get_json = vtable_fn!(self.api, getJSON);
 
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.) and ptr is valid by construction.
-        let status = unsafe { get_json(self.ptr, ctx, &mut str) };
+        let status = unsafe { get_json(self.ptr, ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 str.cast(),
             ))
         } else {

--- a/src/redisearch_rs/redis_reply/src/array.rs
+++ b/src/redisearch_rs/redis_reply/src/array.rs
@@ -118,7 +118,7 @@ impl Drop for ArrayBuilder<'_> {
             // SAFETY: ctx is validated at Replier construction
             unsafe {
                 RedisModule_ReplySetArrayLength.expect("RedisModule_ReplySetArrayLength")(
-                    self.replier.ctx,
+                    self.replier.ctx.as_ptr(),
                     i64::from(self.len),
                 );
             }

--- a/src/redisearch_rs/redis_reply/src/map.rs
+++ b/src/redisearch_rs/redis_reply/src/map.rs
@@ -130,7 +130,7 @@ impl Drop for MapBuilder<'_> {
             // SAFETY: ctx is validated at Replier construction
             unsafe {
                 RedisModule_ReplySetMapLength.expect("RedisModule_ReplySetMapLength")(
-                    self.replier.ctx,
+                    self.replier.ctx.as_ptr(),
                     i64::from(self.len),
                 );
             }

--- a/src/redisearch_rs/redis_reply/src/replier.rs
+++ b/src/redisearch_rs/redis_reply/src/replier.rs
@@ -8,6 +8,7 @@
 */
 
 use std::ffi::CStr;
+use std::ptr::NonNull;
 
 use redis_module::{
     REDISMODULE_POSTPONED_ARRAY_LEN, REDISMODULE_POSTPONED_LEN, RedisModule_ReplyWithArray,
@@ -25,7 +26,7 @@ use crate::map::MapBuilder;
 /// Validates the context once at construction and provides ergonomic
 /// methods for building Redis protocol replies.
 pub struct Replier {
-    pub(crate) ctx: *mut RedisModuleCtx,
+    pub(crate) ctx: NonNull<RedisModuleCtx>,
 }
 
 impl Replier {
@@ -34,8 +35,7 @@ impl Replier {
     /// # Safety
     ///
     /// - `ctx` must be a valid Redis module context for the lifetime of this Replier.
-    pub const unsafe fn new(ctx: *mut RedisModuleCtx) -> Self {
-        debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    pub const unsafe fn new(ctx: NonNull<RedisModuleCtx>) -> Self {
         Self { ctx }
     }
 
@@ -43,7 +43,10 @@ impl Replier {
     pub fn long_long(&mut self, value: i64) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithLongLong.expect("RedisModule_ReplyWithLongLong")(self.ctx, value);
+            RedisModule_ReplyWithLongLong.expect("RedisModule_ReplyWithLongLong")(
+                self.ctx.as_ptr(),
+                value,
+            );
         }
     }
 
@@ -51,7 +54,10 @@ impl Replier {
     pub fn double(&mut self, value: f64) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithDouble.expect("RedisModule_ReplyWithDouble")(self.ctx, value);
+            RedisModule_ReplyWithDouble.expect("RedisModule_ReplyWithDouble")(
+                self.ctx.as_ptr(),
+                value,
+            );
         }
     }
 
@@ -60,7 +66,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithSimpleString.expect("RedisModule_ReplyWithSimpleString")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 s.as_ptr(),
             );
         }
@@ -71,7 +77,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithStringBuffer.expect("RedisModule_ReplyWithStringBuffer")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 buf.as_ptr().cast(),
                 buf.len(),
             );
@@ -82,7 +88,9 @@ impl Replier {
     pub fn empty_array(&mut self) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithEmptyArray.expect("RedisModule_ReplyWithEmptyArray")(self.ctx);
+            RedisModule_ReplyWithEmptyArray.expect("RedisModule_ReplyWithEmptyArray")(
+                self.ctx.as_ptr(),
+            );
         }
     }
 
@@ -90,7 +98,7 @@ impl Replier {
     pub fn empty_map(&mut self) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx, 0);
+            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx.as_ptr(), 0);
         }
     }
 
@@ -101,7 +109,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithArray.expect("RedisModule_ReplyWithArray")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 REDISMODULE_POSTPONED_ARRAY_LEN as i64,
             );
         }
@@ -120,7 +128,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 REDISMODULE_POSTPONED_LEN as i64,
             );
         }
@@ -139,7 +147,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithArray.expect("RedisModule_ReplyWithArray")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 i64::from(len),
             );
         }
@@ -157,7 +165,10 @@ impl Replier {
     pub fn fixed_map(&mut self, len: u32) -> MapBuilder<'_> {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx, i64::from(len));
+            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(
+                self.ctx.as_ptr(),
+                i64::from(len),
+            );
         }
         MapBuilder {
             replier: self,

--- a/src/redisearch_rs/redis_reply/tests/integration/main.rs
+++ b/src/redisearch_rs/redis_reply/tests/integration/main.rs
@@ -30,7 +30,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 pub fn init() -> Replier {
     redis_mock::init_redis_module_mock();
     // SAFETY: Context is ignored in mock mode, using non-null dummy address
-    unsafe { Replier::new(std::ptr::dangling_mut::<RedisModuleCtx>()) }
+    unsafe { Replier::new(std::ptr::NonNull::<RedisModuleCtx>::dangling()) }
 }
 
 /// Extract a single reply, panicking if there are zero or multiple replies.

--- a/src/redisearch_rs/reducers/src/reducer.rs
+++ b/src/redisearch_rs/reducers/src/reducer.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{ffi::c_void, ptr};
+use std::{ffi::c_void, ptr, ptr::NonNull};
 
 /// A safe wrapper around an `ffi::Reducer`.
 #[repr(transparent)]
@@ -34,17 +34,17 @@ impl Reducer {
         })
     }
 
-    /// Create a `Reducer` wrapper from a non-null pointer.
+    /// Create a `Reducer` wrapper from a pointer.
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid non-null pointer to an `ffi::Reducer` that is properly initialized.
+    /// 1. `ptr` must be a [valid] pointer to an `ffi::Reducer` that is properly initialized.
     ///    This also applies to any of its subfields.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub const unsafe fn from_raw<'a>(ptr: *const ffi::Reducer) -> &'a Self {
+    pub const unsafe fn from_raw<'a>(ptr: NonNull<ffi::Reducer>) -> &'a Self {
         // SAFETY: ensured by caller (1.)
-        unsafe { ptr.cast::<Self>().as_ref().unwrap() }
+        unsafe { &*ptr.cast::<Self>().as_ptr() }
     }
 
     /// Set `NewInstance` function pointer.

--- a/src/redisearch_rs/reducers/src/reducer.rs
+++ b/src/redisearch_rs/reducers/src/reducer.rs
@@ -34,7 +34,7 @@ impl Reducer {
         })
     }
 
-    /// Create a `Reducer` wrapper from a pointer.
+    /// Borrow `ptr` as a shared `Reducer`.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/reducers/src/reducer_options.rs
+++ b/src/redisearch_rs/reducers/src/reducer_options.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use query_error::QueryError;
 
 /// A safe wrapper around an `ffi::ReducerOptions`.
@@ -14,17 +16,17 @@ use query_error::QueryError;
 pub struct ReducerOptions(ffi::ReducerOptions);
 
 impl ReducerOptions {
-    /// Create a `ReducerOptions` wrapper from a non-null pointer.
+    /// Create a `ReducerOptions` wrapper from a pointer.
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid non-null pointer to an `ffi::ReducerOptions` that is properly initialized.
+    /// 1. `ptr` must be a [valid] pointer to an `ffi::ReducerOptions` that is properly initialized.
     ///    This also applies to any of its subfields.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::ReducerOptions) -> &'a mut Self {
+    pub const unsafe fn from_raw_mut<'a>(ptr: NonNull<ffi::ReducerOptions>) -> &'a mut Self {
         // SAFETY: ensured by caller (1.)
-        unsafe { ptr.cast::<Self>().as_mut().unwrap() }
+        unsafe { &mut *ptr.cast::<Self>().as_ptr() }
     }
 
     /// Get a reference to the `args` cursor.

--- a/src/redisearch_rs/reducers/src/reducer_options.rs
+++ b/src/redisearch_rs/reducers/src/reducer_options.rs
@@ -16,7 +16,7 @@ use query_error::QueryError;
 pub struct ReducerOptions(ffi::ReducerOptions);
 
 impl ReducerOptions {
-    /// Create a `ReducerOptions` wrapper from a pointer.
+    /// Borrow `ptr` as an exclusive `ReducerOptions`.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -86,7 +86,7 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
         // Safety: the `&'key` reference guarantees `open_key` is valid for `'key`.
         let value = unsafe {
             self.japi
-                .open_from_handle(ptr::from_ref(open_key).cast_mut().cast())
+                .open_from_handle(Some(NonNull::from_ref(open_key).cast()))
         }
         // If we fail to open the JSON root from the borrowed handle: fall back to
         // open the document by name.

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -52,11 +52,8 @@ impl<'a> JsonDocumentFormat<'a> {
     fn open_key(&self, key_name: &RedisString) -> Option<JsonValueRef<'a>> {
         // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
         unsafe {
-            self.japi.open_key_with_flags(
-                self.ctx.cast().as_ptr(),
-                key_name,
-                DOCUMENT_OPEN_KEY_QUERY_FLAGS,
-            )
+            self.japi
+                .open_key_with_flags(self.ctx.cast(), key_name, DOCUMENT_OPEN_KEY_QUERY_FLAGS)
         }
     }
 }
@@ -197,7 +194,7 @@ fn json_iter_to_value(
 
     // SAFETY: `ctx` is a valid Redis module context by construction of `JsonFormat`.
     // First get the JSON serialized value (since it does not consume the iterator)
-    let serialized = unsafe { iter.serialize(ctx.cast().as_ptr())? };
+    let serialized = unsafe { iter.serialize(ctx.cast())? };
 
     // Second, get the first JSON value. `is_empty()` returned false above, so the
     // iterator is contractually obligated to yield at least one value here.
@@ -249,7 +246,7 @@ fn json_val_to_value_expanded(
     match json.get_type() {
         JsonType::Object => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
-            let iter = unsafe { json.key_values(ctx.cast().as_ptr()).unwrap() };
+            let iter = unsafe { json.key_values(ctx.cast()).unwrap() };
 
             let values = iter.map(|(key, value)| {
                 let key = SharedValue::new_string(key.to_vec());
@@ -300,7 +297,7 @@ fn json_val_to_value(
         }
         JsonType::Object | JsonType::Array => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
-            let v = unsafe { json.serialize(ctx.cast().as_ptr()).unwrap() };
+            let v = unsafe { json.serialize(ctx.cast()).unwrap() };
             redis_module::raw::string_retain_string(ptr::null_mut(), v.inner);
             // SAFETY: `v` is a valid Redis string and we retained it above to
             // transfer one owned reference into the RSValue.

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -52,6 +52,8 @@
 //! directly into [`RQEIteratorBoxed`] / [`RQEDynIterator`], and
 //! [`RQEIteratorBoxed`] will be renamed back to `RQEIterator`.
 
+use std::ptr::NonNull;
+
 use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
@@ -283,15 +285,13 @@ pub(crate) const fn assert_layout_compatible<A, B>() {
 /// if it did, unwinding past the uninitialised slot would let the owner drop a
 /// moved-from value (double drop). To keep the window sound, a panic from
 /// `suspend` is converted into a process abort rather than an unwind.
-pub unsafe fn suspend_child_slot_in_place<'index, I>(slot: *mut I)
+pub unsafe fn suspend_child_slot_in_place<'index, I>(slot: NonNull<I>)
 where
     I: RQEIteratorBoxed<'index> + 'index,
 {
     // Statically enforce the size/alignment invariant the `ptr::write` cast
     // below relies on: a mismatched-layout implementer fails to compile here.
     const { assert_layout_compatible::<I, I::Suspended>() };
-
-    debug_assert!(!slot.is_null(), "slot must not be null");
 
     /// Aborts the process if dropped during unwinding through the
     /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once the
@@ -306,7 +306,7 @@ where
     // SAFETY: caller guarantees `slot` is exclusively owned and points to a
     // valid `I` value. `ptr::read` moves the value out; the slot bytes are
     // typed-but-moved-from until the matching `ptr::write` below.
-    let active = unsafe { std::ptr::read(slot) };
+    let active = unsafe { std::ptr::read(slot.as_ptr()) };
     // Armed across the uninitialised-slot window: if `suspend` panics, drop
     // aborts instead of unwinding through the moved-from slot.
     let bomb = AbortOnUnwind;
@@ -321,7 +321,7 @@ where
     // `assert_layout_compatible` guard at the top of the body). The slot is
     // uninitialised after the earlier `ptr::read`; writing a valid `I::Suspended`
     // reinitialises it.
-    unsafe { std::ptr::write(slot as *mut I::Suspended, suspended) };
+    unsafe { std::ptr::write(slot.cast::<I::Suspended>().as_ptr(), suspended) };
     // Slot reinitialised — disarm the abort guard.
     std::mem::forget(bomb);
 }
@@ -377,7 +377,7 @@ pub(crate) enum ResumeSlotOutcome {
 /// panic is converted into a process abort rather than an unwind through the
 /// uninitialised slot.
 pub(crate) unsafe fn resume_child_slot_in_place<'query, 'a, S>(
-    slot: *mut S,
+    slot: NonNull<S>,
     guard: &IndexSpecReadGuard<'a>,
 ) -> Result<ResumeSlotOutcome, RQEIteratorError>
 where
@@ -387,8 +387,6 @@ where
     // Statically enforce the size/alignment invariant the `ptr::write` cast
     // below relies on: a mismatched-layout implementer fails to compile here.
     const { assert_layout_compatible::<S, S::Resumed<'a>>() };
-
-    debug_assert!(!slot.is_null(), "slot must not be null");
 
     /// Aborts the process if dropped during unwinding through the
     /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once
@@ -403,7 +401,7 @@ where
     // SAFETY: caller guarantees `slot` is exclusively owned and points to a
     // valid `S` value. `ptr::read` moves the value out; the slot bytes are
     // typed-but-moved-from until the matching `ptr::write` (or teardown) below.
-    let suspended = unsafe { std::ptr::read(slot) };
+    let suspended = unsafe { std::ptr::read(slot.as_ptr()) };
     // Armed across the uninitialised-slot window: if `resume` panics, drop
     // aborts instead of unwinding through the moved-from slot.
     let bomb = AbortOnUnwind;
@@ -422,7 +420,7 @@ where
     // the `assert_layout_compatible` guard at the top of the body). The slot is
     // uninitialised after the earlier `ptr::read`; writing a valid
     // `S::Resumed<'a>` reinitialises it.
-    unsafe { std::ptr::write(slot as *mut S::Resumed<'a>, *active) };
+    unsafe { std::ptr::write(slot.cast::<S::Resumed<'a>>().as_ptr(), *active) };
     Ok(if moved {
         ResumeSlotOutcome::Moved
     } else {

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -178,8 +178,6 @@ impl CRQEIterator {
         I: RQEIterator<'index> + ProfilePrint + 'index,
     {
         let ptr = RQEIteratorWrapper::boxed_new(inner);
-        // SAFETY: `boxed_new` uses `Box::into_raw`, which is guaranteed non-null.
-        let ptr = unsafe { NonNull::new_unchecked(ptr) };
         // SAFETY: `ptr` is a valid, uniquely-owned `QueryIterator` with all
         // required callbacks populated by `boxed_new`.
         unsafe { CRQEIterator::new(ptr) }
@@ -363,9 +361,8 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
     fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
         match self.type_ {
             IteratorType::Intersect => {
-                let ptr = std::ptr::from_ref(self.as_ref());
                 // SAFETY:
-                // - `type_ == INTERSECT_ITERATOR` guarantees `ptr` was produced by
+                // - `type_ == INTERSECT_ITERATOR` guarantees `self` was produced by
                 //   `RQEIteratorWrapper::boxed_new` with `Intersection<CRQEIterator>` as the
                 //   inner type (`NewIntersectionIterator` is the sole constructor of a C
                 //   wrapped intersection).
@@ -373,16 +370,17 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
                 //   rather than manual `size_of` arithmetic, making it immune to alignment
                 //   padding between `header` and `inner` in `RQEIteratorWrapper`.
                 let n = unsafe {
-                    RQEIteratorWrapper::<Intersection<'_, CRQEIterator>>::ref_from_header_ptr(ptr)
-                        .inner
-                        .num_children()
+                    RQEIteratorWrapper::<Intersection<'_, CRQEIterator>>::ref_from_header_ptr(
+                        NonNull::from_ref(self.as_ref()),
+                    )
+                    .inner
+                    .num_children()
                 };
                 1.0 / n.max(1) as f64
             }
             IteratorType::Union if prioritize_union_children => {
-                let ptr = std::ptr::from_ref(self.as_ref());
                 // SAFETY:
-                // - `type_ == Union` guarantees `ptr` was produced by
+                // - `type_ == Union` guarantees `self` was produced by
                 //   `RQEIteratorWrapper::boxed_new_inner` with
                 //   `UnionOpaque<CRQEIterator>` as the inner type
                 //   (`NewUnionIterator` is the sole constructor of a C wrapped union).
@@ -391,7 +389,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
                 //   padding between `header` and `inner` in `RQEIteratorWrapper`.
                 let n = unsafe {
                     RQEIteratorWrapper::<super::UnionOpaque<'_, CRQEIterator>>::ref_from_header_ptr(
-                        ptr,
+                        NonNull::from_ref(self.as_ref()),
                     )
                     .inner
                     .num_children_active()
@@ -474,7 +472,7 @@ impl CRQEIterator {
             // Preserve a root-only iterator's cleared `SkipTo` (top_k is the only
             // user today) across the outer `Profile` rebox.
             // SAFETY: `result` was just constructed above and has no other alias yet.
-            unsafe { crate::interop::patch_vtable(result.as_raw().as_ptr(), |h| h.SkipTo = None) };
+            unsafe { crate::interop::patch_vtable(result.as_raw(), |h| h.SkipTo = None) };
         }
         result
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -388,7 +388,7 @@ impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
+    /// 1. `slot` is aligned and points to an initialized
     ///    `SuspendedIdList<'query, SORTED>`.
     /// 2. `slot` is unaliased for the duration of the call.
     ///
@@ -396,14 +396,14 @@ impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
     /// at the active type for `'a`; in the `Err` case the slot is byte-for-byte
     /// unchanged and remains a valid `SuspendedIdList<'query, SORTED>`.
     pub(crate) unsafe fn resume_in_place<'a>(
-        slot: *mut Self,
-    ) -> Result<*mut IdList<'a, SORTED>, *mut Self>
+        slot: NonNull<Self>,
+    ) -> Result<NonNull<IdList<'a, SORTED>>, NonNull<Self>>
     where
         'query: 'a,
     {
-        // SAFETY: `slot` is non-null, aligned, initialized, and unaliased (caller
+        // SAFETY: `slot` is aligned, initialized, and unaliased (caller
         // contracts 1 & 2), so a shared read of the result kind is sound.
-        let kind = unsafe { (*slot).result.kind() };
+        let kind = unsafe { (*slot.as_ptr()).result.kind() };
         if kind != RSResultKind::Metric && kind != RSResultKind::Virtual {
             tracing::warn!(
                 "An internal invariant has been violated. A suspended id list is storing a {kind} \
@@ -413,11 +413,14 @@ impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
             return Err(slot);
         }
 
-        // SAFETY: `slot` is non-null, aligned, and points to an initialized
+        // SAFETY: `slot` is aligned and points to an initialized
         // `RawIdList<'query, Suspended, SORTED>` (caller contract 1). `&raw mut` forms a
         // field pointer without creating a reference, leaving `slot`'s provenance
         // over the whole allocation intact for the cast below.
-        let result_slot = unsafe { &raw mut (*slot).result };
+        let result_slot = unsafe { &raw mut (*slot.as_ptr()).result };
+        // SAFETY: `result_slot` is a field pointer derived from the non-null `slot`, so it is
+        // non-null too.
+        let result_slot = unsafe { NonNull::new_unchecked(result_slot) };
         // SAFETY: all preconditions of `into_active_in_place` are met:
         // 1. `result_slot` points at an initialized `RawIndexResult<'query, Suspended>`.
         // 2. `result_slot` is not aliased (caller contract 2).
@@ -425,11 +428,7 @@ impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
         //    the result is virtual or metric. Those variants own their data.
         //    So conditions (1)–(4) range over no pointers and hold for any `'a`; the
         //    `'query: 'a` bound covers any retained query-pipeline pointers.
-        unsafe {
-            RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(
-                NonNull::new(result_slot).expect("`result_slot` must not be null"),
-            )
-        };
+        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
         Ok(slot.cast::<IdList<'a, SORTED>>())
     }
 }
@@ -448,22 +447,23 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
+    /// 1. `slot` is aligned and points to an initialized
     ///    `IdList<'index, SORTED>`.
     /// 2. `slot` is unaliased for the duration of the call.
-    pub(crate) unsafe fn suspend_in_place(slot: *mut Self) -> *mut SuspendedIdList<'index, SORTED> {
-        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+    pub(crate) unsafe fn suspend_in_place(
+        slot: NonNull<Self>,
+    ) -> NonNull<SuspendedIdList<'index, SORTED>> {
+        // SAFETY: `slot` is aligned and initialized (caller contract 1).
         // `&raw mut` forms a field pointer without creating a reference, leaving
         // `slot`'s provenance over the whole allocation intact for the cast below.
-        let result_slot = unsafe { &raw mut (*slot).result };
+        let result_slot = unsafe { &raw mut (*slot.as_ptr()).result };
+        // SAFETY: `result_slot` is a field pointer derived from the non-null `slot`, so it is
+        // non-null too.
+        let result_slot = unsafe { NonNull::new_unchecked(result_slot) };
         // SAFETY: `into_suspended_in_place`'s contract is met — `result_slot` points at
         // an initialized `RSIndexResult<'index>` and is not aliased (caller contracts
         // 1 and 2). Suspending is a safe widening conversion with no further precondition.
-        unsafe {
-            RawIndexResult::<Active<'index>>::into_suspended_in_place(
-                NonNull::new(result_slot).expect("`result_slot` must not be null"),
-            )
-        };
+        unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
 
         slot.cast::<SuspendedIdList<'index, SORTED>>()
     }
@@ -473,15 +473,15 @@ impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdList<'index, SOR
     type Suspended = SuspendedIdList<'index, SORTED>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let active: *mut Self = Box::into_raw(self);
+        let active = NonNull::from(Box::leak(self));
 
-        // SAFETY: `suspend_in_place`'s contract is met — `active` is non-null, aligned, and
+        // SAFETY: `suspend_in_place`'s contract is met — `active` is aligned and
         // initialized (it just came from a `Box`), and unaliased (this function owns `self`).
         let suspended_ptr = unsafe { IdList::<'index, SORTED>::suspend_in_place(active) };
 
-        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::into_raw` above, so the
+        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::leak` above, so the
         // address is unchanged and every field is now valid at the suspended type.
-        unsafe { Box::from_raw(suspended_ptr) }
+        unsafe { Box::from_raw(suspended_ptr.as_ptr()) }
     }
 }
 
@@ -498,22 +498,24 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for SuspendedIdLis
     where
         'query: 'index,
     {
-        let suspended: *mut Self = Box::into_raw(self);
+        let suspended = NonNull::from(Box::leak(self));
 
         // SAFETY: `resume_in_place`'s contract is met:
-        // 1. `suspended` is non-null, aligned, and initialized — it just came from a `Box`.
+        // 1. `suspended` is aligned and initialized — it just came from a `Box`.
         // 2. `suspended` is not aliased, since this function has ownership of `self`.
         match unsafe { SuspendedIdList::<'query, SORTED>::resume_in_place::<'index>(suspended) } {
             Ok(active_ptr) => {
-                // SAFETY: `active_ptr` reuses the same allocation from `Box::into_raw` above, so
+                // SAFETY: `active_ptr` reuses the same allocation from `Box::leak` above, so
                 // the address is unchanged and every field is now valid at the active type for
                 // `'index`.
-                Ok(ResumeOutcome::Ok(unsafe { Box::from_raw(active_ptr) }))
+                Ok(ResumeOutcome::Ok(unsafe {
+                    Box::from_raw(active_ptr.as_ptr())
+                }))
             }
             Err(suspended_ptr) => {
                 // SAFETY: `suspended_ptr` is the same allocation, left untouched and still a valid
                 // `SuspendedIdList`. Reclaim ownership so it is dropped.
-                drop(unsafe { Box::from_raw(suspended_ptr) });
+                drop(unsafe { Box::from_raw(suspended_ptr.as_ptr()) });
                 Ok(ResumeOutcome::Aborted)
             }
         }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -14,6 +14,7 @@ use index_spec::IndexSpecReadGuard;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 use std::cmp::Ordering;
+use std::ptr::NonNull;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
@@ -424,7 +425,11 @@ impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
         //    the result is virtual or metric. Those variants own their data.
         //    So conditions (1)–(4) range over no pointers and hold for any `'a`; the
         //    `'query: 'a` bound covers any retained query-pipeline pointers.
-        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
+        unsafe {
+            RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
+        };
         Ok(slot.cast::<IdList<'a, SORTED>>())
     }
 }
@@ -454,7 +459,11 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
         // SAFETY: `into_suspended_in_place`'s contract is met — `result_slot` points at
         // an initialized `RSIndexResult<'index>` and is not aliased (caller contracts
         // 1 and 2). Suspending is a safe widening conversion with no further precondition.
-        unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
+        unsafe {
+            RawIndexResult::<Active<'index>>::into_suspended_in_place(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
+        };
 
         slot.cast::<SuspendedIdList<'index, SORTED>>()
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
@@ -13,6 +13,7 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
+use std::ptr::NonNull;
 
 use crate::{
     IdList, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
@@ -186,7 +187,7 @@ impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdListLazy<'index,
     type Suspended = SuspendedIdListLazy<'index, SORTED>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let active = Box::into_raw(self);
+        let active = NonNull::from(Box::leak(self));
 
         // Suspend the wrapped id list in place, leaving the outer
         // allocation (and the `Rf`-independent `producer`) untouched.
@@ -194,15 +195,24 @@ impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdListLazy<'index,
         // SAFETY: `&raw mut` forms a field pointer without creating a reference,
         // preserving `active`'s provenance over the whole allocation for the outer
         // cast below.
-        let inner_slot = unsafe { &raw mut (*active).inner };
+        let inner_slot = unsafe { &raw mut (*active.as_ptr()).inner };
+        // SAFETY: `inner_slot` is a field pointer derived from the non-null `active`, so it is
+        // non-null too.
+        let inner_slot = unsafe { NonNull::new_unchecked(inner_slot) };
         // SAFETY: `suspend_in_place`'s contract is met — `inner_slot` is initialized and
         // unaliased (this function owns `self`). Suspending is a safe widening conversion.
         unsafe { IdList::<'index, SORTED>::suspend_in_place(inner_slot) };
 
         // SAFETY: `IdListLazy` and `SuspendedIdListLazy` are both `#[repr(C)]` with identical
-        // field layout. `Box::from_raw` reuses the same heap allocation as `Box::into_raw`,
+        // field layout. `Box::from_raw` reuses the same heap allocation as `Box::leak`,
         // so the address is unchanged.
-        unsafe { Box::from_raw(active.cast::<SuspendedIdListLazy<'index, SORTED>>()) }
+        unsafe {
+            Box::from_raw(
+                active
+                    .cast::<SuspendedIdListLazy<'index, SORTED>>()
+                    .as_ptr(),
+            )
+        }
     }
 }
 
@@ -221,7 +231,7 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query>
     where
         'query: 'index,
     {
-        let suspended = Box::into_raw(self);
+        let suspended = NonNull::from(Box::leak(self));
 
         // Promote the wrapped id list's `result` field in place, leaving the outer
         // allocation (and the `Rf`-independent `producer`) untouched.
@@ -229,7 +239,10 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query>
         // SAFETY: `&raw mut` forms a field pointer without creating a reference,
         // preserving `suspended`'s provenance over the whole allocation for the
         // outer cast below.
-        let inner_slot = unsafe { &raw mut (*suspended).inner };
+        let inner_slot = unsafe { &raw mut (*suspended.as_ptr()).inner };
+        // SAFETY: `inner_slot` is a field pointer derived from the non-null `suspended`, so it is
+        // non-null too.
+        let inner_slot = unsafe { NonNull::new_unchecked(inner_slot) };
         // SAFETY: `resume_in_place`'s contract is met — `inner_slot` is initialized and
         // unaliased (this function owns `self`). We reclaim the outer allocation via `suspended`
         // in either branch, so the inner pointer it returns is not needed.
@@ -237,19 +250,20 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query>
             Ok(_) => {
                 // SAFETY: layout-compatible — see `suspend`. `inner`'s `result` is now valid at
                 // the active type for `'index`; the remaining fields carry no `Rf`. `Box::from_raw`
-                // reuses the same heap allocation as `suspend`'s `Box::into_raw`, so the address
+                // reuses the same heap allocation as `suspend`'s `Box::leak`, so the address
                 // is unchanged.
-                let active =
-                    unsafe { Box::from_raw(suspended.cast::<IdListLazy<'index, SORTED>>()) };
+                let active = unsafe {
+                    Box::from_raw(suspended.cast::<IdListLazy<'index, SORTED>>().as_ptr())
+                };
                 Ok(ResumeOutcome::Ok(active))
             }
             Err(_) => {
                 // `resume_in_place` left the inner id list untouched (the stored result kind was
                 // neither metric nor virtual), so the outer allocation is still a valid
                 // `SuspendedIdListLazy`.
-                // SAFETY: `suspended` came from `Box::into_raw` above and was not mutated; reclaim
+                // SAFETY: `suspended` came from `Box::leak` above and was not mutated; reclaim
                 // ownership so it is dropped.
-                drop(unsafe { Box::from_raw(suspended) });
+                drop(unsafe { Box::from_raw(suspended.as_ptr()) });
                 Ok(ResumeOutcome::Aborted)
             }
         }

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -69,9 +69,10 @@ where
         // Derive the self-referential `current` pointer only *after* the box is
         // stable behind a raw pointer. `sync_current` reads `inner` and writes
         // `header.current` through a single `&mut self`, so the borrow never
-        // escapes across `Box::into_raw`'s `Unique` retag (which would pop it).
+        // escapes across the leaked box's `Unique` retag (which would pop it).
         let mut raw = NonNull::from(Box::leak(wrapper));
-        // SAFETY: `raw` came from `Box::leak`, so it is non-null,
+        // SAFETY: `raw` is the leaked box: initialized, aligned, and — since
+        // nothing else has seen it yet — uniquely ours to borrow mutably.
         unsafe {
             raw.as_mut().sync_current();
         }
@@ -395,16 +396,18 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
     base: *mut QueryIterator,
 ) -> *mut QueryIterator {
     debug_assert!(base.is_aligned());
+    let base = NonNull::new(base).expect("`base` must not be null");
     // SAFETY:
     // 1. As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
-    //    `base` is a non-null, aligned, live header, uniquely owned until it is
-    //    consumed into the `Box` below.
+    //    `base` is an aligned, live header, uniquely owned until it is consumed
+    //    into the `Box` below.
     // 2. `SkipTo` is `Copy`, so reading it through a shared reference leaves
     //    `base` intact for that `Box::from_raw`.
-    let had_no_skip_to = unsafe { (*base).SkipTo.is_none() };
+    let had_no_skip_to = unsafe { (*base.as_ptr()).SkipTo.is_none() };
     // SAFETY: Callbacks are guaranteed to get a header pointer created by
-    // `RQEIteratorWrapper::boxed_new_compound`, which uses `Box::into_raw`.
-    let it = unsafe { Box::from_raw(base as *mut RQEIteratorWrapper<I>) };
+    // `RQEIteratorWrapper::boxed_new_compound`, so it owns a `Box` allocation of
+    // the wrapper around `I`.
+    let it = unsafe { Box::from_raw(base.cast::<RQEIteratorWrapper<I>>().as_ptr()) };
     let profiled = it.inner.profile_children();
     // Re-wrap with `boxed_new_inner` instead of `boxed_new_compound`: profiling is
     // a one-shot pass, so the result's children are already profiled and the
@@ -423,8 +426,8 @@ extern "C" fn free_iterator<'index, I: RQEIterator<'index> + 'index>(base: *mut 
     if !base.is_null() {
         debug_assert!(base.is_aligned());
         // SAFETY: Callbacks are guaranteed to get a header pointer created by
-        //  `RQEIteratorWrapper::boxed_new` or `boxed_new_compound`,
-        //  which (internally) use `Box::into_raw` to return a raw header pointer.
+        //  `RQEIteratorWrapper::boxed_new` or `boxed_new_compound`, so it owns a
+        //  `Box` allocation of the wrapper around `I`.
         let _ = unsafe { Box::from_raw(base as *mut RQEIteratorWrapper<I>) };
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -218,12 +218,11 @@ extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
 ) -> IteratorStatus {
     debug_assert!(base.is_aligned());
+    debug_assert!(!base.is_null());
+    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe {
-        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
-            NonNull::new(base).expect("`base` must not be null"),
-        )
-    };
+    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
     match wrapper.inner.read() {
         Ok(Some(result)) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -249,12 +248,11 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
     doc_id: DocId,
 ) -> IteratorStatus {
     debug_assert!(base.is_aligned());
+    debug_assert!(!base.is_null());
+    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe {
-        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
-            NonNull::new(base).expect("`base` must not be null"),
-        )
-    };
+    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
     match wrapper.inner.skip_to(doc_id) {
         Ok(Some(SkipToOutcome::Found(result))) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -313,12 +311,11 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
         return ValidateStatus_VALIDATE_TIMEOUT;
     }
 
+    debug_assert!(!base.is_null());
+    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe {
-        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
-            NonNull::new(base).expect("`base` must not be null"),
-        )
-    };
+    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
 
     // SAFETY: spec is a valid pointer (guaranteed by C caller)
     let spec_ref = unsafe { &*spec };
@@ -356,12 +353,11 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
 
 extern "C" fn rewind<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIterator) {
     debug_assert!(base.is_aligned());
+    debug_assert!(!base.is_null());
+    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe {
-        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
-            NonNull::new(base).expect("`base` must not be null"),
-        )
-    };
+    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
     wrapper.inner.rewind();
     wrapper.header.lastDocId = wrapper.inner.last_doc_id();
     wrapper.header.atEOF = wrapper.inner.at_eof();
@@ -396,7 +392,10 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
     base: *mut QueryIterator,
 ) -> *mut QueryIterator {
     debug_assert!(base.is_aligned());
-    let base = NonNull::new(base).expect("`base` must not be null");
+    debug_assert!(!base.is_null());
+    // SAFETY: As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
+    // `base` is a live header, so it is non-null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY:
     // 1. As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
     //    `base` is an aligned, live header, uniquely owned until it is consumed

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -15,6 +15,7 @@ use ffi::{
 };
 use index_result::RSIndexResult;
 use rqe_core::DocId;
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{
@@ -47,7 +48,7 @@ where
     pub fn boxed_new_inner(
         inner: I,
         profile_children: Option<unsafe extern "C" fn(*mut QueryIterator) -> *mut QueryIterator>,
-    ) -> *mut QueryIterator {
+    ) -> NonNull<QueryIterator> {
         let wrapper = Box::new(Self {
             header: QueryIterator {
                 type_: inner.type_(),
@@ -69,12 +70,12 @@ where
         // stable behind a raw pointer. `sync_current` reads `inner` and writes
         // `header.current` through a single `&mut self`, so the borrow never
         // escapes across `Box::into_raw`'s `Unique` retag (which would pop it).
-        let raw = Box::into_raw(wrapper);
-        // SAFETY: `raw` was just produced by `Box::into_raw`, so it is non-null,
+        let mut raw = NonNull::from(Box::leak(wrapper));
+        // SAFETY: `raw` came from `Box::leak`, so it is non-null,
         unsafe {
-            (*raw).sync_current();
+            raw.as_mut().sync_current();
         }
-        raw as *mut QueryIterator
+        raw.cast::<QueryIterator>()
     }
 }
 
@@ -87,7 +88,7 @@ where
     /// The wrapper is placed on the heap. The `ProfileChildren` C callback is
     /// set to `None` — use [`boxed_new_compound`](Self::boxed_new_compound) for
     /// compound iterators that need the callback.
-    pub fn boxed_new(inner: I) -> *mut QueryIterator {
+    pub fn boxed_new(inner: I) -> NonNull<QueryIterator> {
         Self::boxed_new_inner(inner, None)
     }
 }
@@ -155,7 +156,7 @@ where
     /// Sets the `ProfileChildren` C callback to [`rust_profile_children`],
     /// which calls [`ProfileChildren::profile_children`]
     /// to preserve the concrete type through profiling.
-    pub fn boxed_new_compound(inner: I) -> *mut QueryIterator {
+    pub fn boxed_new_compound(inner: I) -> NonNull<QueryIterator> {
         debug_assert!(
             !inner.type_().is_leaf(),
             "boxed_new_compound should only be used for compound iterators"
@@ -191,19 +192,10 @@ where
     /// 2. The caller must ensure that the provided header matches the expected Rust iterator type.
     /// 3. The caller must ensure that it has a unique handle over the provided header.
     pub const unsafe fn mut_ref_from_header_ptr(
-        base: *mut QueryIterator,
+        base: NonNull<QueryIterator>,
     ) -> &'index mut RQEIteratorWrapper<I> {
-        debug_assert!(!base.is_null());
-
         // SAFETY: Guaranteed by 1 + 2.
-        let wrapper = unsafe { base.cast::<RQEIteratorWrapper<I>>().as_mut() };
-
-        if cfg!(debug_assertions) {
-            wrapper.expect("Unexpected null pointer!")
-        } else {
-            // SAFETY: Guaranteed by 1.
-            unsafe { wrapper.unwrap_unchecked() }
-        }
+        unsafe { base.cast::<RQEIteratorWrapper<I>>().as_mut() }
     }
 
     /// Convert a type-erased iterator "header into a wrapper around a specific Rust iterator type.
@@ -214,25 +206,23 @@ where
     ///    [`RQEIteratorWrapper::boxed_new`] or [`RQEIteratorWrapper::boxed_new_compound`].
     /// 2. The caller must ensure that the provided header matches the expected Rust iterator type.
     pub const unsafe fn ref_from_header_ptr(
-        base: *const QueryIterator,
+        base: NonNull<QueryIterator>,
     ) -> &'index RQEIteratorWrapper<I> {
-        debug_assert!(!base.is_null());
         // SAFETY: Guaranteed by 1 + 2.
-        unsafe {
-            base.cast::<RQEIteratorWrapper<I>>()
-                .as_ref()
-                .expect("Null pointer!")
-        }
+        unsafe { base.cast::<RQEIteratorWrapper<I>>().as_ref() }
     }
 }
 
 extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
 ) -> IteratorStatus {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     match wrapper.inner.read() {
         Ok(Some(result)) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -257,10 +247,13 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
     doc_id: DocId,
 ) -> IteratorStatus {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     match wrapper.inner.skip_to(doc_id) {
         Ok(Some(SkipToOutcome::Found(result))) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -310,7 +303,6 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
     spec: *mut ffi::IndexSpec,
 ) -> ValidateStatus {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     debug_assert!(!spec.is_null());
 
@@ -321,7 +313,11 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     }
 
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
 
     // SAFETY: spec is a valid pointer (guaranteed by C caller)
     let spec_ref = unsafe { &*spec };
@@ -358,10 +354,13 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
 }
 
 extern "C" fn rewind<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIterator) {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     wrapper.inner.rewind();
     wrapper.header.lastDocId = wrapper.inner.last_doc_id();
     wrapper.header.atEOF = wrapper.inner.at_eof();
@@ -375,10 +374,13 @@ extern "C" fn rewind<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIt
 extern "C" fn num_estimated<'index, I: RQEIterator<'index> + 'index>(
     base: *const QueryIterator,
 ) -> usize {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::ref_from_header_ptr(
+            NonNull::new(base.cast_mut()).expect("`base` must not be null"),
+        )
+    };
     wrapper.inner.num_estimated()
 }
 
@@ -392,7 +394,6 @@ extern "C" fn num_estimated<'index, I: RQEIterator<'index> + 'index>(
 extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + ProfilePrint>(
     base: *mut QueryIterator,
 ) -> *mut QueryIterator {
-    debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     // SAFETY:
     // 1. As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
@@ -415,7 +416,7 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
         // SAFETY: `ptr` was just produced above and has no other alias yet.
         unsafe { patch_vtable(ptr, |h| h.SkipTo = None) };
     }
-    ptr
+    ptr.as_ptr()
 }
 
 extern "C" fn free_iterator<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIterator) {
@@ -442,11 +443,14 @@ unsafe extern "C" fn print_profile<'index, I: ProfilePrint + RQEIterator<'index>
     map: *mut ffi::RsMapBuilder,
     ctx: *mut ffi::RsProfilePrintCtx,
 ) {
-    debug_assert!(!base.is_null());
     debug_assert!(!map.is_null());
     debug_assert!(!ctx.is_null());
     // SAFETY: base was created by boxed_new/boxed_new_compound with inner type I.
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::ref_from_header_ptr(
+            NonNull::new(base.cast_mut()).expect("`base` must not be null"),
+        )
+    };
     // SAFETY: map is a valid &mut MapBuilder per precondition.
     let map = unsafe { &mut *(map as *mut redis_reply::MapBuilder<'_>) };
     // SAFETY: ctx is a valid &mut ProfilePrintCtx per precondition.
@@ -462,10 +466,10 @@ unsafe extern "C" fn print_profile<'index, I: ProfilePrint + RQEIterator<'index>
 ///
 /// # Safety
 ///
-/// 1. `ptr` is a valid, non-null `*mut QueryIterator` produced by a
+/// 1. `ptr` is a valid `NonNull<QueryIterator>` produced by a
 ///    [`RQEIteratorWrapper`] constructor in this module.
 /// 2. No other alias to `ptr` is live for the duration of `f`.
-pub unsafe fn patch_vtable(ptr: *mut QueryIterator, f: impl FnOnce(&mut QueryIterator)) {
+pub unsafe fn patch_vtable(mut ptr: NonNull<QueryIterator>, f: impl FnOnce(&mut QueryIterator)) {
     // SAFETY: upheld by the caller
-    unsafe { f(&mut *ptr) }
+    unsafe { f(ptr.as_mut()) }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -8,6 +8,8 @@
 */
 
 use ffi::IndexFlags;
+use std::ptr::NonNull;
+
 use index_result::{RSIndexResult, RawIndexResult, RawOffsetSlice, RawTermRecord};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{IndexReader, RefreshOutcome, ResumableReader, SuspendableReader};
@@ -664,7 +666,11 @@ where
         // caller's read lock (witnessed by `guard`) plus the `refresh_pointers`
         // call above ensure every index-backed pointer inside `result` is
         // dereferenceable for `'a`; `result_slot` is initialized and unaliased.
-        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
+        unsafe {
+            RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
+        };
         // SAFETY: `result` is now the active form; the remaining `Rf`-dependent
         // fields (`reader`, the `fn` pointers) are layout-identical across modes
         // by invariant 1 on `RawInvIndIterator` (const proof above) given
@@ -740,7 +746,11 @@ where
         // through the canonical in-place conversion — rather than folding it
         // into the blanket struct reinterpretation below — keeps the
         // borrowed-data transition explicit and auditable.
-        unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
+        unsafe {
+            RawIndexResult::<Active<'index>>::into_suspended_in_place(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
+        };
 
         // SAFETY: `result` is now the suspended form; the only other `Rf`-dependent
         // field, `reader`, is reinterpreted `R -> R::Suspended` — sound by

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -122,23 +122,28 @@ pub unsafe fn build_geo_numeric_filters<'index>(
 /// the `iterators_ffi` `GeoFilter_FreeNumericFilters` wrapper — instead of
 /// `rm_free`, so the container is freed with the right allocator in every binary.
 ///
-/// Does nothing when `filters` is NULL.
+/// Does nothing when `filters` is [`None`].
 ///
 /// # Safety
 ///
-/// `filters` must be NULL, or the exact pointer [`build_geo_numeric_filters`]
+/// `filters` must be [`None`], or the exact pointer [`build_geo_numeric_filters`]
 /// wrote into `gf.numericFilters` (a `Box::into_raw` of
 /// `[*mut NumericFilter; GEO_RANGE_COUNT]`), not yet freed. After this call that
 /// pointer is dangling and must not be used again.
-pub unsafe fn free_geo_numeric_filters(filters: *mut *mut NumericFilter) {
-    if filters.is_null() {
+pub unsafe fn free_geo_numeric_filters(filters: Option<NonNull<*mut NumericFilter>>) {
+    let Some(filters) = filters else {
         return;
-    }
+    };
     // SAFETY: per the contract, `filters` is the `Box::into_raw` of a
     // `[*mut NumericFilter; GEO_RANGE_COUNT]`, so reclaiming it with
     // `Box::from_raw` matches the original allocation exactly.
-    let array =
-        unsafe { Box::from_raw(filters as *mut [*mut NumericFilter; geo::GEO_RANGE_COUNT]) };
+    let array = unsafe {
+        Box::from_raw(
+            filters
+                .cast::<[*mut NumericFilter; geo::GEO_RANGE_COUNT]>()
+                .as_ptr(),
+        )
+    };
     for &filt_ptr in array.iter() {
         if !filt_ptr.is_null() {
             // SAFETY: each non-null entry is a live `NumericFilter` from

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -83,8 +83,12 @@ impl<'query, Rf: Ref, E: DecodedBy, C, RA> RawMissing<'query, Rf, E, C, RA> {
 
     /// Get the field name tracked by this missing-field iterator.
     /// The field name is stored as an owned [`CString`].
-    pub fn field_name(&self) -> (*const c_char, usize) {
-        (self.field_name.as_ptr(), self.field_name.as_bytes().len())
+    pub fn field_name(&self) -> (NonNull<c_char>, usize) {
+        (
+            NonNull::new(self.field_name.as_ptr().cast_mut())
+                .expect("`CString::as_ptr` never returns null"),
+            self.field_name.as_bytes().len(),
+        )
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -927,15 +927,15 @@ impl<'index> RQEIteratorBoxed<'index> for NumericIteratorVariant<'index> {
             NumericIteratorVariant::Unfiltered(it) => {
                 // SAFETY: `it` is the valid, exclusively-owned payload; the
                 // helper reinitialises the slot as its `Suspended` form in place.
-                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+                unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) }
             }
             NumericIteratorVariant::Filtered(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+                unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) }
             }
             NumericIteratorVariant::Geo(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+                unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) }
             }
         }
         // SAFETY: the payload now holds its `Suspended` form at the same offset,
@@ -973,15 +973,15 @@ impl<'query> RQESuspendedIterator<'query> for NumericIteratorVariantSuspended<'q
         let outcome = match unsafe { &mut *raw } {
             NumericIteratorVariantSuspended::Unfiltered(it) => {
                 // SAFETY: `it` is the valid, exclusively-owned payload.
-                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+                unsafe { crate::boxed::resume_child_slot_in_place(NonNull::from(it), guard) }
             }
             NumericIteratorVariantSuspended::Filtered(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+                unsafe { crate::boxed::resume_child_slot_in_place(NonNull::from(it), guard) }
             }
             NumericIteratorVariantSuspended::Geo(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+                unsafe { crate::boxed::resume_child_slot_in_place(NonNull::from(it), guard) }
             }
         };
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -430,7 +430,7 @@ unsafe impl ResumableReader for RawTermIndexReader<Suspended> {
 ///
 /// # Safety
 ///
-/// 1. `idx` must be a valid, non-null pointer to a term [`InvertedIndex`],
+/// 1. `idx` must be a valid pointer to a term [`InvertedIndex`],
 ///    remaining valid — and stable between [`revalidate`](RQEIterator::revalidate)
 ///    calls — for `'index`. (Revalidation detects a GC replacement by comparing
 ///    the index pointer looked up via `Redis_OpenInvertedIndex`.)
@@ -442,17 +442,14 @@ unsafe impl ResumableReader for RawTermIndexReader<Suspended> {
 ///
 /// Panics if `idx` is a numeric index, which has no term reader.
 pub unsafe fn build_term_iterator<'index>(
-    idx: *const ffi::InvertedIndex,
+    idx: NonNull<ffi::InvertedIndex>,
     sctx: NonNull<RedisSearchCtx>,
     field_mask_or_index: FieldMaskOrIndex,
     term: Box<RSQueryTerm>,
     weight: f64,
 ) -> Term<'index, TermIndexReader<'index>, FieldExpirationChecker> {
-    debug_assert!(!idx.is_null(), "idx must not be null");
-
-    let idx_ptr: *const InvertedIndex = idx.cast();
-    // SAFETY: precondition (1) — `idx` is a valid, non-null `InvertedIndex`.
-    let idx = unsafe { &*idx_ptr };
+    // SAFETY: precondition (1) — `idx` is a valid `InvertedIndex`.
+    let idx = unsafe { idx.cast::<InvertedIndex>().as_ref() };
 
     // A field mask reads only its fields; a field index reads all fields (index
     // filtering happens later, via the expiration checker).

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -9,6 +9,8 @@
 
 //! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
 
+use std::ptr::NonNull;
+
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
@@ -228,7 +230,7 @@ where
         if let MaybeEmptyOption::Some(it) = inner {
             // SAFETY: `it` is a valid `&mut I` aliased to nothing else;
             // the function leaves the slot in a valid `I::Suspended` state.
-            unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut I) };
+            unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) };
         }
         // SAFETY: the `Some` child (if any) now holds `I::Suspended` and
         // `None(Empty)` is `I`-free, so the allocation is a valid
@@ -286,7 +288,7 @@ where
                 // payload. On Unchanged/Moved the helper rewrites the slot as a
                 // valid `S::Resumed<'a>`; on Aborted/Err it consumes the child,
                 // leaving the payload uninitialised (handled below).
-                match unsafe { resume_child_slot_in_place(child as *mut S, guard) } {
+                match unsafe { resume_child_slot_in_place(NonNull::from(child), guard) } {
                     Ok(ResumeSlotOutcome::Unchanged) => ChildResume::Active { moved: false },
                     Ok(ResumeSlotOutcome::Moved) => ChildResume::Active { moved: true },
                     Ok(ResumeSlotOutcome::Aborted) => ChildResume::Aborted,

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -328,16 +328,19 @@ impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
+    /// 1. `slot` is aligned and points to an initialized
     ///    `Metric<'index, SORTED_BY_ID>`.
     /// 2. `slot` is unaliased for the duration of the call.
     pub(crate) unsafe fn suspend_in_place(
-        slot: *mut Self,
-    ) -> *mut SuspendedMetric<'index, SORTED_BY_ID> {
-        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+        slot: NonNull<Self>,
+    ) -> NonNull<SuspendedMetric<'index, SORTED_BY_ID>> {
+        // SAFETY: `slot` is aligned and initialized (caller contract 1).
         // `&raw mut` forms a field pointer without creating a reference, leaving
         // `slot`'s provenance over the whole allocation intact for the cast below.
-        let base_slot = unsafe { &raw mut (*slot).base };
+        let base_slot = unsafe { &raw mut (*slot.as_ptr()).base };
+        // SAFETY: `base_slot` is a field pointer derived from the non-null `slot`, so it is
+        // non-null too.
+        let base_slot = unsafe { NonNull::new_unchecked(base_slot) };
         // SAFETY: `IdList::suspend_in_place`'s contract is met — `base_slot` is
         // initialized and unaliased (caller contracts 1 and 2).
         unsafe { IdList::<'index, SORTED_BY_ID>::suspend_in_place(base_slot) };
@@ -350,15 +353,15 @@ impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index> for Metric<'inde
     type Suspended = SuspendedMetric<'index, SORTED_BY_ID>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let active: *mut Self = Box::into_raw(self);
+        let active = NonNull::from(Box::leak(self));
 
-        // SAFETY: `suspend_in_place`'s contract is met — `active` is non-null, aligned, and
+        // SAFETY: `suspend_in_place`'s contract is met — `active` is aligned and
         // initialized (it just came from a `Box`), and unaliased (this function owns `self`).
         let suspended_ptr = unsafe { Metric::<'index, SORTED_BY_ID>::suspend_in_place(active) };
 
-        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::into_raw` above, so the
+        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::leak` above, so the
         // address is unchanged and every field is now valid at the suspended type.
-        unsafe { Box::from_raw(suspended_ptr) }
+        unsafe { Box::from_raw(suspended_ptr.as_ptr()) }
     }
 }
 
@@ -376,7 +379,7 @@ impl<'query, const SORTED_BY_ID: bool> SuspendedMetric<'query, SORTED_BY_ID> {
     ///
     /// The caller must guarantee that:
     ///
-    /// 1. `slot` is non-null, aligned, and points to an initialized
+    /// 1. `slot` is aligned and points to an initialized
     ///    `RawMetric<'query, Suspended, SORTED_BY_ID>`.
     /// 2. `slot` is unaliased for the duration of the call.
     ///
@@ -384,15 +387,18 @@ impl<'query, const SORTED_BY_ID: bool> SuspendedMetric<'query, SORTED_BY_ID> {
     /// at the active type for `'a`; in the `Err` case the slot is byte-for-byte
     /// unchanged and remains a valid `SuspendedMetric<'query, SORTED_BY_ID>`.
     pub(crate) unsafe fn resume_in_place<'a>(
-        slot: *mut Self,
-    ) -> Result<*mut Metric<'a, SORTED_BY_ID>, *mut Self>
+        slot: NonNull<Self>,
+    ) -> Result<NonNull<Metric<'a, SORTED_BY_ID>>, NonNull<Self>>
     where
         'query: 'a,
     {
-        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+        // SAFETY: `slot` is aligned and initialized (caller contract 1).
         // `&raw mut` forms a field pointer without creating a reference, leaving
         // `slot`'s provenance over the whole allocation intact for the casts below.
-        let base_slot = unsafe { &raw mut (*slot).base };
+        let base_slot = unsafe { &raw mut (*slot.as_ptr()).base };
+        // SAFETY: `base_slot` is a field pointer derived from the non-null `slot`, so it is
+        // non-null too.
+        let base_slot = unsafe { NonNull::new_unchecked(base_slot) };
         // SAFETY: `SuspendedIdList::resume_in_place`'s contract is met — `base_slot`
         // is initialized and unaliased (caller contracts 1 and 2).
         match unsafe { SuspendedIdList::<'query, SORTED_BY_ID>::resume_in_place::<'a>(base_slot) } {
@@ -419,24 +425,26 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
     where
         'query: 'index,
     {
-        let suspended: *mut Self = Box::into_raw(self);
+        let suspended = NonNull::from(Box::leak(self));
 
         // SAFETY: `resume_in_place`'s contract is met:
-        // 1. `suspended` is non-null, aligned, and initialized — it just came from a `Box`.
+        // 1. `suspended` is aligned and initialized — it just came from a `Box`.
         // 2. `suspended` is not aliased, since this function has ownership of `self`.
         match unsafe {
             SuspendedMetric::<'query, SORTED_BY_ID>::resume_in_place::<'index>(suspended)
         } {
             Ok(active_ptr) => {
-                // SAFETY: `active_ptr` reuses the same allocation from `Box::into_raw` above, so
+                // SAFETY: `active_ptr` reuses the same allocation from `Box::leak` above, so
                 // the address is unchanged and every field is now valid at the active type for
                 // `'index`.
-                Ok(ResumeOutcome::Ok(unsafe { Box::from_raw(active_ptr) }))
+                Ok(ResumeOutcome::Ok(unsafe {
+                    Box::from_raw(active_ptr.as_ptr())
+                }))
             }
             Err(suspended_ptr) => {
                 // SAFETY: `suspended_ptr` is the same allocation, left untouched and still a valid
                 // `SuspendedMetric`. Reclaim ownership so it is dropped.
-                drop(unsafe { Box::from_raw(suspended_ptr) });
+                drop(unsafe { Box::from_raw(suspended_ptr.as_ptr()) });
                 Ok(ResumeOutcome::Aborted)
             }
         }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -61,9 +61,9 @@ pub struct RawMetric<'query, Rf: Ref, const SORTED_BY_ID: bool> {
     ///
     /// The handle is either:
     ///
-    /// - A null pointer, indicating that the iterator is not associated with a key.
+    /// - [`None`], indicating that the iterator is not associated with a key.
     /// - A valid pointer to a [`RLookupKeyHandle`] instance.
-    key_handle: *mut RLookupKeyHandle<'query>,
+    key_handle: Option<NonNull<RLookupKeyHandle<'query>>>,
 }
 
 // Compile-time proof that the `Metric` and its suspended counterpart are layout-identical.
@@ -101,11 +101,11 @@ impl<'query, Rf: Ref, const SORTED_BY_ID: bool> RawMetric<'query, Rf, SORTED_BY_
 
 impl<'query, Rf: Ref, const SORTED_BY_ID: bool> Drop for RawMetric<'query, Rf, SORTED_BY_ID> {
     fn drop(&mut self) {
-        if !self.key_handle.is_null() {
+        if let Some(mut key_handle) = self.key_handle {
             // Safety: thanks to [`Self::key_handle`]'s invariant, we can safely
-            // dereference it if it's not null.
+            // dereference the handle if it is present.
             unsafe {
-                (*self.key_handle).is_valid = false;
+                key_handle.as_mut().is_valid = false;
             }
         }
     }
@@ -145,7 +145,7 @@ impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
             metric_data,
             type_: MetricType::VectorDistance,
             own_key: std::ptr::null_mut(),
-            key_handle: std::ptr::null_mut(),
+            key_handle: None,
         }
     }
 
@@ -163,7 +163,7 @@ impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
             metric_data: OwnedSlice::default(),
             type_,
             own_key: std::ptr::null_mut(),
-            key_handle: std::ptr::null_mut(),
+            key_handle: None,
         }
     }
 
@@ -181,9 +181,12 @@ impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
     ///
     /// The provided `key_handle` can either be:
     ///
-    /// - A null pointer, indicating that the metric iterator does not have a key.
+    /// - [`None`], indicating that the metric iterator does not have a key.
     /// - A valid pointer to a [`RLookupKeyHandle`] instance.
-    pub const unsafe fn set_handle(&mut self, key_handle: *mut RLookupKeyHandle<'index>) {
+    pub const unsafe fn set_handle(
+        &mut self,
+        key_handle: Option<NonNull<RLookupKeyHandle<'index>>>,
+    ) {
         self.key_handle = key_handle;
     }
 
@@ -490,38 +493,39 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
 /// [`MetricLazySortedByScore`] — the four flavours that own a key slot.
 // TODO: this API should use proper Rust types instead of QueryIterator once top-k has been ported
 // to Rust (MOD-17755).
-pub unsafe fn own_key_ref<'index>(header: NonNull<QueryIterator>) -> *mut *mut RLookupKey<'index> {
+pub unsafe fn own_key_ref<'index>(
+    header: NonNull<QueryIterator>,
+) -> NonNull<*mut RLookupKey<'index>> {
     // SAFETY: safe thanks to 1.
     let iterator_type = unsafe { header.as_ref().type_ };
-    let header = header.as_ptr();
 
     match iterator_type {
         IteratorType::MetricSortedById => {
             // SAFETY: safe thanks to 1 + 2.
             let wrapper =
                 unsafe { RQEIteratorWrapper::<MetricSortedById>::mut_ref_from_header_ptr(header) };
-            wrapper.inner.key_mut_ref()
+            NonNull::from(wrapper.inner.key_mut_ref())
         }
         IteratorType::MetricSortedByScore => {
             // SAFETY: safe thanks to 1 + 2.
             let wrapper = unsafe {
                 RQEIteratorWrapper::<MetricSortedByScore>::mut_ref_from_header_ptr(header)
             };
-            wrapper.inner.key_mut_ref()
+            NonNull::from(wrapper.inner.key_mut_ref())
         }
         IteratorType::MetricLazySortedById => {
             // SAFETY: safe thanks to 1 + 2.
             let wrapper = unsafe {
                 RQEIteratorWrapper::<MetricLazySortedById>::mut_ref_from_header_ptr(header)
             };
-            wrapper.inner.key_mut_ref()
+            NonNull::from(wrapper.inner.key_mut_ref())
         }
         IteratorType::MetricLazySortedByScore => {
             // SAFETY: safe thanks to 1 + 2.
             let wrapper = unsafe {
                 RQEIteratorWrapper::<MetricLazySortedByScore>::mut_ref_from_header_ptr(header)
             };
-            wrapper.inner.key_mut_ref()
+            NonNull::from(wrapper.inner.key_mut_ref())
         }
         _ => unreachable!(
             "expected a metric iterator, either sorted by ID or Score (metric value): unexpected type: {iterator_type}"
@@ -538,7 +542,7 @@ pub unsafe fn own_key_ref<'index>(header: NonNull<QueryIterator>) -> *mut *mut R
 ///    for [`own_key_ref`] — metric-ness is a run-time check here too, not a
 ///    pre-condition.
 /// 2. The caller holds that iterator exclusively for the duration of the call.
-/// 3. `handle` is null, or points to a valid [`RLookupKeyHandle`] that outlives
+/// 3. `handle` is [`None`], or points to a valid [`RLookupKeyHandle`] that outlives
 ///    the iterator. The iterator clears the handle's validity flag on its way
 ///    out, so freeing the handle first is a use-after-free at a distance: the
 ///    write lands whenever the iterator is dropped, not during this call.
@@ -546,10 +550,12 @@ pub unsafe fn own_key_ref<'index>(header: NonNull<QueryIterator>) -> *mut *mut R
 /// # Panics
 ///
 /// Panics on any header [`own_key_ref`] would panic on.
-pub unsafe fn set_key_handle(header: NonNull<QueryIterator>, handle: *mut RLookupKeyHandle<'_>) {
+pub unsafe fn set_key_handle(
+    header: NonNull<QueryIterator>,
+    handle: Option<NonNull<RLookupKeyHandle<'_>>>,
+) {
     // SAFETY: safe thanks to 1.
     let iterator_type = unsafe { header.as_ref().type_ };
-    let header = header.as_ptr();
 
     match iterator_type {
         IteratorType::MetricSortedById => {

--- a/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
@@ -217,7 +217,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index>
     type Suspended = SuspendedMetricLazy<'index, SORTED_BY_ID>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let active = Box::into_raw(self);
+        let active = NonNull::from(Box::leak(self));
 
         // Suspend the wrapped metric's base id list `result` field in place, leaving the
         // outer allocation (and the `Rf`-independent `producer`) untouched.
@@ -225,7 +225,10 @@ impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index>
         // SAFETY: `&raw mut` forms a field pointer without creating a reference,
         // preserving `active`'s provenance over the whole allocation for the outer
         // cast below.
-        let inner_slot = unsafe { &raw mut (*active).inner };
+        let inner_slot = unsafe { &raw mut (*active.as_ptr()).inner };
+        // SAFETY: `inner_slot` is a field pointer derived from the non-null `active`, so it is
+        // non-null too.
+        let inner_slot = unsafe { NonNull::new_unchecked(inner_slot) };
         // SAFETY: `suspend_in_place`'s contract is met — `inner_slot` is initialized and
         // unaliased (this function owns `self`). Suspending is a safe widening conversion.
         let _ = unsafe { Metric::<'index, SORTED_BY_ID>::suspend_in_place(inner_slot) };
@@ -233,8 +236,14 @@ impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index>
         // SAFETY: `MetricLazy` and `SuspendedMetricLazy` are both `#[repr(C)]` with identical
         // field layout: `inner` is now the suspended metric, `producer` is `Producer<'static>` in
         // both variants, and `produced`/`num_estimated_hint` carry no lifetime. `Box::from_raw`
-        // reuses the same heap allocation as `Box::into_raw`, so the address is unchanged.
-        unsafe { Box::from_raw(active.cast::<SuspendedMetricLazy<'index, SORTED_BY_ID>>()) }
+        // reuses the same heap allocation as `Box::leak`, so the address is unchanged.
+        unsafe {
+            Box::from_raw(
+                active
+                    .cast::<SuspendedMetricLazy<'index, SORTED_BY_ID>>()
+                    .as_ptr(),
+            )
+        }
     }
 }
 
@@ -253,7 +262,7 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
     where
         'query: 'index,
     {
-        let suspended = Box::into_raw(self);
+        let suspended = NonNull::from(Box::leak(self));
 
         // Promote the wrapped metric's base id list `result` field in place, leaving the
         // outer allocation (and the `Rf`-independent `producer`) untouched.
@@ -261,7 +270,10 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
         // SAFETY: `&raw mut` forms a field pointer without creating a reference,
         // preserving `suspended`'s provenance over the whole allocation for the
         // outer cast below.
-        let inner_slot = unsafe { &raw mut (*suspended).inner };
+        let inner_slot = unsafe { &raw mut (*suspended.as_ptr()).inner };
+        // SAFETY: `inner_slot` is a field pointer derived from the non-null `suspended`, so it is
+        // non-null too.
+        let inner_slot = unsafe { NonNull::new_unchecked(inner_slot) };
         // SAFETY: `resume_in_place`'s contract is met — `inner_slot` is initialized and
         // unaliased (this function owns `self`). We reclaim the outer allocation via `suspended`
         // in either branch, so the inner pointer it returns is not needed.
@@ -271,19 +283,24 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
             Ok(_) => {
                 // SAFETY: layout-compatible — see `suspend`. `inner`'s base `result` is now valid
                 // at the active type for `'index`; the remaining fields carry no `Rf`.
-                // `Box::from_raw` reuses the same heap allocation as `suspend`'s `Box::into_raw`,
+                // `Box::from_raw` reuses the same heap allocation as `suspend`'s `Box::leak`,
                 // so the address is unchanged.
-                let active =
-                    unsafe { Box::from_raw(suspended.cast::<MetricLazy<'index, SORTED_BY_ID>>()) };
+                let active = unsafe {
+                    Box::from_raw(
+                        suspended
+                            .cast::<MetricLazy<'index, SORTED_BY_ID>>()
+                            .as_ptr(),
+                    )
+                };
                 Ok(ResumeOutcome::Ok(active))
             }
             Err(_) => {
                 // `resume_in_place` left the inner metric untouched (the stored result kind was
                 // neither metric nor virtual), so the outer allocation is still a valid
                 // `SuspendedMetricLazy`.
-                // SAFETY: `suspended` came from `Box::into_raw` above and was not mutated; reclaim
+                // SAFETY: `suspended` came from `Box::leak` above and was not mutated; reclaim
                 // ownership so it is dropped.
-                drop(unsafe { Box::from_raw(suspended) });
+                drop(unsafe { Box::from_raw(suspended.as_ptr()) });
                 Ok(ResumeOutcome::Aborted)
             }
         }

--- a/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
@@ -21,6 +21,7 @@ use index_spec::IndexSpecReadGuard;
 use ref_mode::{Active, Ref, Suspended};
 use rlookup::{RLookupKey, RLookupKeyHandle};
 use rqe_core::DocId;
+use std::ptr::NonNull;
 
 /// A lazily-populated metric iterator sorted by document id.
 pub type MetricLazySortedById<'index> = MetricLazy<'index, true>;
@@ -101,7 +102,10 @@ impl<'index, const SORTED_BY_ID: bool> MetricLazy<'index, SORTED_BY_ID> {
     /// # Safety
     ///
     /// Same contract as [`Metric::set_handle`].
-    pub const unsafe fn set_handle(&mut self, key_handle: *mut RLookupKeyHandle<'index>) {
+    pub const unsafe fn set_handle(
+        &mut self,
+        key_handle: Option<NonNull<RLookupKeyHandle<'index>>>,
+    ) {
         // SAFETY: contract forwarded to the caller of this function.
         unsafe { self.inner.set_handle(key_handle) };
     }

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -9,6 +9,8 @@
 
 //! Supporting types for [`Not`].
 
+use std::ptr::NonNull;
+
 use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use ref_mode::{Active, Ref, Suspended};
 
@@ -371,6 +373,8 @@ where
         // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
         // exclusively owned); `&raw mut` forms a field pointer to `child`.
         let child = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child = unsafe { NonNull::new_unchecked(child) };
         // SAFETY: `child` points at a valid, owned `MaybeEmpty<I>`; the helper
         // dispatches its `suspend` and reinitialises the slot as a valid
         // `MaybeEmpty<I::Suspended>`.
@@ -420,6 +424,8 @@ where
         // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
         // exclusively owned); `&raw mut` forms a field pointer to `child`.
         let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child_slot = unsafe { NonNull::new_unchecked(child_slot) };
 
         // Resume the child in place. `MaybeEmpty<S>`'s own `resume` walks its
         // `Some` arm and propagates an inner abort; its `None(Empty)` arm resumes

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -9,6 +9,8 @@
 
 //! Supporting types for [`NotOptimized`].
 
+use std::ptr::NonNull;
+
 use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use ref_mode::{Active, Ref, Suspended};
 
@@ -487,11 +489,15 @@ where
         // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
         // exclusively owned); `&raw mut` forms a field pointer to `wcii`.
         let wcii = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: `wcii` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let wcii = unsafe { NonNull::new_unchecked(wcii) };
         // SAFETY: `wcii` points at a valid, owned `W`; the helper dispatches its
         // `suspend` and reinitialises the slot as a valid `W::Suspended`.
         unsafe { suspend_child_slot_in_place(wcii) };
         // SAFETY: `&raw mut` forms a field pointer to `child`.
         let child = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child = unsafe { NonNull::new_unchecked(child) };
         // SAFETY: `child` points at a valid, owned `MaybeEmpty<I>`; the helper
         // dispatches its `suspend` and reinitialises the slot as a valid
         // `MaybeEmpty<I::Suspended>`.

--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -184,7 +184,14 @@ where
             // The snapshot is read from `query.sctx.diskSnapshot` so the NOT-optimized path
             // observes the same view as the rest of the query; `query.status` is the valid
             // `QueryError` of the evaluating query.
-            unsafe { new_wildcard_iterator_on_disk(disk_spec, weight, snapshot, query_ref.status) }
+            unsafe {
+                new_wildcard_iterator_on_disk(
+                    disk_spec,
+                    weight,
+                    snapshot,
+                    NonNull::new(query_ref.status),
+                )
+            }
         } else {
             // SAFETY: Caller guarantees `query.sctx` is a valid, non-null pointer (2)
             // and all preconditions of `new_wildcard_iterator_optimized` hold (5).

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -9,6 +9,8 @@
 
 //! Supporting types for [`Optional`].
 
+use std::ptr::NonNull;
+
 use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use ref_mode::{Active, Ref, Suspended};
 use std::cmp;
@@ -398,7 +400,7 @@ where
         if let OptionalChild::Present(c) = unsafe { &mut (*raw).child } {
             // SAFETY: `c` points at a valid, exclusively-owned `I`; the helper
             // reinitialises the slot as a valid `I::Suspended` in place.
-            unsafe { suspend_child_slot_in_place(c as *mut I) };
+            unsafe { suspend_child_slot_in_place(NonNull::from(c)) };
         }
         // SAFETY: the `Present` child (if any) now holds `I::Suspended` and `Gone`
         // has no payload, so the allocation is a valid
@@ -478,7 +480,7 @@ where
                 // payload. On Unchanged/Moved the helper rewrites the slot as a
                 // valid `S::Resumed<'a>`; on Aborted/Err it consumes the child,
                 // leaving the payload uninitialised (handled below).
-                match unsafe { resume_child_slot_in_place(c as *mut S, guard) } {
+                match unsafe { resume_child_slot_in_place(NonNull::from(c), guard) } {
                     Ok(ResumeSlotOutcome::Unchanged) => ChildResume::Active { last, moved: false },
                     Ok(ResumeSlotOutcome::Moved) => ChildResume::Active { last, moved: true },
                     Ok(ResumeSlotOutcome::Aborted) => ChildResume::Aborted { last },

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -14,6 +14,8 @@
 //! `spec.existingDocs` to visit only real document IDs, yielding real or virtual
 //! results accordingly.
 
+use std::ptr::NonNull;
+
 use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use ref_mode::{Active, Ref, Suspended};
 
@@ -485,11 +487,15 @@ where
         // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
         // exclusively owned); `&raw mut` forms a field pointer to `wcii`.
         let wcii = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: `wcii` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let wcii = unsafe { NonNull::new_unchecked(wcii) };
         // SAFETY: `wcii` points at a valid, owned `W`; the helper dispatches its
         // `suspend` and reinitialises the slot as a valid `W::Suspended`.
         unsafe { suspend_child_slot_in_place(wcii) };
         // SAFETY: `&raw mut` forms a field pointer to `child`.
         let child = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child = unsafe { NonNull::new_unchecked(child) };
         // SAFETY: `child` points at a valid, owned `MaybeEmpty<I>`; the helper
         // dispatches its `suspend` and reinitialises the slot as a valid
         // `MaybeEmpty<I::Suspended>`.

--- a/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
@@ -111,7 +111,12 @@ where
                     // optional-optimized path observes the same view as the rest of the query;
                     // `query.status` is the valid `QueryError` of the evaluating query.
                     unsafe {
-                        new_wildcard_iterator_on_disk(disk_spec, weight, snapshot, query_ref.status)
+                        new_wildcard_iterator_on_disk(
+                            disk_spec,
+                            weight,
+                            snapshot,
+                            NonNull::new(query_ref.status),
+                        )
                     }
                 } else {
                     // SAFETY: (2) guarantees `sctx` is valid; (7) covers all remaining

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -13,6 +13,8 @@
 //! (read/skip counts and wall-clock time) from a child iterator without
 //! modifying its behavior.
 
+use std::ptr::NonNull;
+
 use std::time::{Duration, Instant};
 
 use crate::{
@@ -247,6 +249,8 @@ where
         // initialised, exclusively owned). `&raw mut` forms a field pointer to
         // the `child` slot without creating a reference.
         let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child_slot = unsafe { NonNull::new_unchecked(child_slot) };
         // SAFETY: `child_slot` points at the valid, exclusively-owned active
         // child. `suspend_child_slot_in_place` drives the child's own `suspend`
         // and reinitialises the slot as a valid `I::Suspended` in place.
@@ -320,6 +324,8 @@ where
         // initialised, exclusively owned). `&raw mut` forms a field pointer to
         // the `child` slot without creating a reference.
         let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` is a field pointer derived from the non-null `raw`, so it is non-null too.
+        let child_slot = unsafe { NonNull::new_unchecked(child_slot) };
         // SAFETY: `child_slot` points at the valid, exclusively-owned suspended
         // child. On `Unchanged`/`Moved` the helper reinitialises the slot as
         // `S::Resumed<'a>`; on `Aborted`/`Err` the child is consumed and the slot

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -306,7 +306,9 @@ type UnionWrapper<'index> = RQEIteratorWrapper<UnionOpaque<'index, CRQEIterator>
 /// `base` must be a valid, owning pointer to a `UnionWrapper` created via
 /// [`build_union`].
 unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut QueryIterator {
-    let base = NonNull::new(base).expect("`base` must not be null");
+    debug_assert!(!base.is_null());
+    // SAFETY: the caller guarantees `base` is a valid owning pointer, so it is non-null.
+    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
     let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
     for child in wrapper.inner.children_mut() {

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -306,7 +306,7 @@ type UnionWrapper<'index> = RQEIteratorWrapper<UnionOpaque<'index, CRQEIterator>
 /// `base` must be a valid, owning pointer to a `UnionWrapper` created via
 /// [`build_union`].
 unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut QueryIterator {
-    debug_assert!(!base.is_null());
+    let base = NonNull::new(base).expect("`base` must not be null");
     // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
     let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
     for child in wrapper.inner.children_mut() {
@@ -324,7 +324,7 @@ unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut Qu
         // iterator back in place.
         unsafe { *slot = profiled.into_raw().as_ptr() };
     }
-    base
+    base.as_ptr()
 }
 
 /// Build a union iterator from a `Vec` of already-owned [`CRQEIterator`]
@@ -420,11 +420,7 @@ unsafe fn build_union_with_q_str_opt(
     use crate::union_reducer::{NewUnionIterator, new_union_iterator};
 
     let variant = match new_union_iterator(children, quick_exit, min_union_iter_heap) {
-        NewUnionIterator::ReducedEmpty(empty) => {
-            let ptr = RQEIteratorWrapper::boxed_new(empty);
-            // SAFETY: `boxed_new` uses `Box::into_raw`, which is guaranteed non-null.
-            return unsafe { NonNull::new_unchecked(ptr) };
-        }
+        NewUnionIterator::ReducedEmpty(empty) => return RQEIteratorWrapper::boxed_new(empty),
         NewUnionIterator::ReducedSingle(child) => return child.into_raw(),
         NewUnionIterator::Flat(flat) => UnionVariant::FlatFull(flat),
         NewUnionIterator::FlatQuick(flat) => UnionVariant::FlatQuick(flat),
@@ -438,7 +434,5 @@ unsafe fn build_union_with_q_str_opt(
         query_string: q_str.map(SharedPtr::from_ref),
     };
     dispatch.set_result_weight(weight);
-    let ptr = RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children));
-    // SAFETY: `boxed_new_inner` uses `Box::into_raw`, which is guaranteed non-null.
-    unsafe { NonNull::new_unchecked(ptr) }
+    RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
 }

--- a/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 /// An owned slice of `T` which is allocated either in C (Redis) or Rust.
 pub struct OwnedSlice<T> {
     kind: SliceKind<T>,
@@ -29,11 +31,11 @@ impl<T> OwnedSlice<T> {
 
     /// # Safety
     ///
-    /// ptr must be non-null and point to `len` initialized elements
-    /// allocated via `RedisModule_Alloc`. [`OwnedSlice`] takes
-    /// ownership from ptr and should therefore no longer be freed by callee.
+    /// ptr must point to `len` initialized elements allocated via
+    /// `RedisModule_Alloc`. [`OwnedSlice`] takes ownership from ptr and should
+    /// therefore no longer be freed by callee.
     #[inline(always)]
-    pub const unsafe fn from_c(ptr: *mut T, len: usize) -> Self {
+    pub const unsafe fn from_c(ptr: NonNull<T>, len: usize) -> Self {
         Self {
             kind: SliceKind::C(
                 // Safety: contract upheld by callee
@@ -84,21 +86,18 @@ enum SliceKind<T> {
 /// This is useful for slices that were created from C,
 /// and we wish to use it as-is without having to re-allocate.
 struct RedisSlice<T> {
-    ptr: std::ptr::NonNull<T>,
+    ptr: NonNull<T>,
     len: usize,
 }
 
 impl<T> RedisSlice<T> {
     /// # Safety
     ///
-    /// ptr must be non-null and point to `len` initialized elements
-    /// allocated via `RedisModule_Alloc`. [`RedisSlice`] takes
-    /// ownership from ptr and should therefore no longer be freed by callee.
+    /// ptr must point to `len` initialized elements allocated via
+    /// `RedisModule_Alloc`. [`RedisSlice`] takes ownership from ptr and should
+    /// therefore no longer be freed by callee.
     #[inline(always)]
-    const unsafe fn from_raw(ptr: *mut T, len: usize) -> Self {
-        debug_assert!(!ptr.is_null());
-        // Safety: because of constructor contract
-        let ptr = unsafe { std::ptr::NonNull::new_unchecked(ptr) };
+    const unsafe fn from_raw(ptr: NonNull<T>, len: usize) -> Self {
         Self { ptr, len }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -514,11 +514,11 @@ impl<'index> RQEIteratorBoxed<'index> for OptimizedWildcard<'index> {
             RawOptimizedWildcard::DocIdsOnly(it) => {
                 // SAFETY: `it` is the valid, exclusively-owned payload; the
                 // helper reinitialises the slot as its `Suspended` form in place.
-                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+                unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) }
             }
             RawOptimizedWildcard::RawDocIdsOnly(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+                unsafe { crate::boxed::suspend_child_slot_in_place(NonNull::from(it)) }
             }
         }
         // SAFETY: the payload now holds its `Suspended` form at the same offset,
@@ -559,11 +559,11 @@ impl<'query> RQESuspendedIterator<'query> for OptimizedWildcardSuspended<'query>
         let outcome = match unsafe { &mut *raw } {
             RawOptimizedWildcard::DocIdsOnly(it) => {
                 // SAFETY: `it` is the valid, exclusively-owned payload.
-                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, spec) }
+                unsafe { crate::boxed::resume_child_slot_in_place(NonNull::from(it), spec) }
             }
             RawOptimizedWildcard::RawDocIdsOnly(it) => {
                 // SAFETY: as above.
-                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, spec) }
+                unsafe { crate::boxed::resume_child_slot_in_place(NonNull::from(it), spec) }
             }
         };
 
@@ -767,7 +767,7 @@ pub unsafe fn new_wildcard_iterator_optimized<'index>(
 /// and wraps the resulting iterator in a [`DiskWildcardIterator`].
 ///
 /// If the enterprise iterator cannot be created, this function populates
-/// `status` (when non-null) with the cause and falls back to an empty iterator;
+/// `status` (when present) with the cause and falls back to an empty iterator;
 /// the query then aborts with an error rather than returning empty results.
 ///
 /// # Safety
@@ -777,20 +777,20 @@ pub unsafe fn new_wildcard_iterator_optimized<'index>(
 /// 2. [`SEARCH_ENTERPRISE_ITERATORS`] must be initialized before calling this function.
 /// 3. `snapshot` must be a [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle
 ///    for `disk_spec` and must remain valid for `'index`.
-/// 4. `status`, when non-null, must point to a valid [`QueryError`](ffi::QueryError).
+/// 4. `status`, when present, must point to a valid [`QueryError`](ffi::QueryError).
 pub unsafe fn new_wildcard_iterator_on_disk<'index>(
     disk_spec: &'index mut ffi::RedisSearchDiskIndexSpec,
     weight: f64,
-    snapshot: std::ptr::NonNull<ffi::RedisSearchDiskSnapshot>,
-    status: *mut ffi::QueryError,
+    snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
+    status: Option<NonNull<ffi::QueryError>>,
 ) -> NewWildcardIterator<'index> {
     // SAFETY: Caller guarantees `SEARCH_ENTERPRISE_ITERATORS` is
     // initialized when `spec.diskSpec` is non-null (8).
     let enterprise_iters_api = SEARCH_ENTERPRISE_ITERATORS
         .get()
         .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
-    // SAFETY: caller guarantees `status`, when non-null, points to a valid `QueryError` (4).
-    let status = unsafe { QueryError::from_opaque_mut_ptr(status.cast()) };
+    // SAFETY: caller guarantees `status`, when present, points to a valid `QueryError` (4).
+    let status = status.map(|status| unsafe { QueryError::from_opaque_non_null(status.cast()) });
     // On failure the enterprise implementation populates `status` with the
     // cause; we just fall back to an empty iterator so the query aborts via the
     // existing `QueryError_HasError` check rather than returning empty results.
@@ -861,7 +861,9 @@ pub unsafe fn new_wildcard_iterator<'index>(
         // SAFETY: Caller guarantees all preconditions of
         // `new_wildcard_iterator_on_disk` hold (7, 8, 9); `query.status` is the
         // valid `QueryError` of the evaluating query.
-        return unsafe { new_wildcard_iterator_on_disk(disk_spec, weight, snapshot, query.status) };
+        return unsafe {
+            new_wildcard_iterator_on_disk(disk_spec, weight, snapshot, NonNull::new(query.status))
+        };
     }
 
     let index_all = NonNull::new(spec.rule)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
@@ -15,7 +15,7 @@
 //! Collapsing the two, as this boundary used to, turns a timed-out query into a successful one.
 
 use ffi::{
-    QueryIterator, ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_OK,
+    ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_OK,
     ValidateStatus_VALIDATE_TIMEOUT,
 };
 use rqe_iterators::{
@@ -32,7 +32,7 @@ fn revalidate_through_c_abi(outcome: MockRevalidateResult) -> ValidateStatus {
     let mock = Mock::new([1, 2, 3]);
     mock.data().set_revalidate_result(outcome);
 
-    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new(mock);
+    let it = RQEIteratorWrapper::boxed_new(mock).as_ptr();
     // SAFETY: `sctx` is a valid `RedisSearchCtx` owned by the mock context, and its `spec` is the
     // spec the iterator is revalidated against. `boxed_new` populates every callback.
     let status = unsafe {
@@ -123,7 +123,7 @@ fn a_child_timeout_reaches_c_as_a_timeout_through_a_composite() {
         1.0,
         false,
     );
-    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new_compound(intersection);
+    let it = RQEIteratorWrapper::boxed_new_compound(intersection).as_ptr();
 
     // SAFETY: as in `revalidate_through_c_abi`.
     let status = unsafe {
@@ -148,7 +148,7 @@ fn the_debug_switch_reports_a_timeout_without_consulting_the_iterator() {
     let ctx = MockContext::new(100, 10);
     let mock = Mock::new([1, 2, 3]);
     let data = mock.data();
-    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new(mock);
+    let it = RQEIteratorWrapper::boxed_new(mock).as_ptr();
 
     rqe_iterators::interop::set_mock_revalidate_timeout(true);
     // SAFETY: as in `revalidate_through_c_abi`.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -268,7 +268,7 @@ mod not_miri {
 
         let (field_name, field_name_len) = it.field_name();
         // SAFETY: `field_name()` returns a valid pointer to the field name stored in the live spec.
-        let field_name = unsafe { CStr::from_ptr(field_name) };
+        let field_name = unsafe { CStr::from_ptr(field_name.as_ptr()) };
 
         assert_eq!(field_name.to_bytes().len(), field_name_len);
         assert_eq!(field_name.to_bytes(), b"text_field");

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -14,6 +14,7 @@ use rqe_iterators::{
     maybe_empty::MaybeEmpty,
 };
 use rqe_iterators_test_utils::ContractChecker;
+use std::ptr::NonNull;
 
 #[derive(Default)]
 #[repr(C)]
@@ -64,7 +65,11 @@ impl<'index> RQEIteratorBoxed<'index> for Infinite<'index> {
         // SAFETY: `result_slot` points at an initialised `RSIndexResult<'index>`
         // and is unaliased; `into_suspended_in_place` is a safe widening
         // conversion with no further precondition.
-        unsafe { <index_result::RSIndexResult<'index>>::into_suspended_in_place(result_slot) };
+        unsafe {
+            <index_result::RSIndexResult<'index>>::into_suspended_in_place(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
+        };
         // SAFETY: `Infinite<'index>` and `InfiniteSuspended<'index>` are
         // layout-identical (const proof above); the allocation is reused, so the
         // box address is preserved and the field is now the suspended form.
@@ -99,7 +104,9 @@ impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended<'query> {
         // pointers to re-validate; any borrowed query-pipeline data is covered by
         // the `'query: 'a` bound.
         unsafe {
-            <index_result::SuspendedIndexResult<'query>>::into_active_in_place::<'a>(result_slot)
+            <index_result::SuspendedIndexResult<'query>>::into_active_in_place::<'a>(
+                NonNull::new(result_slot).expect("`result_slot` must not be null"),
+            )
         };
         // SAFETY: layout-identical (const proof above); the allocation is reused,
         // so the box address is preserved and the field is now active for `'a`.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -303,6 +303,7 @@ mod via_resume {
     use rlookup::RLookupKeyHandle;
     use rqe_iterators::TypeErasedRQEIterator;
     use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+    use std::ptr::NonNull;
 
     #[test]
     fn revalidate() {
@@ -314,7 +315,7 @@ mod via_resume {
         };
         let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
         // SAFETY: handle_ptr points to a valid, stack-allocated RLookupKeyHandle.
-        unsafe { it.set_handle(&raw mut handle) };
+        unsafe { it.set_handle(Some(NonNull::from(&mut handle))) };
 
         let _it = revalidate_via_resume(
             TypeErasedRQEIterator::new(Box::new(it)),
@@ -345,17 +346,18 @@ fn key_mut_ref_initially_null() {
 #[test]
 fn set_handle_non_null_invalidates_on_drop() {
     use rlookup::RLookupKeyHandle;
+    use std::ptr::NonNull;
 
     let mut handle = RLookupKeyHandle {
         key_ptr: std::ptr::null_mut(),
         is_valid: true,
     };
-    let handle_ptr: *mut RLookupKeyHandle = &mut handle;
+    let handle_ptr = NonNull::from(&mut handle);
 
     {
         let mut it = MetricSortedById::new(vec![1], vec![0.5]);
         // SAFETY: handle_ptr points to a valid, stack-allocated RLookupKeyHandle.
-        unsafe { it.set_handle(handle_ptr) };
+        unsafe { it.set_handle(Some(handle_ptr)) };
         // it is dropped here
     }
 
@@ -407,10 +409,8 @@ mod header_dispatch {
     struct OwnedHeader(Option<NonNull<QueryIterator>>);
 
     impl OwnedHeader {
-        fn new(raw: *mut QueryIterator) -> Self {
-            Self(Some(
-                NonNull::new(raw).expect("boxed_new returns an owning pointer"),
-            ))
+        fn new(raw: NonNull<QueryIterator>) -> Self {
+            Self(Some(raw))
         }
 
         fn as_non_null(&self) -> NonNull<QueryIterator> {
@@ -473,7 +473,7 @@ mod header_dispatch {
             // SAFETY: `it` is a live metric iterator, held exclusively here.
             let slot = unsafe { metric::own_key_ref(it.as_non_null()) };
             // SAFETY: `slot` is that iterator's own key slot, live and initialised.
-            let key = unsafe { &mut *slot };
+            let key = unsafe { &mut *slot.as_ptr() };
             assert!(key.is_null(), "{name}: a fresh iterator has no key yet");
             *key = (&raw mut keys[i]).cast::<RLookupKey<'_>>();
         }
@@ -484,7 +484,7 @@ mod header_dispatch {
             // SAFETY: as above.
             let slot = unsafe { metric::own_key_ref(it.as_non_null()) };
             // SAFETY: as above.
-            let key = unsafe { &mut *slot };
+            let key = unsafe { &mut *slot.as_ptr() };
             assert_eq!(
                 *key,
                 (&raw mut keys[i]).cast::<RLookupKey<'_>>(),
@@ -506,7 +506,7 @@ mod header_dispatch {
         for ((name, it), handle) in headers.iter().zip(&mut handles) {
             // SAFETY: `it` is a live metric iterator held exclusively, and `handle`
             // outlives it — the iterators are freed before `handles` goes out of scope.
-            unsafe { metric::set_key_handle(it.as_non_null(), &raw mut *handle) };
+            unsafe { metric::set_key_handle(it.as_non_null(), Some(NonNull::from(&mut *handle))) };
             assert!(handle.is_valid, "{name}: wiring a handle must not clear it");
         }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -24,7 +24,7 @@ fn init() -> Replier {
     // function pointers with mock implementations that record replies
     // without ever dereferencing the `RedisModuleCtx` pointer, so a
     // dangling non-null address is safe here.
-    unsafe { Replier::new(std::ptr::dangling_mut::<RedisModuleCtx>()) }
+    unsafe { Replier::new(std::ptr::NonNull::<RedisModuleCtx>::dangling()) }
 }
 
 /// Capture a single reply from a closure.

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -868,7 +868,8 @@ impl TestContext {
         // Write offset data - write 10 offset values [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         // to match what the tests expect
         for i in 0..10u32 {
-            varint_ffi::VVW_Write(Some(vw_nonnull), i);
+            // SAFETY: `vw_nonnull` comes from `NewVarintVectorWriter` and is exclusively owned here.
+            unsafe { varint_ffi::VVW_Write(vw_nonnull.as_ptr(), i) };
         }
 
         // Create ForwardIndexEntry
@@ -890,7 +891,9 @@ impl TestContext {
             ffi::InvertedIndex_WriteForwardIndexEntry(idx, &mut entry, false);
         }
 
-        varint_ffi::VVW_Free(Some(vw_nonnull));
+        // SAFETY: `vw_nonnull` comes from `NewVarintVectorWriter`, is exclusively owned here,
+        // and is not used again.
+        unsafe { varint_ffi::VVW_Free(vw_nonnull.as_ptr()) };
     }
 
     /// Get the numeric range tree for this context.

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -124,17 +124,17 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// pointer until the loader sets it.
     pub own_key: Box<*mut RLookupKey<'index>>,
     /// Back-reference to the handle that points to [`own_key`](Self::own_key).
-    /// Set by the C side alongside `own_key`; null until then.
-    pub key_handle: *mut RLookupKeyHandle,
+    /// Set by the C side alongside `own_key`; [`None`] until then.
+    pub key_handle: Option<NonNull<RLookupKeyHandle>>,
 }
 
 impl<E: ExpirationChecker> Drop for VectorScoreSource<'_, E> {
     fn drop(&mut self) {
-        if !self.key_handle.is_null() {
-            // SAFETY: key_handle is non-null only when VectorTopK_SetKeyHandle
+        if let Some(mut key_handle) = self.key_handle {
+            // SAFETY: key_handle is set only when VectorTopK_SetKeyHandle
             // stored a valid, live RLookupKeyHandle pointer here.
             unsafe {
-                (*self.key_handle).is_valid = false;
+                key_handle.as_mut().is_valid = false;
             }
         }
     }
@@ -211,7 +211,7 @@ impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
             expiration,
             unfiltered_consumed: false,
             own_key: Box::new(ptr::null_mut()),
-            key_handle: ptr::null_mut(),
+            key_handle: None,
         }
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Pure-Rust signatures across the RQE iterators, the reducers, the RedisJSON API wrapper and several `*_ffi` crates take raw `*mut`/`*const` parameters that are in fact never null, so every callee re-derives that fact and every caller has to read the docs to learn it. The pointer nullability contract lives in prose rather than in the type.
2. Change: Move the non-null contract into the types. `NonNull<T>` where a pointer must be valid, `Option<NonNull<T>>` where null is a meaningful value (it is niche-packed, so the ABI is unchanged). Raw pointers stay at the `extern "C"` boundary itself, per the policy this stack's first PR records. Where a raw pointer arrives from C, the existing `debug_assert!` is kept and paired with a documented `NonNull::new_unchecked`, so the release-mode behavior is byte-for-byte what it was.
3. Outcome: No user-visible change, and no behavior change in either build profile. Internal-only. Two things a reviewer should look at first: 18 public `fn` signatures change, which is source-breaking for RediSearchEnterprise; and four generated C prototypes gain a `const` qualifier (`RLookup_LoadDocumentAll`, `RLookup_LoadDocumentIndividual` on `opts`, `RLookup_LoadRuleFields` on `index_spec`) because `cheadergen` now sees `&T` instead of `*mut T`.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

- `src/redisearch_rs/rqe_iterators/` — iterator interop, id-list, metric and union types
- `src/redisearch_rs/c_entrypoint/iterators_ffi/` — union, intersection, metric, inverted-index term
- `src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/`, `rlookup_ffi/`, `module_init_ffi/`
- `src/redisearch_rs/redis_json_api/` — key opening and `JsonValue`
- `src/redisearch_rs/headers/` — regenerated

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
