### PR TITLE
redisearch_rs: check the FFI null contracts in release builds

### DIFF
--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -14,7 +14,10 @@
   - `c_wrappers/*` are exempt: they mirror C structs, so raw pointer accessors and
     setters are the interface.
 - Safety Comments: Number invariants in the safety doc comment and refer to these invariants in your safety in-line comments throughout that function.
-- debug_assert invariants in FFI functions
+- Check the pointer invariants a null test can express unconditionally at the `extern "C"`
+  boundary (`NonNull::new(p).expect(...)`), so a null argument aborts instead of becoming
+  undefined behavior in a release build. `debug_assert` the invariants a callee cannot
+  check for itself, such as ownership, aliasing, and provenance.
 - RediSearch deals with potentially invalid UTF-8 strings so **never assume** `str` /`String` are fine for user input. Prefer `[u8]`, `Vec<u8>`, `CStr`, or `CString`.
 - [`unsafe-tools`](https://github.com/JonasKruckenberg/unsafe-tools)’ `mimic` and `canary` for sized-opaque types that can be passed to C (and e.g. stack allocated)
 - Know and use `Pin` when heap allocated Rust objects and pointers are at play (chances are high you can't move that object!)

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -133,9 +133,7 @@ pub unsafe extern "C" fn AddIntersectionIteratorChild(
     header: *mut QueryIterator,
     child: *mut QueryIterator,
 ) {
-    debug_assert!(!header.is_null());
-    // SAFETY: `header` is non-null per 1.
-    let header = unsafe { NonNull::new_unchecked(header) };
+    let header = NonNull::new(header).expect("`header` must not be null");
     debug_assert_eq!(
         // SAFETY: safe thanks to 1
         unsafe { header.as_ref().type_ },

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -51,9 +51,7 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     debug_assert!(!sctx.is_null(), "sctx must not be null");
     debug_assert!(!term.is_null(), "term must not be null");
 
-    debug_assert!(!idx.is_null(), "idx must not be null");
-    // SAFETY: 1. guarantees `idx` is valid and non-null.
-    let idx = unsafe { NonNull::new_unchecked(idx.cast_mut()) };
+    let idx = NonNull::new(idx.cast_mut()).expect("`idx` must not be null");
     // SAFETY: 3. guarantees `sctx` is valid and non-null.
     let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -73,12 +73,9 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     _type: MetricType,
 ) -> *mut QueryIterator {
     let (ids_list, metrics_list) = if let Some(ids) = NonNull::new(ids) {
-        debug_assert!(
-            !metrics.is_null(),
-            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null."
+        let metrics = NonNull::new(metrics).expect(
+            "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null.",
         );
-        // SAFETY: 3. guarantees `metrics` is non-null whenever `ids` is.
-        let metrics = unsafe { NonNull::new_unchecked(metrics) };
         // SAFETY: Safe thanks to 1.
         let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
         // SAFETY: Safe thanks to 2.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -139,9 +139,7 @@ pub unsafe extern "C" fn NewUnionIterator(
 ///    created via [`NewUnionIterator`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrimUnionIterator(it: *mut QueryIterator, limit: usize, asc: bool) {
-    debug_assert!(!it.is_null());
-    // SAFETY: `it` is non-null per 1.
-    let it = unsafe { NonNull::new_unchecked(it) };
+    let it = NonNull::new(it).expect("`it` must not be null");
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).
     debug_assert_eq!(unsafe { it.as_ref().type_ }, IteratorType::Union);
     // SAFETY: caller guarantees `it` is valid and points to a union iterator (1).

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -33,9 +33,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
-    let ctx = unsafe { NonNull::new_unchecked(ctx) };
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -60,9 +58,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     t: *const NumericRangeTree,
     with_headers: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
-    let ctx = unsafe { NonNull::new_unchecked(ctx) };
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -87,9 +83,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     t: *const NumericRangeTree,
     minimal: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
-    let ctx = unsafe { NonNull::new_unchecked(ctx) };
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -322,14 +322,11 @@ impl<'a> JsonValue<'a> {
 
     /// Get a non-owning reference to this `JsonValue`.
     pub fn as_ref(&self) -> JsonValueRef<'_> {
-        // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
-        // where we ensure the value is actually initialized before being handed out.
-        let ptr = unsafe { *self.ptr }.cast_mut();
-        debug_assert!(!ptr.is_null());
-
         JsonValueRef {
-            // SAFETY: `new` asserts `allocJson` returned a non-null value.
-            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
+            // where we ensure the value is actually initialized before being handed out.
+            ptr: NonNull::new(unsafe { *self.ptr }.cast_mut())
+                .expect("a populated `JsonValue` holds a non-null value"),
             api: self.api,
         }
     }

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -218,11 +218,12 @@ extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
 ) -> IteratorStatus {
     debug_assert!(base.is_aligned());
-    debug_assert!(!base.is_null());
-    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
-    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     match wrapper.inner.read() {
         Ok(Some(result)) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -248,11 +249,12 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
     doc_id: DocId,
 ) -> IteratorStatus {
     debug_assert!(base.is_aligned());
-    debug_assert!(!base.is_null());
-    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
-    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     match wrapper.inner.skip_to(doc_id) {
         Ok(Some(SkipToOutcome::Found(result))) => {
             wrapper.header.current = result as *mut RSIndexResult as *mut ffi::RSIndexResult;
@@ -311,11 +313,12 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
         return ValidateStatus_VALIDATE_TIMEOUT;
     }
 
-    debug_assert!(!base.is_null());
-    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
-    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
 
     // SAFETY: spec is a valid pointer (guaranteed by C caller)
     let spec_ref = unsafe { &*spec };
@@ -353,11 +356,12 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
 
 extern "C" fn rewind<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIterator) {
     debug_assert!(base.is_aligned());
-    debug_assert!(!base.is_null());
-    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`], which rules out null.
-    let base = unsafe { NonNull::new_unchecked(base) };
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
-    let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
+    let wrapper = unsafe {
+        RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(
+            NonNull::new(base).expect("`base` must not be null"),
+        )
+    };
     wrapper.inner.rewind();
     wrapper.header.lastDocId = wrapper.inner.last_doc_id();
     wrapper.header.atEOF = wrapper.inner.at_eof();
@@ -392,10 +396,7 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
     base: *mut QueryIterator,
 ) -> *mut QueryIterator {
     debug_assert!(base.is_aligned());
-    debug_assert!(!base.is_null());
-    // SAFETY: As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
-    // `base` is a live header, so it is non-null.
-    let base = unsafe { NonNull::new_unchecked(base) };
+    let base = NonNull::new(base).expect("`base` must not be null");
     // SAFETY:
     // 1. As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
     //    `base` is an aligned, live header, uniquely owned until it is consumed

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -306,9 +306,7 @@ type UnionWrapper<'index> = RQEIteratorWrapper<UnionOpaque<'index, CRQEIterator>
 /// `base` must be a valid, owning pointer to a `UnionWrapper` created via
 /// [`build_union`].
 unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut QueryIterator {
-    debug_assert!(!base.is_null());
-    // SAFETY: the caller guarantees `base` is a valid owning pointer, so it is non-null.
-    let base = unsafe { NonNull::new_unchecked(base) };
+    let base = NonNull::new(base).expect("`base` must not be null");
     // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
     let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
     for child in wrapper.inner.children_mut() {


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: At 14 `extern "C"` entry points the incoming pointer's non-nullness is asserted with `debug_assert!`, which compiles out of a release build. A null argument from C is therefore undefined behavior in production — a dereference of address zero at best, a silently miscompiled branch at worst — and each site needs an `unsafe { NonNull::new_unchecked(..) }` block plus a `// SAFETY:` comment to get the pointer into a checked type.
2. Change: Perform the check unconditionally where a callee can actually perform it: `NonNull::new(p).expect(...)`. That deletes 14 `unsafe` blocks. `debug_assert` is left for the invariants a callee cannot check for itself — ownership, aliasing, provenance — and `src/redisearch_rs/CONTRIBUTING.md` is updated to draw that line.
3. Outcome: A null pointer crossing the FFI boundary in a release build now aborts with a named message instead of being undefined behavior. Not reachable from any correct caller, so no user-visible change; internal-only. The knowing tradeoff is one null test per call, on paths that already do a `Box`/slice reconstruction, in exchange for removing UB from the release profile.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

- `src/redisearch_rs/rqe_iterators/src/interop.rs`, `union_opaque.rs`
- `src/redisearch_rs/c_entrypoint/iterators_ffi/` — union, intersection, metric, inverted-index term
- `src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs`
- `src/redisearch_rs/redis_json_api/src/value.rs`
- `src/redisearch_rs/CONTRIBUTING.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
