### PR TITLE
[8.8-rse] [MOD-16794] FT.HYBRID: COMMAND DOCS now documents the VSIM FILTER POLICY/BATCH_SIZE clause on the correct argument

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2367,10 +2367,53 @@
           },
           {
             "name": "filter",
-            "type": "string",
+            "type": "block",
+            "optional": true,
             "token": "FILTER",
-            "expression": true,
-            "optional": true
+            "arguments": [
+              {
+                "name": "count",
+                "type": "integer",
+                "since": "8.4.3"
+              },
+              {
+                "name": "filter_expression",
+                "type": "string",
+                "expression": true
+              },
+              {
+                "name": "policy",
+                "type": "oneof",
+                "optional": true,
+                "token": "POLICY",
+                "since": "8.4.3",
+                "arguments": [
+                  {
+                    "name": "adhoc",
+                    "type": "pure-token",
+                    "token": "ADHOC"
+                  },
+                  {
+                    "name": "batches_policy",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "batches",
+                        "type": "pure-token",
+                        "token": "BATCHES"
+                      },
+                      {
+                        "name": "batch_size_value",
+                        "type": "integer",
+                        "token": "BATCH_SIZE",
+                        "optional": true,
+                        "since": "8.4.3"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3198,47 +3241,19 @@
       },
       {
         "name": "filter",
-        "type": "block",
+        "type": "string",
         "optional": true,
-        "token": "FILTER",
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer"
-          },
-          {
-            "name": "filter_expression",
-            "type": "string",
-            "expression": true
-          },
-          {
-            "name": "policy",
-            "type": "oneof",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "adhoc",
-                "type": "pure-token",
-                "token": "ADHOC"
-              },
-              {
-                "name": "batches",
-                "type": "pure-token",
-                "token": "BATCHES"
-              }
-            ],
-            "token": "POLICY"
-          },
-          {
-            "name": "batch_size_value",
-            "type": "integer",
-            "token": "BATCH_SIZE",
-            "optional": true
-          }
-        ]
+        "expression": true,
+        "token": "FILTER"
       }
     ],
-    "since": "8.4.4",
+    "since": "8.4.0",
+    "history": [
+      [
+        "8.4.3",
+        "Added `count`, `POLICY` and `BATCH_SIZE` arguments to the `VSIM` `FILTER` clause"
+      ]
+    ],
     "group": "search",
     "command_tips": [
       "DONT_CACHE"

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2586,8 +2586,54 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
           {
             .name = "filter",
             .token = "FILTER",
-            .type = REDISMODULE_ARG_TYPE_STRING,
+            .type = REDISMODULE_ARG_TYPE_BLOCK,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+            .subargs = (RedisModuleCommandArg[]){
+              {
+                .name = "count",
+                .since = "8.4.3",
+                .type = REDISMODULE_ARG_TYPE_INTEGER,
+              },
+              {
+                .name = "filter_expression",
+                .type = REDISMODULE_ARG_TYPE_STRING,
+              },
+              {
+                .name = "policy",
+                .token = "POLICY",
+                .since = "8.4.3",
+                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                .subargs = (RedisModuleCommandArg[]){
+                  {
+                    .name = "adhoc",
+                    .token = "ADHOC",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "batches_policy",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "batches",
+                        .token = "BATCHES",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "batch_size_value",
+                        .token = "BATCH_SIZE",
+                        .since = "8.4.3",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                      },
+                      {0}
+                    },
+                  },
+                  {0}
+                },
+              },
+              {0}
+            },
           },
           {0}
         },
