### PR TITLE
[MOD-17730] Remove flaky slow-query search-timeout=0 test

### DIFF
--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -242,42 +242,6 @@ def testModuleLoadexRuntimeStillRejectsMaxSearchResultsNegativeTwo():
 
 
 @skip(cluster=True, redis_less_than='8.0')
-def testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery():
-    """search-timeout 0, set via the native CONFIG SET path, must mean a
-    genuinely slow query runs to completion with no timeout warning, while
-    the same query trips a tiny nonzero timeout."""
-    env = Env(protocol=3)
-    conn = getConnectionByEnv(env)
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-
-    # doc:0 matches '-common' immediately; the run of 'common' docs after it
-    # forces the NOT iterator to scan past all of them before reaching the
-    # trailing rare doc, giving the query real work to do against a 1ms timeout.
-    skipped = 300_000
-    with conn.pipeline(transaction=False) as p:
-        p.execute_command('HSET', 'doc:0', 't', 'rare')
-        for i in range(1, skipped + 1):
-            p.execute_command('HSET', f'doc:{i}', 't', 'common')
-        p.execute_command('HSET', f'doc:{skipped + 1}', 't', 'rare')
-        p.execute()
-
-    # Sanity control: a tiny nonzero timeout on this scan must time out.
-    env.expect('CONFIG', 'SET', 'search-timeout', '1').ok()
-    res = env.cmd('FT.AGGREGATE', 'idx', '-common', 'GROUPBY', '1', '@t', 'REDUCE', 'COUNT', '0', 'AS', 'count')
-    env.assertTrue(res.get('warning'), message=f"expected a timeout warning as a sanity control, got {res}")
-
-    # search-timeout 0 must mean the identical query runs to completion with
-    # no timeout warning.
-    env.expect('CONFIG', 'SET', 'search-timeout', '0').ok()
-    res = env.cmd('FT.AGGREGATE', 'idx', '-common', 'GROUPBY', '1', '@t', 'REDUCE', 'COUNT', '0', 'AS', 'count')
-    env.assertEqual(res.get('warning', []), [],
-                     message=f"expected no timeout warning with search-timeout 0, got {res}")
-    # '-common' excludes every 'common' doc, leaving only the 2 'rare' docs -
-    # skipped is the scan cost, not the match count.
-    env.assertEqual(int(res['results'][0]['extra_attributes']['count']), 2)
-
-
-@skip(cluster=True, redis_less_than='8.0')
 def testConfigRewriteRoundTripSearchTimeoutZero():
     """CONFIG SET search-timeout 0, CONFIG REWRITE, restart: the rewritten
     config file must re-apply 0 at genuine startup, not just in the live


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery` (added in #10997) builds its corpus with a single non-transactional pipeline of 300,002 `HSET` commands before running any query. On a slower or busier CI runner that send exceeds the test timeout, and the test has since failed this way on the 8.8-rse backport.
2. Change: removes that one test. Nothing else in the file changes.
3. Outcome: internal-only, test suite becomes faster and less flaky. The behavior it targeted (search-timeout=0 meaning no timeout) is close to tautological, since `updateTime` in `src/redis_index.c` maps 0 to `INT32_MAX` milliseconds rather than skipping the check. The config round trip stays covered cheaply: `test_config.py`'s `numericConfigs` loop for native `CONFIG SET`/`GET` of `search-timeout 0`, `test_max_timeout_limit.py` for the legacy `_FT.CONFIG SET TIMEOUT 0` path, and this same file's remaining startup test asserting a config file with `search-timeout 0` boots and reads back `0`.

#### Which additional issues this PR fixes

1. MOD-17730
2. Follow-up to #10997

#### Main objects this PR modified

1. `tests/pytests/test_config_native_startup_bounds.py` - removed `testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes