### PR TITLE
[MOD-15812] Narrow request-timeout condition signals

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1173,7 +1173,8 @@ bool QueryRequest_TryOwnStrictRead(QueryRequest *request, QueryRequestStrictRead
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
   pthread_mutex_lock(&req->base.async.aggregateResultsLock);
   req->base.async.aggregateResultsDone = true;
-  pthread_cond_broadcast(&req->base.async.aggregateResultsCond);
+  // A request has at most one timeout callback waiting for its aggregate worker.
+  pthread_cond_signal(&req->base.async.aggregateResultsCond);
   pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 

--- a/src/coord/rmr/chan.c
+++ b/src/coord/rmr/chan.c
@@ -87,7 +87,8 @@ void MRChannel_Push(MRChannel *chan, void *ptr) {
     chan->head = chan->tail = item;
   }
   chan->size++;
-  pthread_cond_broadcast(&chan->cond);
+  // Each channel has a single consumer, so a push wakes at most one waiter.
+  pthread_cond_signal(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
 }
 
@@ -187,7 +188,8 @@ aborted:
 
 void MRChannel_WakeAbort(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
-  pthread_cond_broadcast(&chan->cond);
+  // Only the channel's single consumer can be waiting to observe the abort.
+  pthread_cond_signal(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
 }
 

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -247,7 +247,8 @@ bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
 void MRCtx_SignalReducerComplete(struct MRCtx *ctx) {
   pthread_mutex_lock(&ctx->reducingLock);
   ctx->reducerDone = true;
-  pthread_cond_broadcast(&ctx->reducingCond);
+  // A context has at most one main-thread waiter for reducer completion.
+  pthread_cond_signal(&ctx->reducingCond);
   pthread_mutex_unlock(&ctx->reducingLock);
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Request-timeout synchronization wakes all potential condition-variable waiters even where the owning object permits only one waiter.
2. Change: Single-waiter request, reducer, and MapReduce channel notifications now wake one thread.
3. Outcome: Internal-only synchronization micro-optimization; command behavior, replies, and persistence remain unchanged.

#### Which additional issues this PR fixes

1. https://redislabs.atlassian.net/browse/MOD-15812

#### Main objects this PR modified

1. MapReduce channels — wake their sole consumer.
2. Aggregate result completion — notify the single timeout waiter.
3. Coordinator reducer completion — notify the single main-thread waiter.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
