### PR TITLE
[MOD-17973] rqe_iterators_test_utils: add tag-evaluation test helpers

### DIFF
--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -29,7 +29,7 @@ use rqe_core::DocId;
 use rqe_iterators::{
     RQEIterator, ResumeOutcome, TypeErasedRQEIterator, TypeErasedRQESuspendedIterator,
 };
-pub use test_context::{GlobalGuard, TestContext};
+pub use test_context::{GlobalGuard, TestContext, with_c_globals_locked};
 
 /// Drive `it` from its current position to exhaustion, asserting that it
 /// upholds the contract on [`current`](RQEIterator::current) and

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -1150,6 +1150,39 @@ impl TestContext {
         ttl.add(doc_id, fe);
     }
 
+    /// Replace the [`IteratorsConfig`] that [`qctx`](TestContext::qctx) exposes
+    /// as `QueryEvalCtx.config`.
+    ///
+    /// Allocates the `QueryEvalCtx` if it does not exist yet, so a later call
+    /// to [`qctx`](TestContext::qctx) returns one already carrying the override.
+    pub fn set_iterators_config(&mut self, config: IteratorsConfig) {
+        // Ensure the `QueryEvalCtx` (and its `config` allocation) exists before
+        // overwriting it.
+        self.qctx();
+        let alloc = self.qctx.get_mut().expect("qctx() just initialised this");
+        // SAFETY: `alloc.config` was allocated by `Box::into_raw` in `qctx()`
+        // and is exclusively owned by this `TestContext`.
+        unsafe { *alloc.config = config };
+    }
+
+    /// Set the deadline and the skip flag in `sctx->time`.
+    ///
+    /// `timeout` is an absolute `CLOCK_MONOTONIC_RAW` deadline, matching
+    /// `updateTime` and `TimedOut`. `{0, 0}` disables it only for the Rust
+    /// trie-iterator timeout probe (what these tests exercise) — `TimedOut`
+    /// and [`duration_from_redis_timespec`](rqe_iterators::utils::duration_from_redis_timespec)
+    /// read it as already expired instead, since their "no timeout" sentinel
+    /// is a value near `time_t::MAX`. `skip_checks` sets `skipTimeoutChecks`,
+    /// which stops consumers installing the deadline at all — it wins over a
+    /// deadline that has already passed.
+    pub const fn set_search_time(&mut self, timeout: ffi::timespec, skip_checks: bool) {
+        // SAFETY: `self.sctx` is a valid, exclusively-owned `RedisSearchCtx`.
+        unsafe {
+            self.sctx.as_mut().time.timeout = timeout;
+            self.sctx.as_mut().time.skipTimeoutChecks = skip_checks;
+        }
+    }
+
     /// Mark the given field of the given documents as expired.
     ///
     /// Sets the field expiration time to the past and the current query time
@@ -1252,6 +1285,19 @@ impl Drop for TestContext {
             ffi::Indexes_RemoveSpecFromGlobals(guard.own_ref(), false);
         }
     }
+}
+
+/// Run `f` holding the lock the [`TestContext`] constructors take around C
+/// global state, for a test that builds C structures of its own — an
+/// [`ffi::TagIndex`] whose id comes from a plain non-atomic global, say.
+///
+/// The lock is not reentrant: call this *after* the constructor has
+/// returned, never around one — and never let `f` own and drop a
+/// [`TestContext`], whose [`Drop`] takes this same lock and would
+/// self-deadlock the calling thread rather than merely fail.
+pub fn with_c_globals_locked<T>(f: impl FnOnce() -> T) -> T {
+    let _lock = CONTEXT_MUTEX.lock().unwrap();
+    f()
 }
 
 /// Guard object that manages globally allocated resources.

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -1296,8 +1296,10 @@ impl Drop for TestContext {
 /// [`TestContext`], whose [`Drop`] takes this same lock and would
 /// self-deadlock the calling thread rather than merely fail.
 pub fn with_c_globals_locked<T>(f: impl FnOnce() -> T) -> T {
-    let _lock = CONTEXT_MUTEX.lock().unwrap();
-    f()
+    let lock = CONTEXT_MUTEX.lock().unwrap();
+    let res = f();
+    drop(lock);
+    res
 }
 
 /// Guard object that manages globally allocated resources.


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `TestContext` (`rqe_iterators_test_utils`) has no way to override
   the C evaluator's `IteratorsConfig` (`minTermPrefix`/`maxPrefixExpansions`)
   or the search deadline (`sctx->time`) from a test, and no lock a test can
   take to build its own C structures (e.g. a `TagIndex`) outside a
   constructor.
2. Change: adds `TestContext::set_iterators_config`, `TestContext::set_search_time`
   (a `const fn`), and the free function `with_c_globals_locked`, which reuses
   the same mutex `TestContext`'s own constructors already serialise C
   global-state access on.
3. Outcome: internal-only — no user-visible or API change. These are
   test-only helpers, split out of the `Query_EvalTagNode` characterisation-test
   PR (#11037) so each piece can be reviewed independently. The characterisation
   tests that exercise them land in a follow-up PR stacked on top of this one.

#### Which additional issues this PR fixes

1. MOD-17876

#### Main objects this PR modified

1. `rqe_iterators_test_utils/src/test_context.rs` — `TestContext::set_iterators_config`, `set_search_time`, and the new `with_c_globals_locked` function.
2. `rqe_iterators_test_utils/src/lib.rs` — re-exports `with_c_globals_locked`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
