### PR TITLE
[MOD-14988] tag_index: on disk

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3076,6 +3076,7 @@ dependencies = [
  "inverted_index",
  "lending-iterator",
  "query_term",
+ "redis-module",
  "redis_mock",
  "redisearch_rs",
  "rqe_iterators",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3082,6 +3082,7 @@ dependencies = [
  "rqe_iterators",
  "rqe_iterators_test_utils",
  "rqe_wildcard",
+ "search_disk",
  "tag_index",
  "thin_vec",
  "trie_rs",

--- a/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
@@ -128,6 +128,42 @@ impl SearchDiskHandle {
         api.new_geo_on_disk(disk_spec, gf, field_index, snapshot)
     }
 
+    /// Build a tag iterator backed by this on-disk index.
+    ///
+    /// Consumes the handle and delegates to the registered enterprise tag
+    /// iterator, which yields one entry per document carrying `token` in the
+    /// field at `field_index`.
+    ///
+    /// # Safety
+    ///
+    /// 1. The wrapped disk index spec must remain valid for `'index`.
+    /// 2. [`SEARCH_ENTERPRISE_ITERATORS`] must be initialized (always the case
+    ///    when the spec is backed by a disk index).
+    /// 3. `snapshot` must be a
+    ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for
+    ///    this disk spec that remains valid for `'index`.
+    /// 4. There must be no other live reference to the wrapped spec for `'index`.
+    pub unsafe fn new_tag_iterator<'index>(
+        self,
+        token: &ffi::RSToken,
+        field_index: FieldIndex,
+        weight: f64,
+        snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        // SAFETY: precondition (2) — a disk-backed spec always has the
+        // enterprise iterators registered.
+        let api = SEARCH_ENTERPRISE_ITERATORS
+            .get()
+            .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
+
+        // SAFETY: `new`'s invariant guarantees `self.0` points to a valid
+        // `RedisSearchDiskIndexSpec`; preconditions (1)/(4) uphold the `'index`
+        // lifetime and exclusive access of the returned reference.
+        let disk_spec = unsafe { &mut *self.0.as_ptr() };
+
+        api.new_tag_on_disk(disk_spec, token, field_index, weight, snapshot)
+    }
+
     /// Build a term iterator backed by this on-disk index.
     ///
     /// Consumes the handle and delegates to the registered enterprise term

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -316,7 +316,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/search_disk.h",
-        fns: &["SearchDisk_GetMaxDocId"],
+        fns: &["SearchDisk_GetMaxDocId", "SearchDisk_IndexTags"],
         types: &[],
         vars: &[],
     },

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -28,6 +28,7 @@ query_term.workspace = true
 redis-module.workspace = true
 rqe_iterators.workspace = true
 rqe_wildcard.workspace = true
+search_disk.workspace = true
 thin_vec.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -25,6 +25,7 @@ index_result.workspace = true
 inverted_index.workspace = true
 lending-iterator.workspace = true
 query_term.workspace = true
+redis-module.workspace = true
 rqe_iterators.workspace = true
 rqe_wildcard.workspace = true
 thin_vec.workspace = true

--- a/src/redisearch_rs/tag_index/src/iter.rs
+++ b/src/redisearch_rs/tag_index/src/iter.rs
@@ -30,7 +30,7 @@ use lending_iterator::LendingIterator as _;
 use rqe_wildcard::WildcardPattern;
 use trie_rs::iter::{ContainsLendingIter, LendingIter, WildcardLendingIter, filter::VisitAll};
 
-use crate::{InMemoryMode, SuffixData, Tag, TagIndex, TagIndexMode};
+use crate::{InMemoryMode, OnDiskMode, SuffixData, Tag, TagIndex, TagIndexMode};
 
 /// Value type stored in the memory-mode values trie. Boxed so the heap
 /// [`InvertedIndex`] address stays stable across trie restructuring — callers hold
@@ -189,6 +189,29 @@ impl TagIndex<InMemoryMode> {
         };
 
         TagIndexIterator { iter }
+    }
+}
+
+impl TagIndex<OnDiskMode> {
+    /// Iterate over all tags, in lexicographical order.
+    pub fn value_iter(&self) -> DiskTagIndexIterator<'_> {
+        all_iter(&self.mode.values)
+    }
+
+    /// Iterate over the tags matching `pattern` under `iter_mode`, in
+    /// lexicographical order.
+    ///
+    /// The values trie holds only tag presence, so callers resolve each reader by
+    /// tag string.
+    ///
+    /// `pattern` is borrowed for the iterator's lifetime by the prefix, contains,
+    /// and wildcard modes (the suffix mode copies it).
+    pub fn value_iter_filtered<'a>(
+        &'a self,
+        pattern: Tag<'a>,
+        iter_mode: IterMode,
+    ) -> DiskTagIndexIterator<'a> {
+        filtered_iter(&self.mode.values, pattern, iter_mode)
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/iter.rs
+++ b/src/redisearch_rs/tag_index/src/iter.rs
@@ -28,7 +28,10 @@ use index_result::RSIndexResult;
 use inverted_index::{IndexReader, IndexReaderCore, InvertedIndex, doc_ids_only::DocIdsOnly};
 use lending_iterator::LendingIterator as _;
 use rqe_wildcard::WildcardPattern;
-use trie_rs::iter::{ContainsLendingIter, LendingIter, WildcardLendingIter, filter::VisitAll};
+use trie_rs::{
+    TrieMap,
+    iter::{ContainsLendingIter, LendingIter, WildcardLendingIter, filter::VisitAll},
+};
 
 use crate::{InMemoryMode, OnDiskMode, SuffixData, Tag, TagIndex, TagIndexMode};
 
@@ -154,9 +157,7 @@ impl TagIndex<InMemoryMode> {
     /// Iterate over all `(tag, inverted index)` entries, in lexicographical order
     /// of the tag.
     pub fn value_iter(&self) -> MemTagIndexIterator<'_> {
-        TagIndexIterator {
-            iter: TagIndexIteratorImpl::All(self.mode.values.lending_iter()),
-        }
+        all_iter(&self.mode.values)
     }
 
     /// Iterate over the `(tag, inverted index)` entries whose tag matches
@@ -168,27 +169,7 @@ impl TagIndex<InMemoryMode> {
         pattern: Tag<'a>,
         iter_mode: IterMode,
     ) -> MemTagIndexIterator<'a> {
-        let bytes = pattern.as_bytes();
-        let iter = match iter_mode {
-            IterMode::Prefix => {
-                TagIndexIteratorImpl::All(self.mode.values.prefixed_lending_iter(bytes))
-            }
-            IterMode::Contains => {
-                TagIndexIteratorImpl::Contains(self.mode.values.contains_iter(bytes).into())
-            }
-            // The walk carries the pattern itself; `next_entry` does the matching.
-            IterMode::Suffix => {
-                TagIndexIteratorImpl::Suffix(self.mode.values.lending_iter(), pattern)
-            }
-            IterMode::Wildcard => TagIndexIteratorImpl::Wildcard(
-                self.mode
-                    .values
-                    .wildcard_iter(WildcardPattern::parse(bytes))
-                    .into(),
-            ),
-        };
-
-        TagIndexIterator { iter }
+        filtered_iter(&self.mode.values, pattern, iter_mode)
     }
 }
 
@@ -277,4 +258,35 @@ impl<'trie> TagValueReader<'trie> {
     pub fn next_record(&mut self, res: &mut RSIndexResult<'trie>) -> std::io::Result<bool> {
         self.reader.next_record(res)
     }
+}
+
+/// Iterate over all `(tag, value)` entries of a values trie, in lexicographical
+/// order of the tag.
+fn all_iter<Value>(values: &TrieMap<Value>) -> TagIndexIterator<'_, Value> {
+    TagIndexIterator {
+        iter: TagIndexIteratorImpl::All(values.lending_iter()),
+    }
+}
+
+/// Iterate over the `(tag, value)` entries of a values trie whose tag matches
+/// `pattern` under `iter_mode`, in lexicographical order of the tag.
+///
+/// `pattern` is borrowed for the iterator's lifetime.
+fn filtered_iter<'a, Value>(
+    values: &'a TrieMap<Value>,
+    pattern: Tag<'a>,
+    iter_mode: IterMode,
+) -> TagIndexIterator<'a, Value> {
+    let bytes = pattern.as_bytes();
+    let iter = match iter_mode {
+        IterMode::Prefix => TagIndexIteratorImpl::All(values.prefixed_lending_iter(bytes)),
+        IterMode::Contains => TagIndexIteratorImpl::Contains(values.contains_iter(bytes).into()),
+        // The walk carries the pattern itself; `next_entry` does the matching.
+        IterMode::Suffix => TagIndexIteratorImpl::Suffix(values.lending_iter(), pattern),
+        IterMode::Wildcard => TagIndexIteratorImpl::Wildcard(
+            values.wildcard_iter(WildcardPattern::parse(bytes)).into(),
+        ),
+    };
+
+    TagIndexIterator { iter }
 }

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -20,12 +20,24 @@
 //!   the values trie.
 //! - **Disk mode** keeps the postings on disk behind the
 //!   `RSE` API; the values trie holds only tag *presence* sentinels.
+//!   Writes stage onto a disk write batch ([`TagIndex::index`]), reads open a
+//!   disk iterator ([`TagIndex::open_reader`]), and query expansion still walks
+//!   the presence trie for matching keys before opening each reader by string.
 //!
 //! ## Tag bytes
 //!
 //! Tag values are [`Tag`], which carries exactly one guarantee: no
 //! *interior* (or trailing) NUL byte. [`Tag::new`] enforces it; [`Tag::new_unchecked`]
 //! trusts the caller instead.
+//!
+//! Disk-mode indexing ([`TagIndex::index`] on [`OnDiskMode`]) is the one
+//! exception, and takes `&CStr` instead:
+//! `SearchDisk_IndexTags` receives the tags as a `const char **` with a count
+//! and no per-string length array, so `strlen` is the only way its
+//! (closed-source) implementation can find where each tag ends. `&CStr` is
+//! exactly that guarantee — NUL-terminated, no interior NUL — so the disk write
+//! path states the requirement in its signature rather than as a precondition
+//! prose can only ask for.
 //!
 //! The terms yielded by [`TagIndex::suffix_expand`] are [`CStr`], borrowed from a
 //! NUL-terminated allocation whose pointer is directly usable as a C `char *`.
@@ -127,9 +139,6 @@
 //! ```
 //!
 
-// Temporary
-#![expect(dead_code, reason = "read by methods added in a follow-up change")]
-
 mod iter;
 mod suffix;
 mod unique_id;
@@ -149,12 +158,13 @@ extern crate redisearch_rs;
 #[cfg(test)]
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
-use std::ffi::CStr;
+use std::ffi::{CStr, c_char};
 use std::ptr::NonNull;
 use std::time::Instant;
 
 use ffi::{
-    IndexFlags_Index_DocIdsOnly, RedisSearchCtx, RedisSearchDiskIndexSpec, t_fieldIndex, timespec,
+    IndexFlags_Index_DocIdsOnly, RSToken, RedisSearchCtx, RedisSearchDiskIndexSpec,
+    SearchDiskWriteBatchHandle, t_fieldIndex, timespec,
 };
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
@@ -165,8 +175,9 @@ use inverted_index::{
     doc_ids_only::DocIdsOnly,
 };
 use query_term::RSQueryTerm;
+use redis_module::RedisModuleCtx;
 use rqe_iterators::{
-    FieldExpirationChecker,
+    FieldExpirationChecker, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS,
     inverted_index::{Tag as TagIterator, TagLookup},
     utils::duration_from_redis_timespec,
 };
@@ -174,7 +185,7 @@ use rqe_wildcard::{MatchOutcome, WildcardPattern};
 pub(crate) use suffix::{SuffixData, TagSuffixIndex};
 use trie_rs::{
     TrieMap,
-    iter::{LendingIter, filter::VisitAll},
+    iter::{LendingIter, RangeFilter, RangeLendingIter, filter::VisitAll},
 };
 pub use unique_id::TagUniqueId;
 
@@ -648,6 +659,157 @@ impl TagIndex<OnDiskMode> {
                 disk_index_spec: disk_spec,
             },
         )