@@ -3469,49 +3515,17 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
       {
         .name = "filter",
         .token = "FILTER",
-        .type = REDISMODULE_ARG_TYPE_BLOCK,
+        .type = REDISMODULE_ARG_TYPE_STRING,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-        .subargs = (RedisModuleCommandArg[]){
-          {
-            .name = "count",
-            .type = REDISMODULE_ARG_TYPE_INTEGER,
-          },
-          {
-            .name = "filter_expression",
-            .type = REDISMODULE_ARG_TYPE_STRING,
-          },
-          {
-            .name = "policy",
-            .token = "POLICY",
-            .type = REDISMODULE_ARG_TYPE_ONEOF,
-            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-            .subargs = (RedisModuleCommandArg[]){
-              {
-                .name = "adhoc",
-                .token = "ADHOC",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {
-                .name = "batches",
-                .token = "BATCHES",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {0}
-            },
-          },
-          {
-            .name = "batch_size_value",
-            .token = "BATCH_SIZE",
-            .type = REDISMODULE_ARG_TYPE_INTEGER,
-            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-          },
-          {0}
-        },
       },
       {0}
     },
     .arity = -7,
-    .since = "8.4.4",
+    .since = "8.4.0",
+    .history = (RedisModuleCommandHistoryEntry[]){
+      {"8.4.3", "Added `count`, `POLICY` and `BATCH_SIZE` arguments to the `VSIM` `FILTER` clause"},
+      {0}
+    },
     .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);


### PR DESCRIPTION
Backport of #10429 to `8.8-rse`.

## Describe the changes in the pull request

1. **Current**: MOD-12371 (#7638) added the VSIM `FILTER <count> "expr" [POLICY ADHOC|BATCHES] [BATCH_SIZE <n>]` clause to `commands.json`, but placed the `count`/`POLICY`/`BATCH_SIZE` expansion on the wrong FILTER node — the tail-pipeline `FILTER` (which only accepts a single expression, see `src/hybrid/parse/hybrid_optional_args.c`), while the VSIM clause `FILTER` (where these arguments are actually parsed, see `parseFilterClause` in `src/hybrid/parse_hybrid.c`) remained a plain string. It also set the command-level `since` to `8.4.4`, a version that was never released. Since `commands.json` is compiled into `command_info.c` and registered via `RM_SetCommandInfo`, `COMMAND DOCS FT.HYBRID` described both FILTERs incorrectly.
2. **Change**: Moved the `count`/`POLICY`/`BATCH_SIZE` expansion into the VSIM clause `FILTER` block (per-argument `since: 8.4.3`, the first released version containing the clause), scoped `BATCH_SIZE` under the `BATCHES` branch of the `POLICY` oneof, restored the tail-pipeline `FILTER` to a plain expression argument, reverted the command-level `since` to `8.4.0` with a `history` entry, and regenerated `src/command_info/command_info.c`.
3. **Outcome**: `COMMAND DOCS FT.HYBRID` documents the POLICY/BATCH_SIZE clause under the VSIM clause where it belongs, the tail FILTER matches its real syntax, and the version metadata points at releases that actually exist.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10429

## Why this branch was missed

`8.8-rse` forked from `master` at d5f88d3 (2026-07-12); #10429 merged to `master` on 2026-07-14, two days after the branch point, and the PR carried no `backport 8.8-rse` label. Every other live branch (`master`, `8.8`, `8.6`, `8.6-rse`, `8.4`) already has the fix — `8.8-rse` was the only one left on the pre-fix state (`since: 8.4.4`, POLICY/BATCH_SIZE on the tail FILTER).

## Changes from original

None — clean cherry-pick of d6037df from `master`, no conflicts. `8.8-rse` branched off `master` (34 commits of divergence) rather than off `8.8` (466 commits), so the master commit applies directly; the `8.8` backport (#10502) does not.

Verified on this branch:

- `srcutil/gen_command_info.py -j commands.json -f src/command_info/command_info -i command_info` reproduces the committed `command_info.c` and `.h` byte-for-byte.
- The branch's own parser matches the documented grammar: `parseFilterClause` parses `count`/`POLICY`/`BATCH_SIZE` inside the VSIM clause, `hybrid_optional_args.c` registers the tail `FILTER` as a plain expression, and `SEARCH_ADHOC_BATCH_SIZE_IRRELEVANT` exists in `query_error`, so scoping `BATCH_SIZE` under `BATCHES` is correct here too.
- The `8.8-rse`-only parts of the FT.HYBRID entry are preserved: `EXPLAINSCORE`, `DISTINCT` under `collect_body`, and `command_tips: ["DONT_CACHE"]`. Arity is unchanged.

#### Which additional issues this PR fixes
1. MOD-16794

#### Main objects this PR modified
1. `commands.json` — FT.HYBRID entry
2. `src/command_info/command_info.c` — regenerated from the JSON

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
