### PR TITLE
Rust build: give late bundle references a second linker pass

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -152,8 +152,19 @@ pub fn bind_foreign_c_symbols() {
     let bin_root = bin_root();
     force_link_time_symbol_resolution();
     link_redisearch_c_bundle(&bin_root).unwrap_or_else(|e| panic!("{e}"));
-    // Cargo's `-l` flags precede the rlibs; re-scan the bundle after them.
+    // Cargo's `-l` flags precede the rlibs; re-scan the bundle after them. GNU ld reads
+    // each archive once, so group it there with the system libs its members need.
+    let gnu_ld = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string()) != "macos";
+    if gnu_ld {
+        println!("cargo::rustc-link-arg=-Wl,--start-group");
+    }
     println!("cargo::rustc-link-arg=-lredisearch_c_bundle");
+    if gnu_ld {
+        println!("cargo::rustc-link-arg=-lstdc++");
+        println!("cargo::rustc-link-arg=-lpthread");
+        println!("cargo::rustc-link-arg=-lc");
+        println!("cargo::rustc-link-arg=-Wl,--end-group");
+    }
     link_mkl(&bin_root.join("_deps/svs-src/lib"));
     link_c_plusplus();
 }

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -152,6 +152,8 @@ pub fn bind_foreign_c_symbols() {
     let bin_root = bin_root();
     force_link_time_symbol_resolution();
     link_redisearch_c_bundle(&bin_root).unwrap_or_else(|e| panic!("{e}"));
+    // Cargo's `-l` flags precede the rlibs; re-scan the bundle after them.
+    println!("cargo::rustc-link-arg=-lredisearch_c_bundle");
     link_mkl(&bin_root.join("_deps/svs-src/lib"));
     link_c_plusplus();
 }

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -152,6 +152,7 @@ pub fn bind_foreign_c_symbols() {
     let bin_root = bin_root();
     force_link_time_symbol_resolution();
     link_redisearch_c_bundle(&bin_root).unwrap_or_else(|e| panic!("{e}"));
+    let mkl_linked = link_mkl(&bin_root.join("_deps/svs-src/lib"));
     // Cargo's `-l` flags precede the rlibs; re-scan the bundle after them. GNU ld reads
     // each archive once, so group it there with the system libs its members need.
     let gnu_ld = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string()) != "macos";
@@ -159,13 +160,18 @@ pub fn bind_foreign_c_symbols() {
         println!("cargo::rustc-link-arg=-Wl,--start-group");
     }
     println!("cargo::rustc-link-arg=-lredisearch_c_bundle");
+    if mkl_linked {
+        // The bundle holds the SVS members that call into MKL but not MKL itself, so this
+        // pass can reference it after its own `-l` flag was already scanned. Their
+        // references run both ways, which the surrounding group resolves.
+        println!("cargo::rustc-link-arg=-lmkl_static_library");
+    }
     if gnu_ld {
         println!("cargo::rustc-link-arg=-lstdc++");
         println!("cargo::rustc-link-arg=-lpthread");
         println!("cargo::rustc-link-arg=-lc");
         println!("cargo::rustc-link-arg=-Wl,--end-group");
     }
-    link_mkl(&bin_root.join("_deps/svs-src/lib"));
     link_c_plusplus();
 }
 
@@ -254,12 +260,19 @@ pub fn link_redisearch_c_bundle(bin_root: &Path) -> Result<PathBuf, Box<dyn std:
 /// `svs_lib_dir` is the directory that contains `libmkl_static_library.a`.
 /// Its location varies across build configurations, so callers are responsible
 /// for supplying the correct path.
-pub fn link_mkl(svs_lib_dir: &Path) {
+///
+/// Returns whether the archive was found and linked. It is absent whenever SVS was
+/// built without the Intel optimisation, so callers that reference MKL again — e.g.
+/// through a raw link argument — must gate on this rather than assume it is there.
+pub fn link_mkl(svs_lib_dir: &Path) -> bool {
     let mkl = svs_lib_dir.join("libmkl_static_library.a");
     if std::fs::exists(&mkl).unwrap_or(false) {
         println!("cargo::rerun-if-changed={}", mkl.display());
         println!("cargo::rustc-link-search=native={}", svs_lib_dir.display());
         println!("cargo::rustc-link-lib=static:-bundle=mkl_static_library");
+        true
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
A static archive only yields members that resolve symbols already undefined when the linker reaches it, and Cargo emits `-l` flags before the rlibs.

A dependency referencing a bundle symbol that nothing required earlier was therefore left unresolved, so the top_k, vector_score_source, and numeric_score_source test targets failed to link.

Adding a second link pass allows the linker to find those symbols, the group allows to better handle (complex or circular) dependencies.

- spotted in https://github.com/RediSearch/RediSearch/pull/10950


Running `cargo nextest run -p vector_score_source` was failing to link due to unresolved functions `document_metadata`, `sdslen_rust`...

other crates than top_k were also affected: `query`, `query_eval`, `rlookup`, `reducers`, `result_processor`, `rs_token`, `search_disk`...

- fixed by added a late `rustc-link-arg=-lredisearch_c_bundle` in the build script.

Then other crates were not linking either when running in isolation
- `tag_index` and benchers.

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