+    }
+
+    /// How many distinct tags the index holds.
+    pub const fn n_tags(&self) -> usize {
+        self.mode.values.n_unique_keys()
+    }
+
+    /// Bytes the index's tries occupy, as reported by `FT.INFO`: the values trie
+    /// plus the suffix trie.
+    pub const fn mem_usage(&self) -> usize {
+        self.mode.values.mem_usage() + self.suffix_mem_usage()
+    }
+
+    /// Stage `doc_id`'s postings for each tag in `tags` onto `batch`, committed
+    /// later by `commitDocument`.
+    ///
+    /// Returns whether the disk write succeeded. There is no delta to fold into
+    /// the spec statistics: the record count is tallied in
+    /// [`commit`](Self::commit).
+    ///
+    /// Takes `&CStr` rather than [`Tag`] because the disk API is given the
+    /// tags as a `const char **` with no length array, so each one has to be a
+    /// real C string — see the crate-level "Tag bytes" docs.
+    ///
+    /// # Safety
+    ///
+    /// `ctx` and `batch` must be the valid disk write context and batch handle
+    /// for the ongoing document write.
+    pub unsafe fn index(
+        &mut self,
+        ctx: *mut RedisModuleCtx,
+        batch: *mut SearchDiskWriteBatchHandle,
+        tags: &[&CStr],
+        doc_id: DocId,
+    ) -> bool {
+        debug_assert!(!ctx.is_null(), "disk-mode indexing needs a write context");
+        debug_assert!(
+            !batch.is_null(),
+            "disk-mode indexing needs a disk write batch"
+        );
+
+        let OnDiskMode {
+            field_id,
+            disk_index_spec,
+            ..
+        } = &mut self.mode;
+
+        if tags.is_empty() {
+            return true;
+        }
+
+        let mut value_ptrs: Vec<*const c_char> = tags.iter().map(|tag| tag.as_ptr()).collect();
+        // SAFETY: `disk_index_spec` is a valid `RedisSearchDiskIndexSpec`
+        // (invariant from `new_on_disk`); the caller's contract covers
+        // `ctx`/`batch`; and every pointer in `value_ptrs` addresses a
+        // NUL-terminated string, borrowed for the duration of the call.
+        unsafe {
+            ffi::SearchDisk_IndexTags(
+                ctx,
+                disk_index_spec.as_ptr(),
+                batch,
+                value_ptrs.as_mut_ptr(),
+                value_ptrs.len(),
+                doc_id,
+                *field_id,
+            )
+        }
+    }
+
+    /// Apply the per-tag metadata updates after the indexing phase of a document
+    /// write: register the tags in the values trie, which is what makes them
+    /// visible to query expansion. The postings are staged onto the write
+    /// batch by [`index`](Self::index).
+    ///
+    /// Returns the number of records to fold into the spec statistics.
+    pub fn commit(&mut self, tags: &[Tag<'_>]) -> u32 {
+        for tag in tags {
+            self.mode.values.insert(tag.as_bytes(), ());
+        }
+        self.add_tags_to_suffix(tags);
+        tags.len() as u32
+    }
+
+    /// Iterate over the tags falling within `filter`'s boundaries, in
+    /// lexicographical order.
+    ///
+    /// The postings live on disk, so, the caller resolves each reader by tag string.
+    pub fn range_iter_values<'tm, 'f>(
+        &'tm self,
+        filter: RangeFilter<'f>,
+    ) -> RangeLendingIter<'tm, 'f, ()> {
+        self.mode.values.range_iter(filter).into()
+    }
+
+    /// Create an iterator over the documents matching `tag`, built through the disk
+    /// API and keyed by the tag string.
+    ///
+    /// It filters on the caller's `field_index` rather than the field recorded at
+    /// write time. Unlike the memory-mode counterpart there is no absent-tag case to
+    /// report: the disk backend owns the lookup, and builds an iterator that simply
+    /// reads nothing.
+    ///
+    /// Returns `Err` when the disk backend fails to build its iterator.
+    ///
+    /// # Panics
+    ///
+    /// If [`SEARCH_ENTERPRISE_ITERATORS`] is not initialized.
+    ///
+    /// # Safety
+    ///
+    /// 1. `self` must outlive the returned iterator.
+    /// 2. `sctx` and `sctx.spec` must be valid and outlive the returned iterator.
+    /// 3. `sctx.diskSnapshot` must be a non-null
+    ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for this
+    ///    index's disk spec, valid for the duration of the call:
+    ///    [SearchEnterpriseIterators::new_tag_on_disk](rqe_iterators::SearchEnterpriseIterators::new_tag_on_disk)
+    ///    reads it off `sctx` and hands it to the disk backend.
+    pub unsafe fn open_reader(
+        &self,
+        sctx: NonNull<RedisSearchCtx>,
+        tag: Tag<'_>,
+        weight: f64,
+        field_index: t_fieldIndex,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'_> + '_>, Box<dyn std::error::Error>> {
+        // SAFETY: `sctx` is valid (contract 2).
+        let disk_snapshot = unsafe { sctx.as_ref() }.diskSnapshot;
+        debug_assert!(
+            !disk_snapshot.is_null(),
+            "disk-mode reads need a snapshot on the search context"
+        );
+        // SAFETY: contract 3 guarantees `sctx.diskSnapshot` is non-null, checked
+        // above in debug builds.
+        let snapshot = unsafe { NonNull::new_unchecked(disk_snapshot) };
+
+        // Postings live on disk: build the reader through the disk API, keyed by the
+        // tag string.
+        //
+        // SAFETY: `RSToken` is a plain-old-data `#[repr(C)]` struct whose all-zero
+        // bit pattern is a valid, unexpanded token; only `str`/`len` are then set.
+        let mut tok: RSToken = unsafe { std::mem::zeroed() };
+        tok.str_ = tag.as_ptr().cast::<c_char>().cast_mut();
+        tok.len = tag.as_bytes().len();
+
+        let enterprise_iters = SEARCH_ENTERPRISE_ITERATORS
+            .get()
+            .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
+        // SAFETY: `disk_index_spec` is a valid `RedisSearchDiskIndexSpec` (invariant
+        // from `new_on_disk`); `tok` borrows `tag` for the duration of the call; and
+        // `snapshot` is the snapshot contract 3 requires.
+        let disk_index_spec = unsafe { &mut *self.mode.disk_index_spec.as_ptr() };
+        enterprise_iters.new_tag_on_disk(disk_index_spec, &tok, field_index, weight, snapshot)
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -31,13 +31,8 @@
 //! trusts the caller instead.
 //!
 //! Disk-mode indexing ([`TagIndex::index`] on [`OnDiskMode`]) is the one
-//! exception, and takes `&CStr` instead:
-//! `SearchDisk_IndexTags` receives the tags as a `const char **` with a count
-//! and no per-string length array, so `strlen` is the only way its
-//! (closed-source) implementation can find where each tag ends. `&CStr` is
-//! exactly that guarantee — NUL-terminated, no interior NUL — so the disk write
-//! path states the requirement in its signature rather than as a precondition
-//! prose can only ask for.
+//! exception, and takes `&CStr` instead. In fact,
+//! `SearchDisk_IndexTags` receives the tags as a `const char **` with a count.
 //!
 //! The terms yielded by [`TagIndex::suffix_expand`] are [`CStr`], borrowed from a
 //! NUL-terminated allocation whose pointer is directly usable as a C `char *`.
@@ -177,11 +172,12 @@ use inverted_index::{
 use query_term::RSQueryTerm;
 use redis_module::RedisModuleCtx;
 use rqe_iterators::{
-    FieldExpirationChecker, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS,
+    FieldExpirationChecker, RQEIteratorPrintable,
     inverted_index::{Tag as TagIterator, TagLookup},
     utils::duration_from_redis_timespec,
 };
 use rqe_wildcard::{MatchOutcome, WildcardPattern};
+use search_disk::SearchDiskHandle;
 pub(crate) use suffix::{SuffixData, TagSuffixIndex};
 use trie_rs::{
     TrieMap,
@@ -289,7 +285,7 @@ pub struct WritePostingsDelta {
 
 impl<M: TagIndexMode> TagIndex<M> {
     /// The part of construction every mode's constructor shares.
-    fn with_mode(with_suffix: bool, field_id: t_fieldIndex, mode: M) -> Self {
+    fn with_mode(field_id: t_fieldIndex, with_suffix: bool, mode: M) -> Self {
         Self {
             unique_id: TagUniqueId::next(),
             suffix: with_suffix.then(TagSuffixIndex::new),
@@ -401,10 +397,10 @@ impl TagIndex<InMemoryMode> {
     /// `with_suffix` enables the [suffix index](TagSuffixIndex)
     /// (`WITHSUFFIXTRIE`), so suffix (`*foo`) and contains (`*foo*`)
     /// queries don't have to scan the whole tag trie.
-    pub fn new(with_suffix: bool, field_id: t_fieldIndex) -> Self {
+    pub fn new(field_id: t_fieldIndex, with_suffix: bool) -> Self {
         Self::with_mode(
-            with_suffix,
             field_id,
+            with_suffix,
             InMemoryMode {
                 values: TrieMap::new(),
             },
@@ -654,8 +650,8 @@ impl TagIndex<OnDiskMode> {
         with_suffix: bool,
     ) -> Self {
         Self::with_mode(
-            with_suffix,
             field_id,
+            with_suffix,
             OnDiskMode {
                 values: TrieMap::new(),
                 disk_index_spec: disk_spec,
@@ -674,16 +670,17 @@ impl TagIndex<OnDiskMode> {
         self.mode.values.mem_usage() + self.suffix_mem_usage()
     }
 
-    /// Stage `doc_id`'s postings for each tag in `tags` onto `batch`, committed
-    /// later by `commitDocument`.
+    /// Stage `doc_id`'s postings for each tag in `tags` onto `batch`.
+    /// The caller must follow up with
+    /// [`commit`](Self::commit) on the same `tags` to complete the document
+    /// write (it registers them in the suffix index, when enabled).
     ///
     /// Returns whether the disk write succeeded. There is no delta to fold into
     /// the spec statistics: the record count is tallied in
     /// [`commit`](Self::commit).
     ///
     /// Takes `&CStr` rather than [`Tag`] because the disk API is given the
-    /// tags as a `const char **` with no length array, so each one has to be a
-    /// real C string — see the crate-level "Tag bytes" docs.
+    /// tags as a `const char **` with no length array,
     ///
     /// # Safety
     ///
@@ -760,7 +757,8 @@ impl TagIndex<OnDiskMode> {
     ///
     /// # Panics
     ///
-    /// If [`SEARCH_ENTERPRISE_ITERATORS`] is not initialized.
+    /// If [`SEARCH_ENTERPRISE_ITERATORS`](rqe_iterators::SEARCH_ENTERPRISE_ITERATORS)
+    /// is not initialized.
     ///
     /// # Safety
     ///
@@ -768,9 +766,13 @@ impl TagIndex<OnDiskMode> {
     /// 2. `sctx` and `sctx.spec` must be valid and outlive the returned iterator.
     /// 3. `sctx.diskSnapshot` must be a non-null
     ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for this
-    ///    index's disk spec, valid for the duration of the call:
-    ///    [SearchEnterpriseIterators::new_tag_on_disk](rqe_iterators::SearchEnterpriseIterators::new_tag_on_disk)
-    ///    reads it off `sctx` and hands it to the disk backend.
+    ///    index's disk spec, and must stay valid for as long as the returned
+    ///    iterator. See
+    ///    [`SearchEnterpriseIterators`](rqe_iterators::SearchEnterpriseIterators).
+    /// 4. No other reference to this index's disk spec may be live while the
+    ///    returned iterator is. Building it hands the backend an exclusive
+    ///    reference to the spec, so this is
+    ///    [`SearchDiskHandle::new_tag_iterator`]'s precondition, carried through.
     pub unsafe fn open_reader(
         &self,
         sctx: NonNull<RedisSearchCtx>,
@@ -796,14 +798,18 @@ impl TagIndex<OnDiskMode> {
         tok.str_ = tag.as_ptr().cast::<c_char>().cast_mut();
         tok.len = tag.as_bytes().len();
 
-        let enterprise_iters = SEARCH_ENTERPRISE_ITERATORS
-            .get()
-            .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
-        // SAFETY: `disk_index_spec` is a valid `RedisSearchDiskIndexSpec` (invariant
-        // from `new_on_disk`); `tok` borrows `tag` for the duration of the call; and
-        // `snapshot` is the snapshot contract 3 requires.
-        let disk_index_spec = unsafe { &mut *self.mode.disk_index_spec.as_ptr() };
-        enterprise_iters.new_tag_on_disk(disk_index_spec, &tok, self.field_id, weight, snapshot)
+        // SAFETY: `disk_index_spec` is a valid `RedisSearchDiskIndexSpec` that
+        // outlives `self` (invariant from `Self::new`), hence the returned
+        // iterator (contract 1).
+        let disk = unsafe { SearchDiskHandle::new(self.mode.disk_index_spec.as_ptr()) }
+            .expect("`Self::new` takes the disk spec as a `NonNull`");
+
+        // SAFETY: the handle's four preconditions, in order: the spec outlives the
+        // iterator, as above; a disk-backed index always has the enterprise
+        // iterators registered; `snapshot` is the one contract 3 requires; and
+        // contract 4 rules out any other live reference to the spec. `tok` borrows
+        // `tag` for the duration of the call.
+        unsafe { disk.new_tag_iterator(&tok, self.field_id, weight, snapshot) }
     }
 }
 
@@ -871,7 +877,7 @@ mod tests {
     #[test]
     fn revalidate_aborts_after_tag_removed() {
         let mock = MockContext::new(3, 3);
-        let mut idx = TagIndex::<InMemoryMode>::new(false, 0);
+        let mut idx = TagIndex::<InMemoryMode>::new(0, false);
         let tags = &[Tag::new(b"team").unwrap()];
         for doc_id in 1..=3 {
             // `doc_id` is non-decreasing across loop iterations, as `index` requires.
@@ -1116,7 +1122,7 @@ mod choose_token_tests {
 
     /// Build an in-memory index with a suffix trie and commit `tags`.
     fn indexed(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-        let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
+        let mut idx = TagIndex::<InMemoryMode>::new(0, true);
         let tags: Vec<Tag<'_>> = tags
             .iter()
             .map(|t| Tag::new(t).expect("test literal is NUL-free"))
@@ -1351,11 +1357,11 @@ mod mem_usage_tests {
 
         // Both indexes are indexed *and* committed, so the values trie is non-empty on
         // each side: were it missing from one of the two sums, the delta would not match.
-        let mut with_suffix = TagIndex::<InMemoryMode>::new(true, 0);
+        let mut with_suffix = TagIndex::<InMemoryMode>::new(0, true);
         with_suffix.index(&tags, 1, false);
         with_suffix.commit(&tags);
 
-        let mut without_suffix = TagIndex::<InMemoryMode>::new(false, 0);
+        let mut without_suffix = TagIndex::<InMemoryMode>::new(0, false);
         without_suffix.index(&tags, 1, false);
         without_suffix.commit(&tags);
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -756,11 +756,6 @@ impl TagIndex<OnDiskMode> {
     /// Create an iterator over the documents matching `tag`, built through the disk
     /// API and keyed by the tag string.
     ///
-    /// It filters on the caller's `field_index` rather than the field recorded at
-    /// write time. Unlike the memory-mode counterpart there is no absent-tag case to
-    /// report: the disk backend owns the lookup, and builds an iterator that simply
-    /// reads nothing.
-    ///
     /// Returns `Err` when the disk backend fails to build its iterator.
     ///
     /// # Panics
@@ -781,7 +776,6 @@ impl TagIndex<OnDiskMode> {
         sctx: NonNull<RedisSearchCtx>,
         tag: Tag<'_>,
         weight: f64,
-        field_index: t_fieldIndex,
     ) -> Result<Box<dyn RQEIteratorPrintable<'_> + '_>, Box<dyn std::error::Error>> {
         // SAFETY: `sctx` is valid (contract 2).
         let disk_snapshot = unsafe { sctx.as_ref() }.diskSnapshot;
@@ -809,7 +803,13 @@ impl TagIndex<OnDiskMode> {
         // from `new_on_disk`); `tok` borrows `tag` for the duration of the call; and
         // `snapshot` is the snapshot contract 3 requires.
         let disk_index_spec = unsafe { &mut *self.mode.disk_index_spec.as_ptr() };
-        enterprise_iters.new_tag_on_disk(disk_index_spec, &tok, field_index, weight, snapshot)
+        enterprise_iters.new_tag_on_disk(
+            disk_index_spec,
+            &tok,
+            self.mode.field_id,
+            weight,
+            snapshot,
+        )
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -250,8 +250,6 @@ impl TagIndexMode for InMemoryMode {}
 pub struct OnDiskMode {
     /// tag value -> (). It is used only to know whether a tag is there
     values: TrieMap<()>,
-    /// Field id
-    field_id: t_fieldIndex,
     /// Disk Index spec, valid for as long as this index lives.
     disk_index_spec: NonNull<RedisSearchDiskIndexSpec>,
 }
@@ -266,6 +264,9 @@ pub struct TagIndex<M: TagIndexMode> {
 
     /// Suffix index, present only for fields created `WITHSUFFIXTRIE`.
     suffix: Option<TagSuffixIndex>,
+
+    /// Field id
+    field_id: t_fieldIndex,
 
     /// The storage mode, owning the values trie and whatever else that mode
     /// needs — the postings themselves in [`InMemoryMode`], the disk handles in
@@ -288,10 +289,11 @@ pub struct WritePostingsDelta {
 
 impl<M: TagIndexMode> TagIndex<M> {
     /// The part of construction every mode's constructor shares.
-    fn with_mode(with_suffix: bool, mode: M) -> Self {
+    fn with_mode(with_suffix: bool, field_id: t_fieldIndex, mode: M) -> Self {
         Self {
             unique_id: TagUniqueId::next(),
             suffix: with_suffix.then(TagSuffixIndex::new),
+            field_id,
             mode,
         }
     }
@@ -399,9 +401,10 @@ impl TagIndex<InMemoryMode> {
     /// `with_suffix` enables the [suffix index](TagSuffixIndex)
     /// (`WITHSUFFIXTRIE`), so suffix (`*foo`) and contains (`*foo*`)
     /// queries don't have to scan the whole tag trie.
-    pub fn new(with_suffix: bool) -> Self {
+    pub fn new(with_suffix: bool, field_id: t_fieldIndex) -> Self {
         Self::with_mode(
             with_suffix,
+            field_id,
             InMemoryMode {
                 values: TrieMap::new(),
             },
@@ -510,7 +513,6 @@ impl TagIndex<InMemoryMode> {
         sctx: NonNull<RedisSearchCtx>,
         tag: Tag<'_>,
         weight: f64,
-        field_index: t_fieldIndex,
         lookup: TrieLookup,
     ) -> Option<TagIterator<'_, DocIdsOnly, TrieLookup, FieldExpirationChecker>> {
         let ii = self.mode.values.find(tag.as_bytes())?;
@@ -521,7 +523,7 @@ impl TagIndex<InMemoryMode> {
         let term = RSQueryTerm::new_bytes(tag.as_bytes(), 0, 0);
 
         let filter_ctx = FieldFilterContext {
-            field: FieldMaskOrIndex::Index(field_index),
+            field: FieldMaskOrIndex::Index(self.field_id),
             predicate: FieldExpirationPredicate::Default,
         };
         let reader = ii.reader();
@@ -653,9 +655,9 @@ impl TagIndex<OnDiskMode> {
     ) -> Self {
         Self::with_mode(
             with_suffix,
+            field_id,
             OnDiskMode {
                 values: TrieMap::new(),
-                field_id,
                 disk_index_spec: disk_spec,
             },
         )
@@ -701,9 +703,7 @@ impl TagIndex<OnDiskMode> {
         );
 
         let OnDiskMode {
-            field_id,
-            disk_index_spec,
-            ..
+            disk_index_spec, ..
         } = &mut self.mode;
 
         if tags.is_empty() {
@@ -723,7 +723,7 @@ impl TagIndex<OnDiskMode> {
                 value_ptrs.as_mut_ptr(),
                 value_ptrs.len(),
                 doc_id,
-                *field_id,
+                self.field_id,
             )
         }
     }
@@ -803,13 +803,7 @@ impl TagIndex<OnDiskMode> {
         // from `new_on_disk`); `tok` borrows `tag` for the duration of the call; and
         // `snapshot` is the snapshot contract 3 requires.
         let disk_index_spec = unsafe { &mut *self.mode.disk_index_spec.as_ptr() };
-        enterprise_iters.new_tag_on_disk(
-            disk_index_spec,
-            &tok,
-            self.mode.field_id,
-            weight,
-            snapshot,
-        )
+        enterprise_iters.new_tag_on_disk(disk_index_spec, &tok, self.field_id, weight, snapshot)
     }
 }
 
@@ -877,7 +871,7 @@ mod tests {
     #[test]
     fn revalidate_aborts_after_tag_removed() {
         let mock = MockContext::new(3, 3);
-        let mut idx = TagIndex::<InMemoryMode>::new(false);
+        let mut idx = TagIndex::<InMemoryMode>::new(false, 0);
         let tags = &[Tag::new(b"team").unwrap()];
         for doc_id in 1..=3 {
             // `doc_id` is non-decreasing across loop iterations, as `index` requires.
@@ -1122,7 +1116,7 @@ mod choose_token_tests {
 
     /// Build an in-memory index with a suffix trie and commit `tags`.
     fn indexed(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-        let mut idx = TagIndex::<InMemoryMode>::new(true);
+        let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
         let tags: Vec<Tag<'_>> = tags
             .iter()
             .map(|t| Tag::new(t).expect("test literal is NUL-free"))
@@ -1357,11 +1351,11 @@ mod mem_usage_tests {
 
         // Both indexes are indexed *and* committed, so the values trie is non-empty on
         // each side: were it missing from one of the two sums, the delta would not match.
-        let mut with_suffix = TagIndex::<InMemoryMode>::new(true);
+        let mut with_suffix = TagIndex::<InMemoryMode>::new(true, 0);
         with_suffix.index(&tags, 1, false);
         with_suffix.commit(&tags);
 
-        let mut without_suffix = TagIndex::<InMemoryMode>::new(false);
+        let mut without_suffix = TagIndex::<InMemoryMode>::new(false, 0);
         without_suffix.index(&tags, 1, false);
         without_suffix.commit(&tags);
 

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -65,6 +65,19 @@ fn tag_term_layout(size: usize) -> Layout {
         .expect("a tag term is one byte longer than a tag, far below Layout's size limit")
 }
 
+/// Return the length of the holding string.
+/// 
+/// # Safety
+/// `ptr` has to be NUL-terminated.
+const unsafe fn get_length(ptr: *const u8) -> usize {
+    // This cast doesn't change size, we care about only the NULL
+    let ptr = ptr.cast::<std::ffi::c_char>();
+    // SAFETY: `ptr` is null terminated
+    unsafe { std::ffi::CStr::from_ptr(ptr) }
+        .to_bytes_with_nul()
+        .len()
+}
+
 /// Owning handle to a tag term allocation.
 ///
 /// Dropping it frees the allocation.
@@ -102,12 +115,8 @@ impl OwnedTerm {
 
     /// Full allocation size in bytes (term bytes + the trailing NUL).
     const fn alloc_size(&self) -> usize {
-        // This cast doesn't change size, we care about only the NULL
-        let ptr = self.0.as_ptr().cast::<std::ffi::c_char>().cast_const();
         // SAFETY: [`OwnedTerm::new`] NUL-terminates every allocation.
-        unsafe { std::ffi::CStr::from_ptr(ptr) }
-            .to_bytes_with_nul()
-            .len()
+        unsafe { get_length(self.0.as_ptr()) }
     }
 
     /// Build [`TermPtr`] from the current [`OwnedTerm`]
@@ -137,22 +146,18 @@ impl TermPtr {
         self.0 == owned.0
     }
 
+    pub const fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
     /// Full allocation size in bytes (term bytes + the trailing NUL).
     ///
     /// # Safety
     /// The [`OwnedTerm`] this pointer was taken from must still be alive.
+    #[cfg(test)]
     pub const unsafe fn alloc_size(&self) -> usize {
-        // This cast doesn't change size, we care about only the NULL
-        let ptr = self.0.as_ptr().cast::<std::ffi::c_char>().cast_const();
-        // SAFETY: the pointee is a live allocation from [`OwnedTerm::new`], which
-        // NUL-terminates it.
-        unsafe { std::ffi::CStr::from_ptr(ptr) }
-            .to_bytes_with_nul()
-            .len()
-    }
-
-    pub const fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
+        // SAFETY: The still-alive [`OwnedTerm::new`] is NUL-terminated.
+        unsafe { get_length(self.0.as_ptr()) }
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -65,14 +65,24 @@ fn tag_term_layout(size: usize) -> Layout {
         .expect("a tag term is one byte longer than a tag, far below Layout's size limit")
 }
 
-/// Return the length of the holding string.
+/// Return the length of the holding string, terminator included.
 ///
 /// # Safety
-/// `ptr` has to be NUL-terminated.
+///
+/// `ptr` must meet [`CStr::from_ptr`]'s whole contract, not just the
+/// NUL terminator part of it:
+///
+/// 1. `ptr` is non-null;
+/// 2. every byte from `ptr` up to and including the terminator is initialized,
+///    readable, and belongs to one single live allocation;
+/// 3. that allocation is not mutated for the duration of the call;
+/// 4. the distance from `ptr` to the terminator is at most [`isize::MAX`].
+///
+/// [`CStr::from_ptr`]: std::ffi::CStr::from_ptr
 const unsafe fn get_length(ptr: *const u8) -> usize {
     // This cast doesn't change size, we care about only the NULL
     let ptr = ptr.cast::<std::ffi::c_char>();
-    // SAFETY: `ptr` is null terminated
+    // SAFETY: the caller's contract is `CStr::from_ptr`'s, verbatim.
     unsafe { std::ffi::CStr::from_ptr(ptr) }
         .to_bytes_with_nul()
         .len()
@@ -115,7 +125,10 @@ impl OwnedTerm {
 
     /// Full allocation size in bytes (term bytes + the trailing NUL).
     const fn alloc_size(&self) -> usize {
-        // SAFETY: [`OwnedTerm::new`] NUL-terminates every allocation.
+        // SAFETY: `Self::new` allocated `self.0` as one block of `term.len() + 1`
+        // initialized bytes whose last one is the NUL it wrote, `&self` keeps that
+        // block alive and unmutated for the call, and its size came from a `Layout`,
+        // so it is at most `isize::MAX`.
         unsafe { get_length(self.0.as_ptr()) }
     }
 
@@ -156,7 +169,9 @@ impl TermPtr {
     /// The [`OwnedTerm`] this pointer was taken from must still be alive.
     #[cfg(test)]
     pub const unsafe fn alloc_size(&self) -> usize {
-        // SAFETY: The still-alive [`OwnedTerm::new`] is NUL-terminated.
+        // SAFETY: `self.0` is the pointer of the `OwnedTerm` this was taken from,
+        // which the caller's contract keeps alive; it therefore satisfies
+        // `get_length` for the same reasons `OwnedTerm::alloc_size` does.
         unsafe { get_length(self.0.as_ptr()) }
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -66,7 +66,7 @@ fn tag_term_layout(size: usize) -> Layout {
 }
 
 /// Return the length of the holding string.
-/// 
+///
 /// # Safety
 /// `ptr` has to be NUL-terminated.
 const unsafe fn get_length(ptr: *const u8) -> usize {

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -22,8 +22,8 @@ use crate::util::{commit_mem, index_mem};
 /// the one its child scanned.
 #[test]
 fn each_index_gets_its_own_id() {
-    let first = TagIndex::<InMemoryMode>::new(false);
-    let second = TagIndex::<InMemoryMode>::new(false);
+    let first = TagIndex::<InMemoryMode>::new(false, 0);
+    let second = TagIndex::<InMemoryMode>::new(false, 0);
 
     assert_ne!(first.id(), second.id());
 }
@@ -32,7 +32,7 @@ fn each_index_gets_its_own_id() {
 /// on-disk one can't collide either.
 #[test]
 fn ids_are_unique_across_storage_modes() {
-    let in_memory = TagIndex::<InMemoryMode>::new(false);
+    let in_memory = TagIndex::<InMemoryMode>::new(false, 0);
     // SAFETY: this test only drives paths that never dereference the spec, so a
     // dangling pointer satisfies `new_on_disk` here (see the `disk` module docs).
     let on_disk = unsafe { TagIndex::<OnDiskMode>::new(NonNull::dangling(), 0, false) };
@@ -43,23 +43,23 @@ fn ids_are_unique_across_storage_modes() {
 /// `with_suffix` toggles suffix support.
 #[test]
 fn suffix_support_follows_the_creation_flag() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     assert!(!tag_index.has_suffix());
 
-    let tag_index = TagIndex::<InMemoryMode>::new(true);
+    let tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     assert!(tag_index.has_suffix());
 }
 
 #[test]
 fn new_in_memory_means_memory_mode() {
     // Type checked
-    let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(false);
+    let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(false, 0);
 }
 
 /// A newly created index holds no tags: lookups miss.
 #[test]
 fn new_index_holds_no_tags() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
 
     assert!(tag_index.find_value(b"missing").is_none());
     assert!(
@@ -78,9 +78,9 @@ fn mem_usage_accounts_for_the_suffix_trie() {
 
     // A fresh index already reports its tries' stack footprint, so growth has to be
     // measured against that baseline rather than against zero.
-    let empty = TagIndex::<InMemoryMode>::new(true).mem_usage();
+    let empty = TagIndex::<InMemoryMode>::new(true, 0).mem_usage();
 
-    let mut with_suffix = TagIndex::<InMemoryMode>::new(true);
+    let mut with_suffix = TagIndex::<InMemoryMode>::new(true, 0);
     index_mem(&mut with_suffix, tags, 1);
     commit_mem(&mut with_suffix, tags);
     assert!(
@@ -88,7 +88,7 @@ fn mem_usage_accounts_for_the_suffix_trie() {
         "populating the tries must grow the reported overhead"
     );
 
-    let mut without_suffix = TagIndex::<InMemoryMode>::new(false);
+    let mut without_suffix = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut without_suffix, tags, 1);
     commit_mem(&mut without_suffix, tags);
 

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -22,8 +22,8 @@ use crate::util::{commit_mem, index_mem};
 /// the one its child scanned.
 #[test]
 fn each_index_gets_its_own_id() {
-    let first = TagIndex::<InMemoryMode>::new(false, 0);
-    let second = TagIndex::<InMemoryMode>::new(false, 0);
+    let first = TagIndex::<InMemoryMode>::new(0, false);
+    let second = TagIndex::<InMemoryMode>::new(0, false);
 
     assert_ne!(first.id(), second.id());
 }
@@ -32,7 +32,7 @@ fn each_index_gets_its_own_id() {
 /// on-disk one can't collide either.
 #[test]
 fn ids_are_unique_across_storage_modes() {
-    let in_memory = TagIndex::<InMemoryMode>::new(false, 0);
+    let in_memory = TagIndex::<InMemoryMode>::new(0, false);
     // SAFETY: this test only drives paths that never dereference the spec, so a
     // dangling pointer satisfies `new_on_disk` here (see the `disk` module docs).
     let on_disk = unsafe { TagIndex::<OnDiskMode>::new(NonNull::dangling(), 0, false) };
@@ -43,23 +43,23 @@ fn ids_are_unique_across_storage_modes() {
 /// `with_suffix` toggles suffix support.
 #[test]
 fn suffix_support_follows_the_creation_flag() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let tag_index = TagIndex::<InMemoryMode>::new(0, false);
     assert!(!tag_index.has_suffix());
 
-    let tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let tag_index = TagIndex::<InMemoryMode>::new(0, true);
     assert!(tag_index.has_suffix());
 }
 
 #[test]
 fn new_in_memory_means_memory_mode() {
     // Type checked
-    let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(false, 0);
+    let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(0, false);
 }
 
 /// A newly created index holds no tags: lookups miss.
 #[test]
 fn new_index_holds_no_tags() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let tag_index = TagIndex::<InMemoryMode>::new(0, false);
 
     assert!(tag_index.find_value(b"missing").is_none());
     assert!(
@@ -78,9 +78,9 @@ fn mem_usage_accounts_for_the_suffix_trie() {
 
     // A fresh index already reports its tries' stack footprint, so growth has to be
     // measured against that baseline rather than against zero.
-    let empty = TagIndex::<InMemoryMode>::new(true, 0).mem_usage();
+    let empty = TagIndex::<InMemoryMode>::new(0, true).mem_usage();
 
-    let mut with_suffix = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut with_suffix = TagIndex::<InMemoryMode>::new(0, true);
     index_mem(&mut with_suffix, tags, 1);
     commit_mem(&mut with_suffix, tags);
     assert!(
@@ -88,7 +88,7 @@ fn mem_usage_accounts_for_the_suffix_trie() {
         "populating the tries must grow the reported overhead"
     );
 
-    let mut without_suffix = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut without_suffix = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut without_suffix, tags, 1);
     commit_mem(&mut without_suffix, tags);
 

--- a/src/redisearch_rs/tag_index/tests/integration/disk.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/disk.rs
@@ -98,7 +98,7 @@ fn commit_indexes_the_empty_tag() {
 /// In memory mode `commit` reports no records — they are counted at index time.
 #[test]
 fn memory_commit_reports_no_records() {
-    let mut idx = TagIndex::<InMemoryMode>::new(false);
+    let mut idx = TagIndex::<InMemoryMode>::new(false, 0);
     assert_eq!(commit_mem(&mut idx, &[b"foo", b"bar"]), 0);
 }
 

--- a/src/redisearch_rs/tag_index/tests/integration/disk.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/disk.rs
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for disk (bigredis/Flex) mode.
+//!
+//! Disk mode keeps the postings on disk behind the `SearchDisk_*` API; the
+//! values trie holds only tag *presence* sentinels. These tests exercise every
+//! disk path that does **not** dereference the disk index spec — `commit`
+//! (presence + record accounting), the value-trie iterators used by query
+//! expansion and `FT.TAGVALS`, `mem_usage`, and mode detection. The paths
+//! that call into `SearchDisk_*` (`index_on_disk`, `open_reader`) need a real disk
+//! backend and are covered end-to-end elsewhere, so here the spec pointer is a
+//! dangling-but-non-null placeholder that is never read.
+
+use std::ptr::NonNull;
+
+use lending_iterator::LendingIterator;
+use tag_index::{DiskTagIndexIterator, InMemoryMode, IterMode, OnDiskMode, TagIndex};
+use trie_rs::iter::{RangeBoundary, RangeFilter};
+
+use crate::util::{as_tag, commit_disk, commit_mem};
+
+/// Collect the keys yielded by a lending iterator over `(key, value)` pairs.
+macro_rules! collect_keys {
+    ($iter:expr) => {{
+        let mut iter = $iter;
+        let mut keys: Vec<Vec<u8>> = Vec::new();
+        while let Some((key, _)) = iter.next() {
+            keys.push(key.to_vec());
+        }
+        keys
+    }};
+}
+
+/// Drain a [`DiskTagIndexIterator`] into its yielded keys, in iteration order.
+fn value_iter_keys(mut it: DiskTagIndexIterator<'_>) -> Vec<Vec<u8>> {
+    let mut keys: Vec<Vec<u8>> = Vec::new();
+    while let Some(key) = it.advance() {
+        keys.push(key.as_bytes().to_vec());
+    }
+    keys
+}
+
+/// Build a disk-mode index over a dangling spec pointer, the single place these
+/// tests discharge [`TagIndex<OnDiskMode>::new`]'s contract.
+fn fake_disk_index(with_suffix: bool) -> TagIndex<OnDiskMode> {
+    // SAFETY: these tests drive only the paths that never dereference the spec
+    // (see the module docs), so a dangling but well-aligned pointer is enough.
+    unsafe { TagIndex::<OnDiskMode>::new(NonNull::dangling(), 0, with_suffix) }
+}
+
+/// Build a disk-mode index and register `tags` through `commit` (the phase-3
+/// path).
+fn disk_index_with_tags(tags: &[&[u8]], with_suffix: bool) -> TagIndex<OnDiskMode> {
+    let mut idx = fake_disk_index(with_suffix);
+    commit_disk(&mut idx, tags);
+    idx
+}
+
+/// `commit` counts every committed tag value (disk postings are written during
+/// this phase) and registers each tag's presence in the values trie, keyed
+/// NUL-free like the tags queries look up.
+#[test]
+fn commit_counts_records_and_registers_presence() {
+    let mut idx = fake_disk_index(false);
+
+    let n = commit_disk(&mut idx, &[b"foo", b"bar", b"foo"]);
+    assert_eq!(n, 3, "disk commit counts every committed tag value");
+
+    // The duplicate `foo` collapses to a single trie entry.
+    assert_eq!(idx.n_tags(), 2);
+
+    let mut values = value_iter_keys(idx.value_iter());
+    values.sort();
+    assert_eq!(
+        values,
+        vec![b"bar".to_vec(), b"foo".to_vec()],
+        "values trie is keyed by the NUL-free tag bytes"
+    );
+}
+
+/// The empty tag (INDEXEMPTY) commits to an empty key.
+#[test]
+fn commit_indexes_the_empty_tag() {
+    let mut idx = fake_disk_index(false);
+    let n = commit_disk(&mut idx, &[b""]);
+    assert_eq!(n, 1);
+    let values = value_iter_keys(idx.value_iter());
+    assert_eq!(values, vec![Vec::<u8>::new()]);
+}
+
+/// In memory mode `commit` reports no records — they are counted at index time.
+#[test]
+fn memory_commit_reports_no_records() {
+    let mut idx = TagIndex::<InMemoryMode>::new(false);
+    assert_eq!(commit_mem(&mut idx, &[b"foo", b"bar"]), 0);
+}
+
+/// Disk-mode prefix iteration yields only the matching tag keys.
+#[test]
+fn disk_prefix_iteration_yields_matching_keys() {
+    let idx = disk_index_with_tags(&[b"bar", b"foo", b"foobar", b"foz"], false);
+    let keys = value_iter_keys(idx.value_iter_filtered(as_tag(b"foo"), IterMode::Prefix));
+    assert_eq!(keys, [b"foo".to_vec(), b"foobar".to_vec()]);
+}
+
+/// Disk-mode contains (infix) iteration yields only the matching tag keys.
+#[test]
+fn disk_contains_iteration_yields_matching_keys() {
+    let idx = disk_index_with_tags(&[b"bar", b"foo", b"oof", b"xooy"], false);
+    let keys = value_iter_keys(idx.value_iter_filtered(as_tag(b"oo"), IterMode::Contains));
+    assert_eq!(keys, [b"foo".to_vec(), b"oof".to_vec(), b"xooy".to_vec()]);
+}
+
+/// Disk-mode suffix iteration yields only the tag keys ending with the pattern.
+#[test]
+fn disk_suffix_iteration_yields_matching_keys() {
+    let idx = disk_index_with_tags(&[b"bar", b"foo", b"oof", b"xoo"], false);
+    let keys = value_iter_keys(idx.value_iter_filtered(as_tag(b"oo"), IterMode::Suffix));
+    assert_eq!(keys, [b"foo".to_vec(), b"xoo".to_vec()]);
+}
+
+/// Disk-mode wildcard iteration supports the `*` and `?` metacharacters.
+#[test]
+fn disk_wildcard_iteration_matches_metacharacters() {
+    let idx = disk_index_with_tags(&[b"bar", b"gao", b"go", b"goo", b"gooo"], false);
+
+    let keys = value_iter_keys(idx.value_iter_filtered(as_tag(b"g?o"), IterMode::Wildcard));
+    assert_eq!(keys, [b"gao".to_vec(), b"goo".to_vec()]);
+
+    let keys = value_iter_keys(idx.value_iter_filtered(as_tag(b"g*o"), IterMode::Wildcard));
+    assert_eq!(
+        keys,
+        [
+            b"gao".to_vec(),
+            b"go".to_vec(),
+            b"goo".to_vec(),
+            b"gooo".to_vec()
+        ],
+        "`g*o` also matches `go`, where the `*` expands to nothing"
+    );
+}
+
+/// Disk-mode lexical range iteration yields the keys within the boundaries.
+#[test]
+fn disk_range_iteration_yields_keys_in_range() {
+    let idx = disk_index_with_tags(&[b"a", b"b", b"c", b"d"], false);
+    let filter = RangeFilter {
+        min: Some(RangeBoundary {
+            value: b"b",
+            is_included: true,
+        }),
+        max: Some(RangeBoundary {
+            value: b"c",
+            is_included: true,
+        }),
+    };
+    let keys = collect_keys!(idx.range_iter_values(filter));
+    assert_eq!(keys, [b"b".to_vec(), b"c".to_vec()]);
+}
+
+/// Full iteration visits every key in lexicographical order.
+#[test]
+fn disk_iter_values_yields_every_key_in_order() {
+    let idx = disk_index_with_tags(&[b"z", b"a", b"m"], false);
+    let keys = value_iter_keys(idx.value_iter());
+    assert_eq!(keys, [b"a".to_vec(), b"m".to_vec(), b"z".to_vec()]);
+}
+
+/// `mem_usage` counts the values trie in disk mode too, even though the
+/// postings it would otherwise account for live on disk.
+#[test]
+fn mem_usage_accounts_for_the_values_trie() {
+    let idx = disk_index_with_tags(&[b"foo", b"bar", b"baz"], false);
+    assert!(
+        idx.mem_usage() > 0,
+        "the values trie holding the tag keys is counted"
+    );
+}
+
+/// Disk mode still supports the suffix trie (`WITHSUFFIXTRIE`): `commit`
+/// populates it, so it holds entries afterwards.
+#[test]
+fn disk_mode_supports_suffix_trie() {
+    let idx = disk_index_with_tags(&[b"hello", b"world"], true);
+    assert!(idx.has_suffix());
+
+    let mut suffix = idx
+        .suffix_value_iter()
+        .expect("suffix trie is enabled in disk mode");
+    let mut count = 0;
+    while suffix.advance().is_some() {
+        count += 1;
+    }
+    assert!(count > 0, "commit populated the suffix trie in disk mode");
+}

--- a/src/redisearch_rs/tag_index/tests/integration/disk.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/disk.rs
@@ -13,10 +13,10 @@
 //! values trie holds only tag *presence* sentinels. These tests exercise every
 //! disk path that does **not** dereference the disk index spec — `commit`
 //! (presence + record accounting), the value-trie iterators used by query
-//! expansion and `FT.TAGVALS`, `mem_usage`, and mode detection. The paths
-//! that call into `SearchDisk_*` (`index_on_disk`, `open_reader`) need a real disk
-//! backend and are covered end-to-end elsewhere, so here the spec pointer is a
-//! dangling-but-non-null placeholder that is never read.
+//! expansion and `FT.TAGVALS`, `mem_usage`, and mode detection. The spec pointer
+//! is therefore a dangling-but-non-null placeholder that is never read; the two
+//! paths that do cross into the backend, `index` and `open_reader`, are covered
+//! against recording stand-ins in [`disk_backend`](super::disk_backend).
 
 use std::ptr::NonNull;
 
@@ -98,7 +98,7 @@ fn commit_indexes_the_empty_tag() {
 /// In memory mode `commit` reports no records — they are counted at index time.
 #[test]
 fn memory_commit_reports_no_records() {
-    let mut idx = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut idx = TagIndex::<InMemoryMode>::new(0, false);
     assert_eq!(commit_mem(&mut idx, &[b"foo", b"bar"]), 0);
 }
 

--- a/src/redisearch_rs/tag_index/tests/integration/disk_backend.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/disk_backend.rs
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the two disk-mode paths that cross into the storage backend:
+//! `TagIndex::index`, which stages postings through `SearchDisk_IndexTags`, and
+//! `TagIndex::open_reader`, which builds a reader through the registered
+//! enterprise iterators.
+//!
+//! Both backends are closed source, so each is replaced here by a recording
+//! stand-in — the C `disk` API table for the write path, a
+//! `SearchEnterpriseIterators` implementation for the read path. What is under
+//! test is the marshalling either side of that boundary: which tags, document id
+//! and field index reach the backend, and what the Rust API makes of the answer
+//! it gives back.
+
+use std::{
+    ffi::{CStr, CString, c_char, c_void},
+    ptr::NonNull,
+    sync::{
+        Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use ffi::{
+    RSToken, RedisSearchDiskAPI, RedisSearchDiskIndexSpec, RedisSearchDiskSnapshot,
+    SearchDiskWriteBatchHandle, t_docId, t_fieldIndex,
+};
+use redis_module::RedisModuleCtx;
+use rqe_iterators::{
+    QueryError, RQEIterator, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS,
+    SearchEnterpriseIterators, wildcard::Wildcard,
+};
+use rqe_iterators_test_utils::MockContext;
+use tag_index::{OnDiskMode, TagIndex};
+
+use crate::util::as_tag;
+
+/// Field index the indexes under test are created with. Deliberately not `0`, so
+/// a path that dropped the field id on the floor would show up as a mismatch
+/// rather than as an accidental pass.
+const FIELD_INDEX: t_fieldIndex = 7;
+
+/// A disk index spec the fake backends never dereference, but which is a real
+/// allocation: the read path takes a reference to it on the way to the backend,
+/// and a reference has to be in bounds even when nothing reads through it.
+struct FakeDiskSpec {
+    /// Keeps the spec allocation alive. Every use goes through
+    /// [`ptr`](Self::ptr), the one pointer derived from it.
+    _spec: Box<RedisSearchDiskIndexSpec>,
+    ptr: NonNull<RedisSearchDiskIndexSpec>,
+}
+
+impl FakeDiskSpec {
+    fn new() -> Self {
+        let mut spec = Box::new(std::ptr::null::<c_void>());
+        let ptr = NonNull::from(&mut *spec);
+        Self { _spec: spec, ptr }
+    }
+
+    /// A disk-mode index over this spec, with the suffix trie disabled.
+    fn index(&self) -> TagIndex<OnDiskMode> {
+        // SAFETY: `self.ptr` points at the boxed spec, which outlives the
+        // returned index — every test drops the index first.
+        unsafe { TagIndex::<OnDiskMode>::new(self.ptr, FIELD_INDEX, false) }
+    }
+
+    /// The address the backend should see as the index's spec.
+    fn addr(&self) -> usize {
+        self.ptr.as_ptr() as usize
+    }
+}
+
+// -------------------------------------------------------------------------
+// Write path: a fake `disk` API table standing in for the storage backend.
+// -------------------------------------------------------------------------
+
+// The disk backend's global API table, defined in `src/search_disk.c`. It is left
+// NULL in the open-source build and every `SearchDisk_*` entry point dispatches
+// through it, so installing a table here is what makes the write path callable
+// from a test.
+unsafe extern "C" {
+    // Lowercase to match the C global's name.
+    static mut disk: *mut RedisSearchDiskAPI;
+}
+
+/// One `indexTags` call, as the fake backend saw it. Pointers are recorded as
+/// addresses so a call record is [`Send`].
+#[derive(Debug, PartialEq, Eq)]
+struct IndexTagsCall {
+    ctx: usize,
+    spec: usize,
+    batch: usize,
+    values: Vec<Vec<u8>>,
+    doc_id: t_docId,
+    field_index: t_fieldIndex,
+}
+
+/// Serialises the tests that install a fake `disk` table, which is process-global.
+static DISK_API_LOCK: Mutex<()> = Mutex::new(());
+
+/// What the fake `indexTags` has recorded so far.
+static INDEX_TAGS_CALLS: Mutex<Vec<IndexTagsCall>> = Mutex::new(Vec::new());
+
+/// What the fake `indexTags` answers.
+static INDEX_TAGS_ANSWER: AtomicBool = AtomicBool::new(true);
+
+unsafe extern "C" fn fake_index_tags(
+    ctx: *mut RedisModuleCtx,
+    spec: *mut RedisSearchDiskIndexSpec,
+    batch: *mut SearchDiskWriteBatchHandle,
+    values: *mut *const c_char,
+    num_values: usize,
+    doc_id: t_docId,
+    field_index: t_fieldIndex,
+) -> bool {
+    // SAFETY: `TagIndex::index` passes an array of `num_values` pointers, each
+    // one taken from a live `&CStr`, so the array and every string in it are
+    // readable for the duration of this call.
+    let values = unsafe { std::slice::from_raw_parts(values, num_values) }
+        .iter()
+        // SAFETY: as above — every entry is a live, NUL-terminated `&CStr`.
+        .map(|value| unsafe { CStr::from_ptr(*value) }.to_bytes().to_vec())
+        .collect();
+
+    INDEX_TAGS_CALLS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .push(IndexTagsCall {
+            ctx: ctx as usize,
+            spec: spec as usize,
+            batch: batch as usize,
+            values,
+            doc_id,
+            field_index,
+        });
+
+    INDEX_TAGS_ANSWER.load(Ordering::Relaxed)
+}
+
+/// Installs [`fake_index_tags`] as the disk backend for as long as it is held,
+/// then restores the previous global.
+struct FakeIndexTagsBackend {
+    _lock: MutexGuard<'static, ()>,
+    previous: *mut RedisSearchDiskAPI,
+    /// Keeps the table `disk` points at alive for the guard's lifetime.
+    _api: Box<RedisSearchDiskAPI>,
+}
+
+impl FakeIndexTagsBackend {
+    /// `answer` is what the fake backend returns from every call it records.
+    fn install(answer: bool) -> Self {
+        let lock = DISK_API_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        INDEX_TAGS_CALLS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        INDEX_TAGS_ANSWER.store(answer, Ordering::Relaxed);
+
+        // SAFETY: every field of the disk API table is a nullable function
+        // pointer, whose all-zero bit pattern is the valid `None`.
+        let mut api: Box<RedisSearchDiskAPI> = Box::new(unsafe { std::mem::zeroed() });
+        api.index.indexTags = Some(fake_index_tags);
+
+        // SAFETY: `lock` is held, so no other test is touching the global.
+        let previous = unsafe { disk };
+        // SAFETY: as above, plus `api` outlives the pointer stored here because
+        // the guard below owns it.
+        unsafe { disk = std::ptr::from_mut(&mut *api) };
+
+        Self {
+            _lock: lock,
+            previous,
+            _api: api,
+        }
+    }
+
+    /// Everything the fake backend recorded since it was installed, in order.
+    fn calls(&self) -> Vec<IndexTagsCall> {
+        std::mem::take(
+            &mut *INDEX_TAGS_CALLS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+    }
+}
+
+impl Drop for FakeIndexTagsBackend {
+    fn drop(&mut self) {
+        // SAFETY: `self._lock` is still held, so no other test is reading or
+        // writing the global.
+        unsafe { disk = self.previous };
+    }
+}
+
+// -------------------------------------------------------------------------
+// Read path: a fake enterprise iterator backend.
+// -------------------------------------------------------------------------
+
+/// The `top_id` of the [`Wildcard`] the fake enterprise backend hands back. It
+/// serves as a fingerprint: an iterator reporting this estimate came from the
+/// backend and not from anywhere else.
+const MOCK_TAG_TOP_ID: t_docId = 4242;
+
+/// The one tag the fake enterprise backend refuses to build an iterator for.
+const FAILING_TAG: &[u8] = b"backend-error";
+
+/// The message that refusal carries.
+const BACKEND_ERROR: &str = "the disk backend could not open this tag";
+
+/// One `new_tag_on_disk` call, as the fake backend saw it.
+#[derive(Debug, PartialEq)]
+struct TagIteratorCall {
+    spec: usize,
+    token: Vec<u8>,
+    field_index: t_fieldIndex,
+    weight: f64,
+    snapshot: usize,
+}
+
+/// What the fake enterprise backend has recorded so far.
+static TAG_ITERATOR_CALLS: Mutex<Vec<TagIteratorCall>> = Mutex::new(Vec::new());
+
+/// Stands in for the closed-source disk iterators, recording what the tag reader
+/// forwards and answering with a recognisable iterator — or, for [`FAILING_TAG`],
+/// with a failure.
+struct FakeEnterpriseIterators;
+
+impl SearchEnterpriseIterators for FakeEnterpriseIterators {
+    fn new_wildcard_on_disk<'index>(
+        &self,
+        _index: &'index mut RedisSearchDiskIndexSpec,
+        _weight: f64,
+        _snapshot: NonNull<RedisSearchDiskSnapshot>,
+        _status: Option<&mut QueryError>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("the tag index never opens a disk wildcard iterator")
+    }
+
+    fn new_term_on_disk_with_offsets<'index>(
+        &self,
+        _index: &'index mut RedisSearchDiskIndexSpec,
+        _query_term: Box<query_term::RSQueryTerm>,
+        _field_mask: inverted_index::FieldMask,
+        _weight: f64,
+        _snapshot: NonNull<RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("the tag index never opens a disk term iterator")
+    }
+
+    fn new_term_on_disk_without_offsets<'index>(
+        &self,
+        _index: &'index mut RedisSearchDiskIndexSpec,
+        _query_term: Box<query_term::RSQueryTerm>,
+        _field_mask: inverted_index::FieldMask,
+        _weight: f64,
+        _snapshot: NonNull<RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("the tag index never opens a disk term iterator")
+    }
+
+    fn new_tag_on_disk<'index>(
+        &self,
+        index: &'index mut RedisSearchDiskIndexSpec,
+        token: &RSToken,
+        field_index: t_fieldIndex,
+        weight: f64,
+        snapshot: NonNull<RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        // SAFETY: `TagIndex::open_reader` points `token` at the tag it was given,
+        // which outlives this call.
+        let token = unsafe { std::slice::from_raw_parts(token.str_.cast::<u8>(), token.len) };
+
+        TAG_ITERATOR_CALLS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(TagIteratorCall {
+                spec: std::ptr::from_mut(index) as usize,
+                token: token.to_vec(),
+                field_index,
+                weight,
+                snapshot: snapshot.as_ptr() as usize,
+            });
+
+        if token == FAILING_TAG {
+            return Err(BACKEND_ERROR.into());
+        }
+        Ok(Box::new(Wildcard::new(MOCK_TAG_TOP_ID, weight)))
+    }
+
+    fn new_numeric_on_disk<'index>(
+        &self,
+        _index: &'index mut RedisSearchDiskIndexSpec,
+        _filter: &inverted_index::NumericFilter,
+        _field_index: t_fieldIndex,
+        _snapshot: NonNull<RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("the tag index never opens a disk numeric iterator")
+    }
+
+    fn new_geo_on_disk<'index>(
+        &self,
+        _index: &'index mut RedisSearchDiskIndexSpec,
+        _gf: &'index mut ffi::GeoFilter,
+        _field_index: t_fieldIndex,
+        _snapshot: NonNull<RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("the tag index never opens a disk geo iterator")
+    }
+}
+
+/// Serialises the tests reading [`TAG_ITERATOR_CALLS`], which — like the
+/// registration itself — is process-global.
+static ENTERPRISE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Claims [`FakeEnterpriseIterators`] for as long as it is held.
+struct FakeEnterpriseBackend {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl FakeEnterpriseBackend {
+    /// Register the fake backend and drop whatever an earlier test recorded. The
+    /// registration itself happens once per process: the `OnceLock` keeps the
+    /// first value, and there is only ever this one.
+    fn install() -> Self {
+        let lock = ENTERPRISE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        SEARCH_ENTERPRISE_ITERATORS.get_or_init(|| Box::new(FakeEnterpriseIterators));
+        TAG_ITERATOR_CALLS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        Self { _lock: lock }
+    }
+
+    /// Everything the fake backend recorded since it was installed, in order.
+    fn calls(&self) -> Vec<TagIteratorCall> {
+        std::mem::take(
+            &mut *TAG_ITERATOR_CALLS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+    }
+}
+
+// -------------------------------------------------------------------------
+// Write path tests.
+// -------------------------------------------------------------------------
+
+/// A non-null write context and batch. `TagIndex::index` only forwards them, and
+/// the fake backend only records their addresses, so nothing ever dereferences
+/// either.
+const fn write_handles() -> (*mut RedisModuleCtx, *mut SearchDiskWriteBatchHandle) {
+    (
+        NonNull::<RedisModuleCtx>::dangling().as_ptr(),
+        NonNull::<SearchDiskWriteBatchHandle>::dangling().as_ptr(),
+    )
+}
+
+/// `index` hands the backend one call carrying every tag as a C string, in the
+/// order given, together with the document id and the index's own field id.
+#[test]
+fn index_forwards_the_tags_document_and_field_to_the_backend() {
+    const DOC_ID: t_docId = 11;
+
+    let backend = FakeIndexTagsBackend::install(true);
+    let spec = FakeDiskSpec::new();
+    let mut idx = spec.index();
+    let (ctx, batch) = write_handles();
+
+    let tags: Vec<CString> = [&b"foo"[..], b"bar", b"foo"]
+        .iter()
+        .map(|tag| CString::new(*tag).expect("test literal is NUL-free"))
+        .collect();
+    let tags: Vec<&CStr> = tags.iter().map(CString::as_c_str).collect();
+
+    // SAFETY: `ctx` and `batch` are the non-null handles the fake backend
+    // expects, and it never dereferences them.
+    let ok = unsafe { idx.index(ctx, batch, &tags, DOC_ID) };
+    assert!(ok, "the fake backend accepted the write");
+
+    assert_eq!(
+        backend.calls(),
+        vec![IndexTagsCall {
+            ctx: ctx as usize,
+            spec: spec.addr(),
+            batch: batch as usize,
+            // The repeated `foo` is *not* deduplicated: `index` stages exactly
+            // what the document holds and leaves collapsing to the backend.
+            values: vec![b"foo".to_vec(), b"bar".to_vec(), b"foo".to_vec()],
+            doc_id: DOC_ID,
+            field_index: FIELD_INDEX,
+        }]
+    );
+}
+
+/// The empty tag (INDEXEMPTY) reaches the backend as an empty C string rather
+/// than being skipped on the way.
+#[test]
+fn index_forwards_the_empty_tag() {
+    let backend = FakeIndexTagsBackend::install(true);
+    let spec = FakeDiskSpec::new();
+    let mut idx = spec.index();
+    let (ctx, batch) = write_handles();
+
+    // SAFETY: as in `index_forwards_the_tags_document_and_field_to_the_backend`.
+    let ok = unsafe { idx.index(ctx, batch, &[c""], 1) };
+    assert!(ok);
+
+    let calls = backend.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].values, vec![Vec::<u8>::new()]);
+}
+
+/// A document with no tags for this field is not a backend write at all.
+#[test]
+fn index_without_tags_does_not_reach_the_backend() {
+    let backend = FakeIndexTagsBackend::install(false);
+    let spec = FakeDiskSpec::new();
+    let mut idx = spec.index();
+    let (ctx, batch) = write_handles();
+
+    // SAFETY: as in `index_forwards_the_tags_document_and_field_to_the_backend`.
+    let ok = unsafe { idx.index(ctx, batch, &[], 1) };
+
+    assert!(
+        ok,
+        "an empty write succeeds without consulting the backend, which here \
+         would have refused"
+    );
+    assert_eq!(backend.calls(), vec![]);
+}
+
+/// A backend refusal is reported to the caller, which aborts the write batch on
+/// the strength of it.
+#[test]
+fn index_propagates_a_backend_refusal() {
+    let _backend = FakeIndexTagsBackend::install(false);
+    let spec = FakeDiskSpec::new();
+    let mut idx = spec.index();
+    let (ctx, batch) = write_handles();
+
+    // SAFETY: as in `index_forwards_the_tags_document_and_field_to_the_backend`.
+    let ok = unsafe { idx.index(ctx, batch, &[c"foo"], 1) };
+    assert!(!ok, "the refusal is passed on rather than swallowed");
+}
+
+// -------------------------------------------------------------------------
+// Read path tests.
+// -------------------------------------------------------------------------
+
+/// `open_reader` builds its reader through the backend, forwarding the tag, the
+/// index's field id, the caller's weight and the search context's snapshot.
+#[test]
+fn open_reader_forwards_the_tag_field_and_snapshot_to_the_backend() {
+    let backend = FakeEnterpriseBackend::install();
+
+    let spec = FakeDiskSpec::new();
+    let idx = spec.index();
+    let mock = MockContext::new(0, 0);
+    let mut snapshot: RedisSearchDiskSnapshot = std::ptr::null();
+    let snapshot = std::ptr::from_mut(&mut snapshot);
+    // SAFETY: `snapshot` outlives the iterator, which is dropped at the end of
+    // this test.
+    unsafe { mock.set_disk_snapshot(snapshot) };
+
+    // SAFETY: `idx` and `mock` outlive the iterator; the snapshot is the one just
+    // installed; and nothing else references the spec while the iterator lives.
+    let it = unsafe { idx.open_reader(mock.sctx(), as_tag(b"hello"), 2.5) }
+        .expect("the fake backend builds an iterator for every tag but the failing one");
+
+    assert_eq!(
+        it.num_estimated(),
+        MOCK_TAG_TOP_ID as usize,
+        "the reader is the one the backend returned"
+    );
+    assert_eq!(
+        backend.calls(),
+        vec![TagIteratorCall {
+            spec: spec.addr(),
+            token: b"hello".to_vec(),
+            field_index: FIELD_INDEX,
+            weight: 2.5,
+            snapshot: snapshot as usize,
+        }]
+    );
+}
+
+/// A tag whose bytes carry no NUL terminator still reaches the backend intact:
+/// the token is passed as pointer plus length, so the reader does not need one.
+#[test]
+fn open_reader_forwards_the_empty_tag() {
+    let backend = FakeEnterpriseBackend::install();
+
+    let spec = FakeDiskSpec::new();
+    let idx = spec.index();
+    let mock = MockContext::new(0, 0);
+    mock.set_dummy_disk_snapshot();
+
+    // SAFETY: as in `open_reader_forwards_the_tag_field_and_snapshot_to_the_backend`.
+    let it = unsafe { idx.open_reader(mock.sctx(), as_tag(b""), 1.0) };
+    assert!(it.is_ok());
+
+    let calls = backend.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].token, Vec::<u8>::new());
+}
+
+/// When the backend cannot build an iterator the failure is returned rather than
+/// turned into an empty reader, so the query aborts instead of silently missing
+/// documents.
+#[test]
+fn open_reader_propagates_a_backend_failure() {
+    let _backend = FakeEnterpriseBackend::install();
+
+    let spec = FakeDiskSpec::new();
+    let idx = spec.index();
+    let mock = MockContext::new(0, 0);
+    mock.set_dummy_disk_snapshot();
+
+    // SAFETY: as in `open_reader_forwards_the_tag_field_and_snapshot_to_the_backend`.
+    let Err(err) = (unsafe { idx.open_reader(mock.sctx(), as_tag(FAILING_TAG), 1.0) }) else {
+        panic!("the fake backend refuses this tag");
+    };
+    assert_eq!(err.to_string(), BACKEND_ERROR);
+}

--- a/src/redisearch_rs/tag_index/tests/integration/expansion_timeout.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/expansion_timeout.rs
@@ -47,7 +47,7 @@ fn big_index() -> (TagIndex<InMemoryMode>, usize) {
         .map(|i| format!("he{i:05}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-    let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut idx = TagIndex::<InMemoryMode>::new(0, true);
     commit_mem(&mut idx, &tags);
     (idx, tags.len())
 }

--- a/src/redisearch_rs/tag_index/tests/integration/expansion_timeout.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/expansion_timeout.rs
@@ -47,7 +47,7 @@ fn big_index() -> (TagIndex<InMemoryMode>, usize) {
         .map(|i| format!("he{i:05}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-    let mut idx = TagIndex::<InMemoryMode>::new(true);
+    let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
     commit_mem(&mut idx, &tags);
     (idx, tags.len())
 }

--- a/src/redisearch_rs/tag_index/tests/integration/filtered_iteration.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/filtered_iteration.rs
@@ -32,7 +32,7 @@ fn suffix_keys(idx: &TagIndex<InMemoryMode>) -> Vec<Vec<u8>> {
 
 /// Build an in-memory index holding `tags`, each with one document.
 fn index_with_tags(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut tag_index, tags, 1);
     tag_index
 }
@@ -91,7 +91,7 @@ fn suffix_iter_values_yields_only_matching_tags() {
 /// The order is asserted unsorted because it is part of the contract.
 #[test]
 fn suffix_query_exact_node_yields_every_member() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, true);
     // `eat` last, so it lands after the terms it is a suffix of.
     let tags: &[&[u8]] = &[b"beat", b"heat", b"eat", b"bean"];
     index_mem(&mut tag_index, tags, 1);
@@ -122,7 +122,7 @@ fn set_timeout_cuts_iteration_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter();
@@ -150,7 +150,7 @@ fn set_timeout_bounds_the_nonmatches_a_suffix_walk_skips() {
         .chain(std::iter::once(b"zzzoo".to_vec()))
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"oo"), IterMode::Suffix);
@@ -174,7 +174,7 @@ fn set_timeout_cuts_a_contains_walk_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"tag"), IterMode::Contains);
@@ -200,7 +200,7 @@ fn set_timeout_cuts_a_wildcard_walk_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"tag*"), IterMode::Wildcard);
@@ -253,7 +253,7 @@ fn wildcard_iter_values_matches_metacharacters() {
 /// document, so any tag value shared by two documents takes this path.
 #[test]
 fn recommitting_a_tag_keeps_its_suffix_terms_readable() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, true);
     let tags: &[&[u8]] = &[b"cat"];
 
     for doc_id in 1..=2 {
@@ -279,7 +279,7 @@ fn recommitting_a_tag_keeps_its_suffix_terms_readable() {
 /// Without `WITHSUFFIXTRIE` there is no suffix index to iterate.
 #[test]
 fn iter_suffix_entries_is_none_without_suffix_trie() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let tag_index = TagIndex::<InMemoryMode>::new(0, false);
     assert!(tag_index.suffix_value_iter().is_none());
 }
 
@@ -287,7 +287,7 @@ fn iter_suffix_entries_is_none_without_suffix_trie() {
 /// its suffixes in the suffix index.
 #[test]
 fn iter_suffix_entries_lists_every_suffix() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, true);
     index_mem(&mut tag_index, &[b"foo"], 1);
     commit_mem(&mut tag_index, &[b"foo"]);
 

--- a/src/redisearch_rs/tag_index/tests/integration/filtered_iteration.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/filtered_iteration.rs
@@ -32,7 +32,7 @@ fn suffix_keys(idx: &TagIndex<InMemoryMode>) -> Vec<Vec<u8>> {
 
 /// Build an in-memory index holding `tags`, each with one document.
 fn index_with_tags(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut tag_index, tags, 1);
     tag_index
 }
@@ -91,7 +91,7 @@ fn suffix_iter_values_yields_only_matching_tags() {
 /// The order is asserted unsorted because it is part of the contract.
 #[test]
 fn suffix_query_exact_node_yields_every_member() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     // `eat` last, so it lands after the terms it is a suffix of.
     let tags: &[&[u8]] = &[b"beat", b"heat", b"eat", b"bean"];
     index_mem(&mut tag_index, tags, 1);
@@ -122,7 +122,7 @@ fn set_timeout_cuts_iteration_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter();
@@ -150,7 +150,7 @@ fn set_timeout_bounds_the_nonmatches_a_suffix_walk_skips() {
         .chain(std::iter::once(b"zzzoo".to_vec()))
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"oo"), IterMode::Suffix);
@@ -174,7 +174,7 @@ fn set_timeout_cuts_a_contains_walk_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"tag"), IterMode::Contains);
@@ -200,7 +200,7 @@ fn set_timeout_cuts_a_wildcard_walk_short() {
         .map(|i| format!("tag{i:04}").into_bytes())
         .collect();
     let tags: Vec<&[u8]> = owned.iter().map(|t| t.as_slice()).collect();
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     index_mem(&mut tag_index, &tags, 1);
 
     let mut it = tag_index.value_iter_filtered(as_tag(b"tag*"), IterMode::Wildcard);
@@ -253,7 +253,7 @@ fn wildcard_iter_values_matches_metacharacters() {
 /// document, so any tag value shared by two documents takes this path.
 #[test]
 fn recommitting_a_tag_keeps_its_suffix_terms_readable() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     let tags: &[&[u8]] = &[b"cat"];
 
     for doc_id in 1..=2 {
@@ -279,7 +279,7 @@ fn recommitting_a_tag_keeps_its_suffix_terms_readable() {
 /// Without `WITHSUFFIXTRIE` there is no suffix index to iterate.
 #[test]
 fn iter_suffix_entries_is_none_without_suffix_trie() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     assert!(tag_index.suffix_value_iter().is_none());
 }
 
@@ -287,7 +287,7 @@ fn iter_suffix_entries_is_none_without_suffix_trie() {
 /// its suffixes in the suffix index.
 #[test]
 fn iter_suffix_entries_lists_every_suffix() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     index_mem(&mut tag_index, &[b"foo"], 1);
     commit_mem(&mut tag_index, &[b"foo"]);
 

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -29,7 +29,7 @@ use crate::util::{as_tag, commit_mem, gc_mem, index_mem, scan, unique_id};
 /// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
 /// trie is populated too.
 fn indexed(tags: &[&[u8]], n: DocId, with_suffix: bool) -> TagIndex<InMemoryMode> {
-    let mut idx = TagIndex::<InMemoryMode>::new(with_suffix);
+    let mut idx = TagIndex::<InMemoryMode>::new(with_suffix, 0);
     for doc_id in 1..=n {
         index_mem(&mut idx, tags, doc_id);
     }

--- a/src/redisearch_rs/tag_index/tests/integration/gc.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/gc.rs
@@ -29,7 +29,7 @@ use crate::util::{as_tag, commit_mem, gc_mem, index_mem, scan, unique_id};
 /// `with_suffix` mirrors `WITHSUFFIXTRIE`, and commits the tags so the suffix
 /// trie is populated too.
 fn indexed(tags: &[&[u8]], n: DocId, with_suffix: bool) -> TagIndex<InMemoryMode> {
-    let mut idx = TagIndex::<InMemoryMode>::new(with_suffix, 0);
+    let mut idx = TagIndex::<InMemoryMode>::new(0, with_suffix);
     for doc_id in 1..=n {
         index_mem(&mut idx, tags, doc_id);
     }

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -18,7 +18,7 @@ use crate::util::{commit_mem, index_mem, value_iter_keys};
 /// Indexing a document registers each of its tags.
 #[test]
 fn indexing_registers_every_tag() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
 
     let tags: &[&[u8]] = &[b"tag-1", b"tag-2"];
 
@@ -37,7 +37,7 @@ fn indexing_registers_every_tag() {
 /// between them could go unnoticed.
 #[test]
 fn index_and_commit_agree_on_the_key() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, true);
     let tags: &[&[u8]] = &[b"foo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -71,7 +71,7 @@ fn tag_value_reader_reads_every_posting_in_order() {
     // the reader cross a block boundary.
     const N: u64 = 1500;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     for doc_id in 1..=N {
         index_mem(&mut tag_index, &[b"team"], doc_id);
     }
@@ -103,7 +103,7 @@ fn tag_value_reader_reads_every_posting_in_order() {
 /// a suffix of `"foo"` and also indexed as a tag on its own).
 #[test]
 fn commit_registers_tags_in_the_suffix_index_when_enabled() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, true);
     let tags: &[&[u8]] = &[b"foo", b"oo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -125,7 +125,7 @@ fn commit_registers_tags_in_the_suffix_index_when_enabled() {
 /// With suffix indexing disabled, `commit` is a no-op on the suffix index.
 #[test]
 fn commit_does_not_touch_the_suffix_index_when_disabled() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags: &[&[u8]] = &[b"foo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -136,7 +136,7 @@ fn commit_does_not_touch_the_suffix_index_when_disabled() {
 
 #[test]
 fn field_expiration_flag_round_trips() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags = &[Tag::new(b"team").unwrap()];
 
     // Doc 1 has no TTL on this field; doc 2 does.
@@ -162,7 +162,7 @@ fn field_expiration_flag_round_trips() {
 /// Tags are yielded in lexicographical order, whatever the insertion order.
 #[test]
 fn iterate_values_is_lexicographically_ordered() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
 
     let tags: &mut [&[u8]] = &mut [b"z", b"r", b"t", b"d", b"m", b"a"];
 
@@ -178,7 +178,7 @@ fn iterate_values_is_lexicographically_ordered() {
 /// order, and each yielded index is the one stored in the trie.
 #[test]
 fn iter_values_yields_the_stored_entries_in_order() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
 
     let tags: &mut [&[u8]] = &mut [b"z", b"r", b"t", b"d", b"m", b"a"];
 
@@ -208,7 +208,7 @@ fn iter_values_yields_the_stored_entries_in_order() {
 /// An empty index yields no entries.
 #[test]
 fn iter_values_on_empty_index_yields_nothing() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let tag_index = TagIndex::<InMemoryMode>::new(0, false);
     assert!(tag_index.value_iter().advance().is_none());
 }
 
@@ -217,7 +217,7 @@ fn iter_values_on_empty_index_yields_nothing() {
 /// bytes.
 #[test]
 fn reindexing_the_same_document_is_a_no_op() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let first = index_mem(&mut tag_index, tags, 1);
@@ -242,7 +242,7 @@ fn n_tags_and_record_count_track_the_writes() {
     #[cfg(miri)]
     const N: u64 = 20;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let mut total_records = 0u32;
@@ -258,7 +258,7 @@ fn n_tags_and_record_count_track_the_writes() {
 /// `["foo", "foo", "bar"]` yields two records and two unique values.
 #[test]
 fn intra_document_duplicate_tag_counted_once() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags: &[&[u8]] = &[b"foo", b"foo", b"bar"];
 
     let delta = index_mem(&mut tag_index, tags, 1);
@@ -280,7 +280,7 @@ fn size_and_block_accounting_matches_reported_memory() {
     // each tag's posting list spill into more than one block.
     const N: u64 = 2500;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(0, false);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let first = index_mem(&mut tag_index, tags, 1);

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -18,7 +18,7 @@ use crate::util::{commit_mem, index_mem, value_iter_keys};
 /// Indexing a document registers each of its tags.
 #[test]
 fn indexing_registers_every_tag() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
 
     let tags: &[&[u8]] = &[b"tag-1", b"tag-2"];
 
@@ -37,7 +37,7 @@ fn indexing_registers_every_tag() {
 /// between them could go unnoticed.
 #[test]
 fn index_and_commit_agree_on_the_key() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     let tags: &[&[u8]] = &[b"foo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -71,7 +71,7 @@ fn tag_value_reader_reads_every_posting_in_order() {
     // the reader cross a block boundary.
     const N: u64 = 1500;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     for doc_id in 1..=N {
         index_mem(&mut tag_index, &[b"team"], doc_id);
     }
@@ -103,7 +103,7 @@ fn tag_value_reader_reads_every_posting_in_order() {
 /// a suffix of `"foo"` and also indexed as a tag on its own).
 #[test]
 fn commit_registers_tags_in_the_suffix_index_when_enabled() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true, 0);
     let tags: &[&[u8]] = &[b"foo", b"oo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -125,7 +125,7 @@ fn commit_registers_tags_in_the_suffix_index_when_enabled() {
 /// With suffix indexing disabled, `commit` is a no-op on the suffix index.
 #[test]
 fn commit_does_not_touch_the_suffix_index_when_disabled() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags: &[&[u8]] = &[b"foo"];
 
     index_mem(&mut tag_index, tags, 1);
@@ -136,7 +136,7 @@ fn commit_does_not_touch_the_suffix_index_when_disabled() {
 
 #[test]
 fn field_expiration_flag_round_trips() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags = &[Tag::new(b"team").unwrap()];
 
     // Doc 1 has no TTL on this field; doc 2 does.
@@ -162,7 +162,7 @@ fn field_expiration_flag_round_trips() {
 /// Tags are yielded in lexicographical order, whatever the insertion order.
 #[test]
 fn iterate_values_is_lexicographically_ordered() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
 
     let tags: &mut [&[u8]] = &mut [b"z", b"r", b"t", b"d", b"m", b"a"];
 
@@ -178,7 +178,7 @@ fn iterate_values_is_lexicographically_ordered() {
 /// order, and each yielded index is the one stored in the trie.
 #[test]
 fn iter_values_yields_the_stored_entries_in_order() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
 
     let tags: &mut [&[u8]] = &mut [b"z", b"r", b"t", b"d", b"m", b"a"];
 
@@ -208,7 +208,7 @@ fn iter_values_yields_the_stored_entries_in_order() {
 /// An empty index yields no entries.
 #[test]
 fn iter_values_on_empty_index_yields_nothing() {
-    let tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     assert!(tag_index.value_iter().advance().is_none());
 }
 
@@ -217,7 +217,7 @@ fn iter_values_on_empty_index_yields_nothing() {
 /// bytes.
 #[test]
 fn reindexing_the_same_document_is_a_no_op() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let first = index_mem(&mut tag_index, tags, 1);
@@ -242,7 +242,7 @@ fn n_tags_and_record_count_track_the_writes() {
     #[cfg(miri)]
     const N: u64 = 20;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let mut total_records = 0u32;
@@ -258,7 +258,7 @@ fn n_tags_and_record_count_track_the_writes() {
 /// `["foo", "foo", "bar"]` yields two records and two unique values.
 #[test]
 fn intra_document_duplicate_tag_counted_once() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags: &[&[u8]] = &[b"foo", b"foo", b"bar"];
 
     let delta = index_mem(&mut tag_index, tags, 1);
@@ -280,7 +280,7 @@ fn size_and_block_accounting_matches_reported_memory() {
     // each tag's posting list spill into more than one block.
     const N: u64 = 2500;
 
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false, 0);
     let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
 
     let first = index_mem(&mut tag_index, tags, 1);

--- a/src/redisearch_rs/tag_index/tests/integration/main.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/main.rs
@@ -16,6 +16,7 @@ extern crate redisearch_rs;
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 mod create;
+mod disk;
 mod expansion_timeout;
 mod filtered_iteration;
 mod gc;

--- a/src/redisearch_rs/tag_index/tests/integration/main.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/main.rs
@@ -17,6 +17,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 mod create;
 mod disk;
+mod disk_backend;
 mod expansion_timeout;
 mod filtered_iteration;
 mod gc;

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -66,7 +66,7 @@ fn open_reader_reads_all_ids_in_order() {
     const N: ffi::t_docId = 300;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     let tags: &[&[u8]] = &[b"hello"];
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
@@ -75,10 +75,8 @@ fn open_reader_reads_all_ids_in_order() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
 
     let doc_ids = drain(it);
     assert_eq!(doc_ids, (1..=N).collect::<Vec<_>>());
@@ -92,17 +90,15 @@ fn open_reader_reads_all_ids_in_order() {
 #[test]
 fn skip_to_past_last_id_yields_eof() {
     let mock = MockContext::new(1, 1);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     let doc_id: ffi::t_docId = 1;
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let mut it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let mut it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
 
     it.read().expect("read must not error");
     assert_eq!(it.last_doc_id(), doc_id);
@@ -122,16 +118,14 @@ fn skip_to_past_last_id_yields_eof() {
 /// NULL-index case is a C-ABI concern and stays in the C++ suite.
 #[test]
 fn open_reader_absent_tag_returns_none() {
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"hello"], 1);
 
     let mock = MockContext::new(1, 1);
     // SAFETY: `tag_index` and `mock` outlive the (never created) iterator, and
     // `lookup` resolves `tag_index`.
-    let it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"missing"), 1.0, FIELD_INDEX, lookup)
-    };
+    let it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"missing"), 1.0, lookup) };
     assert!(it.is_none());
 
     // SAFETY: `allocate` allocated it; no iterator was built from it.
@@ -150,7 +144,7 @@ fn revalidate_aborts_after_gc() {
     let tags: &[&[u8]] = &[b"team"];
     // `allocate` reaches the index through a raw pointer, so it can be mutated while
     // the iterator holds its back-pointer — as the query layer does across GC cycles.
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     for doc_id in 1..=3 {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, tags, doc_id);
@@ -158,9 +152,8 @@ fn revalidate_aborts_after_gc() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, `tag_index` is mutated
     // below only between revalidations, and `lookup` resolves `tag_index`.
-    let mut it =
-        unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"team"), 1.0, FIELD_INDEX, lookup) }
-            .expect("the tag is indexed");
+    let mut it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"team"), 1.0, lookup) }
+        .expect("the tag is indexed");
 
     let status = it
         .revalidate(&mock.spec_read())
@@ -192,7 +185,7 @@ fn revalidate_aborts_after_gc() {
 /// EOF.
 #[test]
 fn open_reader_returns_none_for_empty_inverted_index() {
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     // Register the tag, then force its posting list empty without unregistering
     // the tag. No public path leaves that state — `TagIndex::gc` drops a tag that
     // lost its last document — so it is forced here to reach the guard, which
@@ -205,9 +198,7 @@ fn open_reader_returns_none_for_empty_inverted_index() {
     let mock = MockContext::new(0, 0);
     // SAFETY: `tag_index` and `mock` outlive the (never created) iterator, and
     // `lookup` resolves `tag_index`.
-    let it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"empty"), 1.0, FIELD_INDEX, lookup)
-    };
+    let it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"empty"), 1.0, lookup) };
     assert!(it.is_none());
 
     // SAFETY: `allocate` allocated it; no iterator was built from it.
@@ -217,7 +208,7 @@ fn open_reader_returns_none_for_empty_inverted_index() {
 #[test]
 fn open_reader_omits_expired_field_documents() {
     let mock = MockContext::new(2, 2);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     let tags = &[as_tag(b"hello")];
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     unsafe { &mut *tag_index }.index(tags, 1, false);
@@ -230,10 +221,8 @@ fn open_reader_omits_expired_field_documents() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
 
     assert_eq!(drain(it), vec![1]);
 
@@ -252,7 +241,7 @@ fn open_reader_omits_expired_field_documents() {
 #[test]
 fn resume_after_the_tag_was_collected_aborts() {
     let mock = MockContext::new(2, 2);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     for doc_id in 1..=2 {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -260,10 +249,8 @@ fn resume_after_the_tag_was_collected_aborts() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let mut it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let mut it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
     it.read().expect("read must not error");
 
     let suspended = Box::new(it).suspend();
@@ -293,7 +280,7 @@ fn resume_with_the_tag_untouched_reads_on() {
     const N: ffi::t_docId = 3;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -301,10 +288,8 @@ fn resume_with_the_tag_untouched_reads_on() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let mut it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let mut it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
     it.read().expect("read must not error");
 
     let guard = mock.spec_read();
@@ -346,7 +331,7 @@ fn resume_after_the_current_document_was_collected_reads_on() {
     const COLLECTED: ffi::t_docId = 2;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -354,10 +339,8 @@ fn resume_after_the_current_document_was_collected_reads_on() {
 
     // SAFETY: `tag_index` and `mock` outlive the iterator, and `lookup` resolves
     // `tag_index`.
-    let mut it = unsafe {
-        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
-    }
-    .expect("the tag is indexed");
+    let mut it = unsafe { (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, lookup) }
+        .expect("the tag is indexed");
     // Park the reader exactly on the document about to be collected, the position
     // the resume has to recover from.
     for _ in 1..=COLLECTED {

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -66,7 +66,7 @@ fn open_reader_reads_all_ids_in_order() {
     const N: ffi::t_docId = 300;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     let tags: &[&[u8]] = &[b"hello"];
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
@@ -90,7 +90,7 @@ fn open_reader_reads_all_ids_in_order() {
 #[test]
 fn skip_to_past_last_id_yields_eof() {
     let mock = MockContext::new(1, 1);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     let doc_id: ffi::t_docId = 1;
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -118,7 +118,7 @@ fn skip_to_past_last_id_yields_eof() {
 /// NULL-index case is a C-ABI concern and stays in the C++ suite.
 #[test]
 fn open_reader_absent_tag_returns_none() {
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     index_mem(unsafe { &mut *tag_index }, &[b"hello"], 1);
 
@@ -144,7 +144,7 @@ fn revalidate_aborts_after_gc() {
     let tags: &[&[u8]] = &[b"team"];
     // `allocate` reaches the index through a raw pointer, so it can be mutated while
     // the iterator holds its back-pointer — as the query layer does across GC cycles.
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     for doc_id in 1..=3 {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, tags, doc_id);
@@ -185,7 +185,7 @@ fn revalidate_aborts_after_gc() {
 /// EOF.
 #[test]
 fn open_reader_returns_none_for_empty_inverted_index() {
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     // Register the tag, then force its posting list empty without unregistering
     // the tag. No public path leaves that state — `TagIndex::gc` drops a tag that
     // lost its last document — so it is forced here to reach the guard, which
@@ -208,7 +208,7 @@ fn open_reader_returns_none_for_empty_inverted_index() {
 #[test]
 fn open_reader_omits_expired_field_documents() {
     let mock = MockContext::new(2, 2);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     let tags = &[as_tag(b"hello")];
     // SAFETY: `tag_index` was just allocated and is not yet aliased.
     unsafe { &mut *tag_index }.index(tags, 1, false);
@@ -241,7 +241,7 @@ fn open_reader_omits_expired_field_documents() {
 #[test]
 fn resume_after_the_tag_was_collected_aborts() {
     let mock = MockContext::new(2, 2);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     for doc_id in 1..=2 {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -280,7 +280,7 @@ fn resume_with_the_tag_untouched_reads_on() {
     const N: ffi::t_docId = 3;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
@@ -331,7 +331,7 @@ fn resume_after_the_current_document_was_collected_reads_on() {
     const COLLECTED: ffi::t_docId = 2;
 
     let mock = MockContext::new(N, N as usize);
-    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false, 0));
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(0, false));
     for doc_id in 1..=N {
         // SAFETY: `tag_index` was just allocated and is not yet aliased.
         index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);

--- a/src/redisearch_rs/tag_index/tests/integration/suffix_wildcard.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/suffix_wildcard.rs
@@ -23,7 +23,7 @@ const NO_CAP: u64 = u64::MAX;
 
 /// Build an in-memory index with a suffix trie and commit `tags`.
 fn indexed(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-    let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
+    let mut idx = TagIndex::<InMemoryMode>::new(0, true);
     commit_mem(&mut idx, tags);
     idx
 }

--- a/src/redisearch_rs/tag_index/tests/integration/suffix_wildcard.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/suffix_wildcard.rs
@@ -23,7 +23,7 @@ const NO_CAP: u64 = u64::MAX;
 
 /// Build an in-memory index with a suffix trie and commit `tags`.
 fn indexed(tags: &[&[u8]]) -> TagIndex<InMemoryMode> {
-    let mut idx = TagIndex::<InMemoryMode>::new(true);
+    let mut idx = TagIndex::<InMemoryMode>::new(true, 0);
     commit_mem(&mut idx, tags);
     idx
 }

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -12,7 +12,7 @@
 use ffi::timespec;
 use index_result::RSIndexResult;
 use inverted_index::{DocId, GcApplyInfo, GcScanDelta, IndexUniqueId, RepairContext};
-use tag_index::{InMemoryMode, MemTagIndexIterator, Tag, TagIndex, WritePostingsDelta};
+use tag_index::{InMemoryMode, MemTagIndexIterator, OnDiskMode, Tag, TagIndex, WritePostingsDelta};
 
 /// Wrap a NUL-free test literal into a [`Tag`].
 pub fn as_tag(bytes: &[u8]) -> Tag<'_> {
@@ -48,6 +48,11 @@ pub fn index_mem(
 
 /// Run the post-indexing commit phase for `tags` on a memory-mode index.
 pub fn commit_mem(idx: &mut TagIndex<InMemoryMode>, tags: &[&[u8]]) -> u32 {
+    idx.commit(&tag_values(tags))
+}
+
+/// Run the post-indexing commit phase for `tags` on a disk-mode index.
+pub fn commit_disk(idx: &mut TagIndex<OnDiskMode>, tags: &[&[u8]]) -> u32 {
     idx.commit(&tag_values(tags))
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The `tag_index` Rust port has so far only covered in-memory mode. Disk-backed tag indexes still had no Rust implementation.
2. Change: Adds the disk-mode half of the crate.
3. Outcome: This is the last slice of the `tag_index` Rust-port split. Only ffi + switch is left.

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->
1. MOD-14988

#### Main objects this PR modified

1. tag_index/src/lib.rs — adds `TagIndex<OnDiskMode>` impl: `index`, `commit`, `n_tags`, `mem_usage`, `range_iter_values`, `open_reader`
2. tag_index/src/iter.rs — disk-mode `value_iter`/`value_iter_filtered` over the presence-only values trie
3. tag_index/src/suffix.rs — adjustments to support disk-mode suffix handling
4. tag_index/tests/integration/disk.rs (new, 202 lines) — integration tests covering the new disk-mode APIs
5. ffi/build.rs, tag_index/Cargo.toml — build/dependency wiring for the new FFI surface (SearchDisk_IndexTags, SearchEnterpriseIterators)


#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
