### PR TITLE
[MOD-17995] Type the non-null pointer contract in the pure Rust crates

### DIFF
--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     io_result_ext::IoResultExt,
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -39,7 +40,7 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -67,7 +68,7 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_existing_docs(fgc), "existing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -18,6 +18,7 @@
 use std::{
     ffi::{c_char, c_int, c_void},
     io::{Read, Write},
+    ptr::NonNull,
 };
 
 use fork_gc::{ForkGC, Frame, io_result_ext::IoResultExt};
@@ -70,7 +71,7 @@ pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_voi
     debug_assert!(len > 0, "buffer length cannot be 0");
 
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let slice = unsafe { std::slice::from_raw_parts(buff.cast::<u8>(), len) };
 
@@ -93,7 +94,7 @@ pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_voi
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_void, len: usize) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     let slice = if len > 0 {
         // SAFETY: caller guarantees (2).
@@ -120,7 +121,7 @@ pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_vo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendTerminator(fgc: *mut ffi::ForkGC) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     Frame::Terminator.encode(&mut fgc.writer()).unwrap_or_exit();
 }
@@ -143,7 +144,7 @@ pub unsafe extern "C" fn FGC_recvFixed(
     len: usize,
 ) -> c_int {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let slice = unsafe { std::slice::from_raw_parts_mut(buf.cast::<u8>(), len) };
 
@@ -183,7 +184,7 @@ pub unsafe extern "C" fn FGC_recvBuffer(
     len: *mut usize,
 ) -> c_int {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
 
     let frame = match Frame::decode_nul_terminated(&mut fgc.reader()) {
         Ok(frame) => frame,
@@ -226,7 +227,7 @@ pub unsafe extern "C" fn recvFieldHeader(
     id_ptr: *mut u64,
 ) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(fgc).expect("`fgc` must not be null")) };
     let mut reader = fgc.reader();
 
     let frame = match Frame::decode_nul_terminated(&mut reader) {

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     missing_docs::{collect_missing_docs, handle_missing_docs},
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -40,7 +41,7 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -70,7 +71,7 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_missing_docs(fgc), "missing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
@@ -13,6 +13,7 @@ use fork_gc::{
     numeric::{collect_numeric, handle_numeric},
 };
 use index_spec::IndexSpecReadGuard;
+use std::ptr::NonNull;
 
 use crate::{FGCError, util::into_fgc_error};
 
@@ -40,7 +41,7 @@ pub unsafe extern "C" fn FGC_childCollectNumeric(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -70,7 +71,7 @@ pub unsafe extern "C" fn FGC_childCollectNumeric(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleNumeric(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_numeric(fgc), "numeric")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/terms.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/terms.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use fork_gc::{
     ForkGC,
     io_result_ext::IoResultExt,
@@ -41,7 +43,7 @@ pub unsafe extern "C" fn FGC_childCollectTerms(
     sctx: *mut ffi::RedisSearchCtx,
 ) {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
     // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (3).
@@ -71,7 +73,7 @@ pub unsafe extern "C" fn FGC_childCollectTerms(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleTerms(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).
-    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::new(gc).expect("`gc` must not be null")) };
 
     into_fgc_error(handle_terms(fgc), "terms")
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
@@ -150,6 +150,7 @@ pub unsafe extern "C" fn Profile_PrintIterators(
         return;
     };
 
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: precondition 1.
     let mut replier = unsafe { Replier::new(ctx) };
     let mut profile_ctx = ProfilePrintCtx::new(limited, print_profile_clock);

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -208,5 +208,5 @@ pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
     debug_assert!(!it.is_null());
     // SAFETY: guaranteed by 1.
     let wrapper = unsafe { wrapper_mut(it) };
-    wrapper.inner.source_mut().key_handle = handle;
+    wrapper.inner.source_mut().key_handle = NonNull::new(handle);
 }

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -14,6 +14,8 @@
 //! - DUMP_NUMIDX: Index entries dump
 //! - DUMP_NUMIDXTREE: Tree structure dump
 
+use std::ptr::NonNull;
+
 use numeric_range_tree::NumericRangeTree;
 use redis_module::RedisModuleCtx;
 
@@ -31,7 +33,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -56,7 +58,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     t: *const NumericRangeTree,
     with_headers: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -81,7 +83,7 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     t: *const NumericRangeTree,
     minimal: bool,
 ) {
-    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -33,7 +33,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -58,7 +60,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     t: *const NumericRangeTree,
     with_headers: bool,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
@@ -83,7 +87,9 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     t: *const NumericRangeTree,
     minimal: bool,
 ) {
-    let ctx = NonNull::new(ctx).expect("`ctx` must not be null");
+    debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    // SAFETY: `ctx` is a valid Redis module context per the function docs, so non-null.
+    let ctx = unsafe { NonNull::new_unchecked(ctx) };
     // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
     let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -12,6 +12,7 @@ use std::{
     marker::PhantomData,
     mem::ManuallyDrop,
     os::fd::FromRawFd,
+    ptr::NonNull,
     time::Duration,
 };
 
@@ -34,11 +35,11 @@ impl ForkGC {
     /// 1. `ptr` must point to a valid, initialised [`ffi::ForkGC`].
     /// 2. For the chosen lifetime `'a`, no other reference to the same
     ///    struct may exist.
-    pub unsafe fn from_ptr_mut<'a>(ptr: *mut ffi::ForkGC) -> &'a mut Self {
-        // SAFETY: `#[repr(transparent)]` guarantees `*mut ffi::ForkGC` and
-        // `*mut ForkGC` have identical layout. Validity and aliasing are
+    pub const unsafe fn from_ptr_mut<'a>(ptr: NonNull<ffi::ForkGC>) -> &'a mut Self {
+        // SAFETY: `#[repr(transparent)]` guarantees `NonNull<ffi::ForkGC>` and
+        // `NonNull<ForkGC>` have identical layout. Validity and aliasing are
         // the caller's responsibility per (1) and (2).
-        unsafe { &mut *ptr.cast::<ForkGC>() }
+        unsafe { ptr.cast::<ForkGC>().as_mut() }
     }
 
     /// Return a writable handle to the GC pipe.

--- a/src/redisearch_rs/fork_gc/tests/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/tests/fork_gc.rs
@@ -16,6 +16,7 @@ use std::{
     io::{self, Read, Write},
     mem,
     os::fd::AsRawFd,
+    ptr::NonNull,
     time::Duration,
 };
 
@@ -44,7 +45,7 @@ fn make_fork_gc() -> (ffi::ForkGC, io::PipeReader, io::PipeWriter) {
 fn roundtrip_through_fork_gc() {
     let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
     // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
-    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::from(&mut raw)) };
 
     fgc.writer().write_all(b"hello").unwrap();
 
@@ -57,7 +58,7 @@ fn roundtrip_through_fork_gc() {
 fn times_out_when_no_data_available() {
     let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
     // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
-    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+    let fgc = unsafe { ForkGC::from_ptr_mut(NonNull::from(&mut raw)) };
 
     let mut buf = [0u8; 5];
     let err = fgc

--- a/src/redisearch_rs/numeric_range_tree/src/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/debug.rs
@@ -12,6 +12,8 @@
 //! This module provides functions to dump tree state for debugging purposes.
 //! These are used by the FT.DEBUG commands (NUMIDX_SUMMARY, DUMP_NUMIDX, DUMP_NUMIDXTREE).
 
+use std::ptr::NonNull;
+
 use index_result::RSIndexResult;
 use inverted_index::IndexReader;
 use redis_reply::{ArrayBuilder, MapBuilder, RedisModuleCtx, Replier};
@@ -33,7 +35,7 @@ struct BlocksEfficiencyStats {
 /// # Safety
 ///
 /// - `ctx` must be a valid Redis module context.
-pub unsafe fn debug_summary(ctx: *mut RedisModuleCtx, tree: Option<&NumericRangeTree>) {
+pub unsafe fn debug_summary(ctx: NonNull<RedisModuleCtx>, tree: Option<&NumericRangeTree>) {
     // SAFETY: ctx is valid per function docs
     let mut replier = unsafe { Replier::new(ctx) };
     let mut arr = replier.array();
@@ -67,7 +69,7 @@ pub unsafe fn debug_summary(ctx: *mut RedisModuleCtx, tree: Option<&NumericRange
 ///
 /// - `ctx` must be a valid Redis module context.
 pub unsafe fn debug_dump_index(
-    ctx: *mut RedisModuleCtx,
+    ctx: NonNull<RedisModuleCtx>,
     tree: Option<&NumericRangeTree>,
     with_headers: bool,
 ) {
@@ -105,7 +107,7 @@ pub unsafe fn debug_dump_index(
 ///
 /// - `ctx` must be a valid Redis module context.
 pub unsafe fn debug_dump_tree(
-    ctx: *mut RedisModuleCtx,
+    ctx: NonNull<RedisModuleCtx>,
     tree: Option<&NumericRangeTree>,
     minimal: bool,
 ) {

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
@@ -13,9 +13,9 @@ use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::debug;
 use redis_mock::reply::{ReplyValue, capture_replies};
 
-fn mock_ctx() -> *mut redis_reply::RedisModuleCtx {
+fn mock_ctx() -> std::ptr::NonNull<redis_reply::RedisModuleCtx> {
     redis_mock::init_redis_module_mock();
-    std::ptr::dangling_mut::<redis_reply::RedisModuleCtx>()
+    std::ptr::NonNull::dangling()
 }
 
 fn capture_single_reply(f: impl FnOnce()) -> ReplyValue {

--- a/src/redisearch_rs/redis_json_api/src/key_values.rs
+++ b/src/redisearch_rs/redis_json_api/src/key_values.rs
@@ -25,7 +25,7 @@ pub struct KeyValuesIterator<'a> {
     ) -> i32,
     // Free the iterator
     free: unsafe extern "C" fn(ptr: ffi::JSONKeyValuesIterator),
-    ctx: *mut redis_module::RedisModuleCtx,
+    ctx: NonNull<redis_module::RedisModuleCtx>,
     api: &'a RedisJsonApi,
     // Remaining items. Probed at construction from the source object via
     // `getLen`.
@@ -54,7 +54,7 @@ impl<'a> KeyValuesIterator<'a> {
     /// 2. `ptr` must be a valid ptr obtained from `getKeyValues` if `Some`.
     pub(crate) unsafe fn from_non_null(
         ptr: Option<NonNull<c_void>>,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         api: &'a RedisJsonApi,
         len: usize,
     ) -> Self {
@@ -86,7 +86,7 @@ impl<'a> Iterator for KeyValuesIterator<'a> {
         let status = unsafe { (self.next)(self.ptr?.as_ptr(), &raw mut key, value.ptr) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
-            let key = RedisString::from_redis_module_string(self.ctx.cast(), key.cast());
+            let key = RedisString::from_redis_module_string(self.ctx.as_ptr().cast(), key.cast());
             self.remaining = self.remaining.saturating_sub(1);
             Some((key, value))
         } else {

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -124,11 +124,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key(ctx.as_ptr(), key_name.inner.cast()) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Opens a readable JSON key with the specified name.
@@ -148,11 +144,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key_from_str(ctx.as_ptr(), key_name.as_ptr()) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Opens a readable JSON key with the specified name and flags.
@@ -181,11 +173,7 @@ impl RedisJsonApi {
             )
         };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     /// Gets the JSON root from an already-open [`RedisModuleKey`] handle.
@@ -211,11 +199,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.); the helper tolerates a NULL/non-JSON key.
         let ptr = unsafe { ffi::JSON_GetJsonFromHandleCompat(redis_key) };
 
-        if ptr.is_null() {
-            None
-        } else {
-            Some(JsonValueRef { ptr, api: self })
-        }
+        NonNull::new(ptr.cast_mut()).map(|ptr| JsonValueRef { ptr, api: self })
     }
 
     pub const fn vtable(&self) -> NonNull<RedisJsonApiVTable> {

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -32,7 +32,7 @@ mod value;
 
 use ffi::RedisJSONAPI as RedisJsonApiVTable;
 use redis_module::{RedisString, key::KeyFlags};
-use std::{error::Error, ffi::CStr, fmt, ptr::NonNull};
+use std::{error::Error, ffi::CStr, fmt, ptr, ptr::NonNull};
 
 pub use key_values::KeyValuesIterator;
 pub use path::JsonPath;
@@ -190,7 +190,7 @@ impl RedisJsonApi {
 
     /// Gets the JSON root from an already-open [`RedisModuleKey`] handle.
     ///
-    /// Returns `None` if the key is `NULL`, is not a module type, or does not hold JSON.
+    /// Returns `None` if the key is absent, is not a module type, or does not hold JSON.
     /// The caller owns the key handle and must keep it open while the returned
     /// [`JsonValueRef`] is in use.
     ///
@@ -199,13 +199,15 @@ impl RedisJsonApi {
     ///
     /// # Safety
     ///
-    /// 1. `redis_key` must be a valid, open `RedisModuleKey` handle (or NULL).
+    /// 1. `redis_key`, when present, must be a valid, open `RedisModuleKey` handle.
     ///
     /// [`RedisModuleKey`]: redis_module::RedisModuleKey
     pub unsafe fn open_from_handle(
         &self,
-        redis_key: *mut redis_module::RedisModuleKey,
+        redis_key: Option<NonNull<redis_module::RedisModuleKey>>,
     ) -> Option<JsonValueRef<'_>> {
+        let redis_key = redis_key.map_or(ptr::null_mut(), NonNull::as_ptr);
+
         // Safety: ensured by caller (1.); the helper tolerates a NULL/non-JSON key.
         let ptr = unsafe { ffi::JSON_GetJsonFromHandleCompat(redis_key) };
 

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -116,13 +116,13 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &RedisString,
     ) -> Option<JsonValueRef<'_>> {
         let open_key = vtable_fn!(self, openKey);
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { open_key(ctx, key_name.inner.cast()) };
+        let ptr = unsafe { open_key(ctx.as_ptr(), key_name.inner.cast()) };
 
         if ptr.is_null() {
             None
@@ -140,13 +140,13 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key_from_str(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &CStr,
     ) -> Option<JsonValueRef<'_>> {
         let open_key_from_str = vtable_fn!(self, openKeyFromStr);
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { open_key_from_str(ctx, key_name.as_ptr()) };
+        let ptr = unsafe { open_key_from_str(ctx.as_ptr(), key_name.as_ptr()) };
 
         if ptr.is_null() {
             None
@@ -166,7 +166,7 @@ impl RedisJsonApi {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn open_key_with_flags(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         key_name: &RedisString,
         flags: KeyFlags,
     ) -> Option<JsonValueRef<'_>> {
@@ -175,7 +175,7 @@ impl RedisJsonApi {
         // Safety: ensured by caller (1.)
         let ptr = unsafe {
             open_key_with_flags(
-                ctx,
+                ctx.as_ptr(),
                 key_name.inner.cast(),
                 flags.bits() | redis_module::raw::REDISMODULE_READ as i32,
             )

--- a/src/redisearch_rs/redis_json_api/src/path.rs
+++ b/src/redisearch_rs/redis_json_api/src/path.rs
@@ -42,7 +42,7 @@ impl<'a> JsonPath<'a> {
     /// 1. `ctx` must be a valid Redis module context
     pub unsafe fn parse(
         path: &CStr,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
         api: &'a RedisJsonApi,
     ) -> Result<Self, RedisString> {
         let path_parse = vtable_fn!(api, pathParse);
@@ -50,7 +50,7 @@ impl<'a> JsonPath<'a> {
         let mut err_msg: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { path_parse(path.as_ptr(), ctx, &raw mut err_msg) };
+        let ptr = unsafe { path_parse(path.as_ptr(), ctx.as_ptr(), &raw mut err_msg) };
 
         if let Some(ptr) = NonNull::new(ptr as *mut c_void) {
             let path_free = vtable_fn!(api, pathFree);
@@ -62,7 +62,7 @@ impl<'a> JsonPath<'a> {
             })
         } else {
             Err(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 err_msg.cast(),
             ))
         }

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -116,11 +116,9 @@ impl<'a> LendingIterator for ResultsIter<'a> {
         // Safety: `ptr` is valid by construction.
         let raw = unsafe { (self.next)(self.ptr.as_ptr()) };
 
-        if raw.is_null() {
-            None
-        } else {
-            // Safety: we obtained the `raw` from calling `next`.
-            Some(unsafe { JsonValueRef::from_raw(raw, self.api) })
-        }
+        let raw = NonNull::new(raw.cast_mut())?;
+
+        // Safety: we obtained the `raw` from calling `next`.
+        Some(unsafe { JsonValueRef::from_raw(raw, self.api) })
     }
 }

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -85,17 +85,17 @@ impl<'a> ResultsIter<'a> {
     #[inline]
     pub unsafe fn serialize(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Result<RedisString, SerializeError> {
         let get_json_from_iter = vtable_fn!(self.api, getJSONFromIter);
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: `ptr` and `ctx` are valid by construction/caller guarantee
-        let status = unsafe { get_json_from_iter(self.ptr.as_ptr(), ctx, &mut str) };
+        let status = unsafe { get_json_from_iter(self.ptr.as_ptr(), ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 str.cast(),
             ))
         } else {

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -91,7 +91,7 @@ impl From<ffi::JSONType> for JsonType {
 //   will remain valid after it is freed I guess.
 #[derive(Clone, Copy)]
 pub struct JsonValueRef<'a> {
-    pub(crate) ptr: *const c_void, // is non-null
+    pub(crate) ptr: NonNull<c_void>,
     pub(crate) api: &'a RedisJsonApi,
 }
 
@@ -101,7 +101,7 @@ impl<'a> JsonValueRef<'a> {
     /// # Safety
     ///
     /// 1. `ptr` must be a valid ptr obtained from `getKey*`.
-    pub(crate) const unsafe fn from_raw(ptr: *const c_void, api: &'a RedisJsonApi) -> Self {
+    pub(crate) const unsafe fn from_raw(ptr: NonNull<c_void>, api: &'a RedisJsonApi) -> Self {
         Self { ptr, api }
     }
 
@@ -112,7 +112,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: usize = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_len(self.ptr, &raw mut out) };
+        let status = unsafe { get_len(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -131,7 +131,7 @@ impl<'a> JsonValueRef<'a> {
         let get_type = vtable_fn!(self.api, getType);
 
         // Safety: `ptr` is valid by construction.
-        let raw = unsafe { get_type(self.ptr) };
+        let raw = unsafe { get_type(self.ptr.as_ptr()) };
 
         JsonType::from_raw(raw).expect("invalid JSON type")
     }
@@ -143,7 +143,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: i64 = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_int(self.ptr, &raw mut out) };
+        let status = unsafe { get_int(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -159,7 +159,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: f64 = 0.0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_double(self.ptr, &raw mut out) };
+        let status = unsafe { get_double(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
@@ -175,7 +175,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out: i32 = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_boolean(self.ptr, &raw mut out) };
+        let status = unsafe { get_boolean(self.ptr.as_ptr(), &raw mut out) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out != 0)
@@ -192,7 +192,7 @@ impl<'a> JsonValueRef<'a> {
         let mut len: usize = 0;
 
         // Safety: `ptr` is valid by construction.
-        let status = unsafe { get_string(self.ptr, &raw mut str, &raw mut len) };
+        let status = unsafe { get_string(self.ptr.as_ptr(), &raw mut str, &raw mut len) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             // Safety: `getString` returns `OK` it promises to return a valid c string.
@@ -213,7 +213,7 @@ impl<'a> JsonValueRef<'a> {
         let mut out = JsonValue::new(self.api);
 
         // Safety: `ptr` is valid by construction, we correctly allocated the `JsonValue` before.
-        let status = unsafe { get_at(self.ptr, idx, out.as_ptr()) };
+        let status = unsafe { get_at(self.ptr.as_ptr(), idx, out.as_ptr()) };
         if status == redis_module::REDISMODULE_OK as i32 {
             Some(out)
         } else {
@@ -238,7 +238,7 @@ impl<'a> JsonValueRef<'a> {
             let get_key_values = vtable_fn!(self.api, getKeyValues);
 
             // Safety: `ptr` is valid by construction.
-            let ptr = unsafe { get_key_values(self.ptr) };
+            let ptr = unsafe { get_key_values(self.ptr.as_ptr()) };
             // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
             let ptr = NonNull::new(ptr.cast_mut())?;
 
@@ -256,7 +256,7 @@ impl<'a> JsonValueRef<'a> {
         let get = vtable_fn!(self.api, get);
 
         // Safety: `ptr` is valid by construction and CStr ensures `ptr` is a valid c string.
-        let ptr = unsafe { get(self.ptr, path.as_ptr()) };
+        let ptr = unsafe { get(self.ptr.as_ptr(), path.as_ptr()) };
         // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
         let ptr = NonNull::new(ptr.cast_mut())?;
 
@@ -279,7 +279,7 @@ impl<'a> JsonValueRef<'a> {
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.) and ptr is valid by construction.
-        let status = unsafe { get_json(self.ptr, ctx.as_ptr(), &mut str) };
+        let status = unsafe { get_json(self.ptr.as_ptr(), ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
@@ -325,7 +325,8 @@ impl<'a> JsonValue<'a> {
         JsonValueRef {
             // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
             // where we ensure the value is actually initialized before being handed out.
-            ptr: unsafe { *self.ptr },
+            ptr: NonNull::new(unsafe { *self.ptr }.cast_mut())
+                .expect("a populated `JsonValue` holds a non-null value"),
             api: self.api,
         }
     }

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -322,11 +322,14 @@ impl<'a> JsonValue<'a> {
 
     /// Get a non-owning reference to this `JsonValue`.
     pub fn as_ref(&self) -> JsonValueRef<'_> {
+        // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
+        // where we ensure the value is actually initialized before being handed out.
+        let ptr = unsafe { *self.ptr }.cast_mut();
+        debug_assert!(!ptr.is_null());
+
         JsonValueRef {
-            // Safety: we obtained this pointer from `allocJson` and the `new` constructor is private
-            // where we ensure the value is actually initialized before being handed out.
-            ptr: NonNull::new(unsafe { *self.ptr }.cast_mut())
-                .expect("a populated `JsonValue` holds a non-null value"),
+            // SAFETY: `new` asserts `allocJson` returned a non-null value.
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
             api: self.api,
         }
     }

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -230,7 +230,7 @@ impl<'a> JsonValueRef<'a> {
     /// 1. `ctx` must be a valid Redis module context.
     pub unsafe fn key_values(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Option<KeyValuesIterator<'_>> {
         let (ptr, len) = if let Some(len) = self.len()
             && len > 0
@@ -272,18 +272,18 @@ impl<'a> JsonValueRef<'a> {
     #[inline]
     pub unsafe fn serialize(
         &self,
-        ctx: *mut redis_module::RedisModuleCtx,
+        ctx: NonNull<redis_module::RedisModuleCtx>,
     ) -> Result<RedisString, SerializeError> {
         let get_json = vtable_fn!(self.api, getJSON);
 
         let mut str: *mut redis_module::RedisModuleString = std::ptr::null_mut();
 
         // Safety: ensured by caller (1.) and ptr is valid by construction.
-        let status = unsafe { get_json(self.ptr, ctx, &mut str) };
+        let status = unsafe { get_json(self.ptr, ctx.as_ptr(), &mut str) };
 
         if status == redis_module::REDISMODULE_OK as i32 {
             Ok(RedisString::from_redis_module_string(
-                ctx.cast(),
+                ctx.as_ptr().cast(),
                 str.cast(),
             ))
         } else {

--- a/src/redisearch_rs/redis_reply/src/array.rs
+++ b/src/redisearch_rs/redis_reply/src/array.rs
@@ -118,7 +118,7 @@ impl Drop for ArrayBuilder<'_> {
             // SAFETY: ctx is validated at Replier construction
             unsafe {
                 RedisModule_ReplySetArrayLength.expect("RedisModule_ReplySetArrayLength")(
-                    self.replier.ctx,
+                    self.replier.ctx.as_ptr(),
                     i64::from(self.len),
                 );
             }

--- a/src/redisearch_rs/redis_reply/src/map.rs
+++ b/src/redisearch_rs/redis_reply/src/map.rs
@@ -130,7 +130,7 @@ impl Drop for MapBuilder<'_> {
             // SAFETY: ctx is validated at Replier construction
             unsafe {
                 RedisModule_ReplySetMapLength.expect("RedisModule_ReplySetMapLength")(
-                    self.replier.ctx,
+                    self.replier.ctx.as_ptr(),
                     i64::from(self.len),
                 );
             }

--- a/src/redisearch_rs/redis_reply/src/replier.rs
+++ b/src/redisearch_rs/redis_reply/src/replier.rs
@@ -8,6 +8,7 @@
 */
 
 use std::ffi::CStr;
+use std::ptr::NonNull;
 
 use redis_module::{
     REDISMODULE_POSTPONED_ARRAY_LEN, REDISMODULE_POSTPONED_LEN, RedisModule_ReplyWithArray,
@@ -25,7 +26,7 @@ use crate::map::MapBuilder;
 /// Validates the context once at construction and provides ergonomic
 /// methods for building Redis protocol replies.
 pub struct Replier {
-    pub(crate) ctx: *mut RedisModuleCtx,
+    pub(crate) ctx: NonNull<RedisModuleCtx>,
 }
 
 impl Replier {
@@ -34,8 +35,7 @@ impl Replier {
     /// # Safety
     ///
     /// - `ctx` must be a valid Redis module context for the lifetime of this Replier.
-    pub const unsafe fn new(ctx: *mut RedisModuleCtx) -> Self {
-        debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
+    pub const unsafe fn new(ctx: NonNull<RedisModuleCtx>) -> Self {
         Self { ctx }
     }
 
@@ -43,7 +43,10 @@ impl Replier {
     pub fn long_long(&mut self, value: i64) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithLongLong.expect("RedisModule_ReplyWithLongLong")(self.ctx, value);
+            RedisModule_ReplyWithLongLong.expect("RedisModule_ReplyWithLongLong")(
+                self.ctx.as_ptr(),
+                value,
+            );
         }
     }
 
@@ -51,7 +54,10 @@ impl Replier {
     pub fn double(&mut self, value: f64) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithDouble.expect("RedisModule_ReplyWithDouble")(self.ctx, value);
+            RedisModule_ReplyWithDouble.expect("RedisModule_ReplyWithDouble")(
+                self.ctx.as_ptr(),
+                value,
+            );
         }
     }
 
@@ -60,7 +66,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithSimpleString.expect("RedisModule_ReplyWithSimpleString")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 s.as_ptr(),
             );
         }
@@ -71,7 +77,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithStringBuffer.expect("RedisModule_ReplyWithStringBuffer")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 buf.as_ptr().cast(),
                 buf.len(),
             );
@@ -82,7 +88,9 @@ impl Replier {
     pub fn empty_array(&mut self) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithEmptyArray.expect("RedisModule_ReplyWithEmptyArray")(self.ctx);
+            RedisModule_ReplyWithEmptyArray.expect("RedisModule_ReplyWithEmptyArray")(
+                self.ctx.as_ptr(),
+            );
         }
     }
 
@@ -90,7 +98,7 @@ impl Replier {
     pub fn empty_map(&mut self) {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx, 0);
+            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx.as_ptr(), 0);
         }
     }
 
@@ -101,7 +109,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithArray.expect("RedisModule_ReplyWithArray")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 REDISMODULE_POSTPONED_ARRAY_LEN as i64,
             );
         }
@@ -120,7 +128,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 REDISMODULE_POSTPONED_LEN as i64,
             );
         }
@@ -139,7 +147,7 @@ impl Replier {
         // SAFETY: ctx is validated at construction
         unsafe {
             RedisModule_ReplyWithArray.expect("RedisModule_ReplyWithArray")(
-                self.ctx,
+                self.ctx.as_ptr(),
                 i64::from(len),
             );
         }
@@ -157,7 +165,10 @@ impl Replier {
     pub fn fixed_map(&mut self, len: u32) -> MapBuilder<'_> {
         // SAFETY: ctx is validated at construction
         unsafe {
-            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(self.ctx, i64::from(len));
+            RedisModule_ReplyWithMap.expect("RedisModule_ReplyWithMap")(
+                self.ctx.as_ptr(),
+                i64::from(len),
+            );
         }
         MapBuilder {
             replier: self,

--- a/src/redisearch_rs/redis_reply/tests/integration/main.rs
+++ b/src/redisearch_rs/redis_reply/tests/integration/main.rs
@@ -30,7 +30,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 pub fn init() -> Replier {
     redis_mock::init_redis_module_mock();
     // SAFETY: Context is ignored in mock mode, using non-null dummy address
-    unsafe { Replier::new(std::ptr::dangling_mut::<RedisModuleCtx>()) }
+    unsafe { Replier::new(std::ptr::NonNull::<RedisModuleCtx>::dangling()) }
 }
 
 /// Extract a single reply, panicking if there are zero or multiple replies.

--- a/src/redisearch_rs/reducers/src/reducer.rs
+++ b/src/redisearch_rs/reducers/src/reducer.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{ffi::c_void, ptr};
+use std::{ffi::c_void, ptr, ptr::NonNull};
 
 /// A safe wrapper around an `ffi::Reducer`.
 #[repr(transparent)]
@@ -34,17 +34,17 @@ impl Reducer {
         })
     }
 
-    /// Create a `Reducer` wrapper from a non-null pointer.
+    /// Create a `Reducer` wrapper from a pointer.
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid non-null pointer to an `ffi::Reducer` that is properly initialized.
+    /// 1. `ptr` must be a [valid] pointer to an `ffi::Reducer` that is properly initialized.
     ///    This also applies to any of its subfields.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub const unsafe fn from_raw<'a>(ptr: *const ffi::Reducer) -> &'a Self {
+    pub const unsafe fn from_raw<'a>(ptr: NonNull<ffi::Reducer>) -> &'a Self {
         // SAFETY: ensured by caller (1.)
-        unsafe { ptr.cast::<Self>().as_ref().unwrap() }
+        unsafe { &*ptr.cast::<Self>().as_ptr() }
     }
 
     /// Set `NewInstance` function pointer.

--- a/src/redisearch_rs/reducers/src/reducer.rs
+++ b/src/redisearch_rs/reducers/src/reducer.rs
@@ -34,7 +34,7 @@ impl Reducer {
         })
     }
 
-    /// Create a `Reducer` wrapper from a pointer.
+    /// Borrow `ptr` as a shared `Reducer`.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/reducers/src/reducer_options.rs
+++ b/src/redisearch_rs/reducers/src/reducer_options.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use query_error::QueryError;
 
 /// A safe wrapper around an `ffi::ReducerOptions`.
@@ -14,17 +16,17 @@ use query_error::QueryError;
 pub struct ReducerOptions(ffi::ReducerOptions);
 
 impl ReducerOptions {
-    /// Create a `ReducerOptions` wrapper from a non-null pointer.
+    /// Create a `ReducerOptions` wrapper from a pointer.
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid non-null pointer to an `ffi::ReducerOptions` that is properly initialized.
+    /// 1. `ptr` must be a [valid] pointer to an `ffi::ReducerOptions` that is properly initialized.
     ///    This also applies to any of its subfields.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::ReducerOptions) -> &'a mut Self {
+    pub const unsafe fn from_raw_mut<'a>(ptr: NonNull<ffi::ReducerOptions>) -> &'a mut Self {
         // SAFETY: ensured by caller (1.)
-        unsafe { ptr.cast::<Self>().as_mut().unwrap() }
+        unsafe { &mut *ptr.cast::<Self>().as_ptr() }
     }
 
     /// Get a reference to the `args` cursor.

--- a/src/redisearch_rs/reducers/src/reducer_options.rs
+++ b/src/redisearch_rs/reducers/src/reducer_options.rs
@@ -16,7 +16,7 @@ use query_error::QueryError;
 pub struct ReducerOptions(ffi::ReducerOptions);
 
 impl ReducerOptions {
-    /// Create a `ReducerOptions` wrapper from a pointer.
+    /// Borrow `ptr` as an exclusive `ReducerOptions`.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -86,7 +86,7 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
         // Safety: the `&'key` reference guarantees `open_key` is valid for `'key`.
         let value = unsafe {
             self.japi
-                .open_from_handle(ptr::from_ref(open_key).cast_mut().cast())
+                .open_from_handle(Some(NonNull::from_ref(open_key).cast()))
         }
         // If we fail to open the JSON root from the borrowed handle: fall back to
         // open the document by name.

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -52,11 +52,8 @@ impl<'a> JsonDocumentFormat<'a> {
     fn open_key(&self, key_name: &RedisString) -> Option<JsonValueRef<'a>> {
         // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
         unsafe {
-            self.japi.open_key_with_flags(
-                self.ctx.cast().as_ptr(),
-                key_name,
-                DOCUMENT_OPEN_KEY_QUERY_FLAGS,
-            )
+            self.japi
+                .open_key_with_flags(self.ctx.cast(), key_name, DOCUMENT_OPEN_KEY_QUERY_FLAGS)
         }
     }
 }
@@ -197,7 +194,7 @@ fn json_iter_to_value(
 
     // SAFETY: `ctx` is a valid Redis module context by construction of `JsonFormat`.
     // First get the JSON serialized value (since it does not consume the iterator)
-    let serialized = unsafe { iter.serialize(ctx.cast().as_ptr())? };
+    let serialized = unsafe { iter.serialize(ctx.cast())? };
 
     // Second, get the first JSON value. `is_empty()` returned false above, so the
     // iterator is contractually obligated to yield at least one value here.
@@ -249,7 +246,7 @@ fn json_val_to_value_expanded(
     match json.get_type() {
         JsonType::Object => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
-            let iter = unsafe { json.key_values(ctx.cast().as_ptr()).unwrap() };
+            let iter = unsafe { json.key_values(ctx.cast()).unwrap() };
 
             let values = iter.map(|(key, value)| {
                 let key = SharedValue::new_string(key.to_vec());
@@ -300,7 +297,7 @@ fn json_val_to_value(
         }
         JsonType::Object | JsonType::Array => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
-            let v = unsafe { json.serialize(ctx.cast().as_ptr()).unwrap() };
+            let v = unsafe { json.serialize(ctx.cast()).unwrap() };
             redis_module::raw::string_retain_string(ptr::null_mut(), v.inner);
             // SAFETY: `v` is a valid Redis string and we retained it above to
             // transfer one owned reference into the RSValue.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -24,7 +24,7 @@ fn init() -> Replier {
     // function pointers with mock implementations that record replies
     // without ever dereferencing the `RedisModuleCtx` pointer, so a
     // dangling non-null address is safe here.
-    unsafe { Replier::new(std::ptr::dangling_mut::<RedisModuleCtx>()) }
+    unsafe { Replier::new(std::ptr::NonNull::<RedisModuleCtx>::dangling()) }
 }
 
 /// Capture a single reply from a closure.

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -126,17 +126,17 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// pointer until the loader sets it.
     pub own_key: Box<*mut RLookupKey<'index>>,
     /// Back-reference to the handle that points to [`own_key`](Self::own_key).
-    /// Set by the C side alongside `own_key`; null until then.
-    pub key_handle: *mut RLookupKeyHandle,
+    /// Set by the C side alongside `own_key`; [`None`] until then.
+    pub key_handle: Option<NonNull<RLookupKeyHandle>>,
 }
 
 impl<E: ExpirationChecker> Drop for VectorScoreSource<'_, E> {
     fn drop(&mut self) {
-        if !self.key_handle.is_null() {
-            // SAFETY: key_handle is non-null only when VectorTopK_SetKeyHandle
+        if let Some(mut key_handle) = self.key_handle {
+            // SAFETY: key_handle is set only when VectorTopK_SetKeyHandle
             // stored a valid, live RLookupKeyHandle pointer here.
             unsafe {
-                (*self.key_handle).is_valid = false;
+                key_handle.as_mut().is_valid = false;
             }
         }
     }
@@ -210,7 +210,7 @@ impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
             expiration,
             unfiltered_consumed: false,
             own_key: Box::new(ptr::null_mut()),
-            key_handle: ptr::null_mut(),
+            key_handle: None,
         }
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Pure-Rust signatures in `redis_reply`, `redis_json_api`, `numeric_range_tree`, `rlookup`, `fork_gc`, `reducers` and `vector_score_source` take raw `*mut`/`*const` parameters that are in fact never null. Every callee re-derives that fact, and every caller has to read the docs to learn it — the nullability contract lives in prose rather than in the type.
2. Change: Move the contract into the types: `NonNull<T>` where a pointer must be valid, `Option<NonNull<T>>` where null is a meaningful value (niche-packed, so the ABI is unchanged). Where a raw pointer arrives from C, the existing `debug_assert!` is kept and paired with a documented `NonNull::new_unchecked`, so release-mode behavior is byte-for-byte what it was.
3. Outcome: No user-visible change and no behavior change in either build profile; internal-only. The one thing for a reviewer to weigh is that public `fn` signatures change, which is source-breaking for RediSearchEnterprise. This covers the non-iterator crates; the iterator stack is a separate PR.

#### Which additional issues this PR fixes

1. MOD-17995

#### Main objects this PR modified

- `src/redisearch_rs/fork_gc/`, `reducers/`, `vector_score_source/`
- `src/redisearch_rs/redis_json_api/` — key opening and `JsonValue`
- `src/redisearch_rs/redis_reply/`, `numeric_range_tree/`, `rlookup/`
- `src/redisearch_rs/c_entrypoint/fork_gc_ffi/`, `numeric_range_tree_ffi/`, `iterators_ffi/`

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

