### PR TITLE
[MOD-17994] Include Rust panic payload and location in the crash report

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -305,6 +305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1423,7 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "redis-module",
  "tracing",
  "tracing_redismodule",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -191,6 +191,9 @@ cargo_metadata = "0.19"
 bytecount = "0.6.9"
 cc = "1.2.53"
 cheadergen = { version = "0.3.2" }
+# `default-features = false` drops the `clock` feature, whose `iana-time-zone`
+# dependency we do not need: timestamps are formatted as UTC, never local time.
+chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
 crc32fast = "1.5.0"
 criterion = { version = "0.8.1", features = ["html_reports"] }
 csv = "1.4.0"

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
@@ -6,9 +6,8 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
-# This crate has no tests nor benches.
-# Compiling a no-op bench/test binary can cause linking issues with C.
-test = false
+# This crate has no benches.
+# Compiling a no-op bench binary can cause linking issues with C.
 bench = false
 
 [dependencies]

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 bench = false
 
 [dependencies]
+chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
 redis-module.workspace = true
 tracing = { workspace = true }
 tracing_redismodule.workspace = true

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 bench = false
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
+chrono.workspace = true
 redis-module.workspace = true
 tracing = { workspace = true }
 tracing_redismodule.workspace = true

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -7,8 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ffi::{CStr, c_char};
+use std::ffi::{CStr, CString, c_char};
 use std::ptr::NonNull;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::level_filters::LevelFilter;
 
 /// Parses a redis `loglevel` config value into a `tracing` level.
@@ -66,9 +68,65 @@ pub unsafe extern "C" fn TracingRedisModule_SetLogLevel(level: *const c_char) {
     tracing_redismodule::set_log_level(level);
 }
 
+/// Details of a Rust panic, stashed by the hook installed in
+/// [`RustPanicHook_Init`] and emitted inside the crash report by
+/// [`AddToInfo_RustBacktrace`].
+///
+/// Strings are stored as-is, without truncation. `payload` and `location`
+/// match the rendering of the hook's `tracing::error!` log line: the literal
+/// `None` for a non-string payload or a missing location. `timestamp` is
+/// captured at hook time, in the [`format_epoch_timestamp`] format.
+#[derive(Clone)]
+struct StashedPanic {
+    payload: String,
+    location: String,
+    timestamp: String,
+}
+
+/// A first-write-wins slot for the details of the process' first Rust panic.
+///
+/// The panic hook fires twice per crash: for the real panic, then for the
+/// nested "panic in a function that cannot unwind" panic at the `extern "C"`
+/// boundary. First-write-wins preserves the real panic's details. In
+/// production every panic is fatal, so a stashed panic can never go stale.
+struct PanicStash(Mutex<Option<StashedPanic>>);
+
+impl PanicStash {
+    const fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    /// Stores `panic` if no panic was stashed before; otherwise drops it.
+    fn stash(&self, panic: StashedPanic) {
+        // Tolerate poisoning: this runs from the panic hook, which must not
+        // itself panic, and the stashed value stays consistent either way.
+        let mut slot = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot.is_none() {
+            *slot = Some(panic);
+        }
+    }
+
+    /// A copy of the stashed panic details, or `None` if no panic was stashed.
+    fn get(&self) -> Option<StashedPanic> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+/// The process-wide [`PanicStash`], written by the hook installed in
+/// [`RustPanicHook_Init`] and read by [`AddToInfo_RustBacktrace`].
+static PANIC_STASH: PanicStash = PanicStash::new();
+
 /// Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
 ///
-/// Panic messages will be logged through `tracing` at the `ERROR` level.
+/// Panic messages will be logged through `tracing` at the `ERROR` level, and
+/// stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+/// the crash report.
 #[unsafe(no_mangle)]
 pub extern "C" fn RustPanicHook_Init() {
     let previous_hook = std::panic::take_hook();
@@ -82,34 +140,71 @@ pub extern "C" fn RustPanicHook_Init() {
             "A panic occurred in the Rust code",
         );
 
+        // The log line above lands above the crash report's START marker,
+        // outside the span users are asked to copy; the stash rides the
+        // module INFO callback instead, which runs inside the report.
+        PANIC_STASH.stash(StashedPanic {
+            payload: panic_info.payload_as_str().unwrap_or("None").to_owned(),
+            location: panic_info
+                .location()
+                .map_or_else(|| "None".to_owned(), |l| l.to_string()),
+            timestamp: format_utc_timestamp(SystemTime::now()),
+        });
+
         // Invoke the previous panic hook, if any.
         previous_hook(panic_info);
     }));
 }
-/// Add the current backtrace as a new section to the report printed
-/// by RediSearch's INFO command.
+
+/// Formats `now` in the [`format_epoch_timestamp`] format.
+fn format_utc_timestamp(now: SystemTime) -> String {
+    let secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    format_epoch_timestamp(secs)
+}
+
+/// Formats seconds since the Unix epoch as `YYYY-MM-DD HH:MM:SS UTC`:
+/// ISO-8601 with a space separator, seconds precision, literal ` UTC` suffix.
+fn format_epoch_timestamp(secs: u64) -> String {
+    const SECS_PER_DAY: u64 = 24 * 60 * 60;
+    let days = (secs / SECS_PER_DAY) as i64;
+    let secs_of_day = secs % SECS_PER_DAY;
+    let (year, month, day) = civil_from_days(days);
+    format!(
+        "{year:04}-{month:02}-{day:02} {:02}:{:02}:{:02} UTC",
+        secs_of_day / 3600,
+        secs_of_day % 3600 / 60,
+        secs_of_day % 60,
+    )
+}
+
+/// The proleptic Gregorian date `(year, month, day)` falling `days` days
+/// after 1970-01-01, via Howard Hinnant's `civil_from_days` algorithm.
+const fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let days = days + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let day_of_era = (days - era * 146_097) as u64;
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era as i64 + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * month_prime + 2) / 5 + 1) as u32;
+    let month = (if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    }) as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+/// Converts `value` into the null-terminated C string expected by the
+/// `RedisModule_Info*` functions.
 ///
-/// # Safety
-///
-/// `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
-#[unsafe(no_mangle)]
-pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::RedisModuleInfoCtx>>) {
-    use std::ffi::CString;
-
-    let Some(ctx) = ctx else {
-        return;
-    };
-
-    let backtrace = std::backtrace::Backtrace::force_capture();
-    let backtrace_str = backtrace.to_string();
-
-    // The `RedisModule_Info*` functions we need to invoke expect a valid C string.
-    // We need to ensure that the backtrace we printed doesn't contain any null bytes and
-    // is properly null-terminated.
-    //
-    // For perf purposes, we strive to avoid allocating a new string if possible—i.e.
-    // if the formatted backtrace string doesn't contain any null bytes.
-    let backtrace_cstr = match CString::new(backtrace_str) {
+/// For perf purposes, we strive to avoid allocating a new string if
+/// possible—i.e. if `value` doesn't contain any null bytes. Interior null
+/// bytes are replaced with `?`.
+fn info_cstring(value: String) -> CString {
+    match CString::new(value) {
         Ok(cstr) => cstr,
         Err(err) => {
             let mut bytes = err.into_vec();
@@ -121,7 +216,25 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
             // SAFETY: We just replaced all null bytes with '?'.
             unsafe { CString::from_vec_unchecked(bytes) }
         }
+    }
+}
+
+/// Add the current backtrace as a new section to the report printed
+/// by RediSearch's INFO command.
+///
+/// When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+/// in the same section, ahead of the backtrace.
+///
+/// # Safety
+///
+/// `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
+#[unsafe(no_mangle)]
+pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::RedisModuleInfoCtx>>) {
+    let Some(ctx) = ctx else {
+        return;
     };
+
+    let backtrace_cstr = info_cstring(std::backtrace::Backtrace::force_capture().to_string());
 
     // SAFETY: `RedisModule_InfoAddSection` has been initialized during module load.
     let info_add_section = unsafe { redis_module::RedisModule_InfoAddSection.unwrap() };
@@ -130,6 +243,88 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
 
     // SAFETY: `ctx` is a valid pointer to a `RedisModuleInfoCtx`.
     unsafe { info_add_section(ctx.as_ptr(), c"rust_backtrace".as_ptr()) };
+
+    if let Some(stashed) = PANIC_STASH.get() {
+        let payload = info_cstring(stashed.payload);
+        let location = info_cstring(stashed.location);
+        let timestamp = info_cstring(stashed.timestamp);
+        // SAFETY: `ctx` is a valid pointer and `payload` is a valid null-terminated C string.
+        unsafe {
+            info_add_field_cstring(ctx.as_ptr(), c"panic_payload".as_ptr(), payload.as_ptr())
+        };
+        // SAFETY: `ctx` is a valid pointer and `location` is a valid null-terminated C string.
+        unsafe {
+            info_add_field_cstring(ctx.as_ptr(), c"panic_location".as_ptr(), location.as_ptr())
+        };
+        // SAFETY: `ctx` is a valid pointer and `timestamp` is a valid null-terminated C string.
+        unsafe {
+            info_add_field_cstring(
+                ctx.as_ptr(),
+                c"panic_timestamp".as_ptr(),
+                timestamp.as_ptr(),
+            )
+        };
+    }
+
     // SAFETY: `ctx` is a valid pointer and `backtrace_cstr` is a valid null-terminated C string.
     unsafe { info_add_field_cstring(ctx.as_ptr(), c"backtrace".as_ptr(), backtrace_cstr.as_ptr()) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stashed_panic(payload: &str) -> StashedPanic {
+        StashedPanic {
+            payload: payload.to_owned(),
+            location: "src/crash.rs:1:1".to_owned(),
+            timestamp: "2026-01-01 00:00:00 UTC".to_owned(),
+        }
+    }
+
+    // The hook fires twice per crash (the real panic, then the nested
+    // "cannot unwind" panic at the `extern "C"` boundary): the stash must
+    // keep the first panic's details.
+    #[test]
+    fn stash_is_first_write_wins() {
+        let stash = PanicStash::new();
+        assert!(stash.get().is_none());
+
+        stash.stash(stashed_panic("first"));
+        stash.stash(stashed_panic("second"));
+
+        assert_eq!(
+            stash.get().as_ref().map(|s| s.payload.as_str()),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn epoch_seconds_format_as_utc_civil_time() {
+        assert_eq!(format_epoch_timestamp(0), "1970-01-01 00:00:00 UTC");
+        assert_eq!(
+            format_epoch_timestamp(1_000_000_000),
+            "2001-09-09 01:46:40 UTC"
+        );
+        // 2024 is a leap year.
+        assert_eq!(
+            format_epoch_timestamp(1_709_164_800),
+            "2024-02-29 00:00:00 UTC"
+        );
+        // 2100 is divisible by 100 but not by 400: not a leap year.
+        assert_eq!(
+            format_epoch_timestamp(4_102_444_800),
+            "2100-01-01 00:00:00 UTC"
+        );
+        assert_eq!(
+            format_epoch_timestamp(253_402_300_799),
+            "9999-12-31 23:59:59 UTC"
+        );
+    }
+
+    #[test]
+    fn info_cstring_replaces_interior_null_bytes() {
+        assert_eq!(info_cstring("a\0b".to_owned()).to_bytes(), b"a?b");
+        assert_eq!(info_cstring("clean".to_owned()).to_bytes(), b"clean");
+    }
 }

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -75,14 +75,14 @@ pub unsafe extern "C" fn TracingRedisModule_SetLogLevel(level: *const c_char) {
 /// Strings are stored as-is, without truncation. `payload` and `location`
 /// match the rendering of the hook's `tracing::error!` log line: the literal
 /// `None` for a non-string payload or a missing location. `recorded_at` is
-/// captured at hook time, in the [`format_utc_timestamp`] format.
+/// captured at hook time by [`format_utc_timestamp`].
 ///
 /// The stash outlives the panic: a panic crossing an `extern "C"` boundary
 /// aborts right away, but a panic that unwinds and is caught, or one on a
 /// Rust-only thread, leaves the stash populated until a later, possibly
-/// unrelated crash — where it reads as that crash's cause. `recorded_at`
-/// lets the reader tell the two apart by comparing it against the crash log
-/// line's own timestamp prefix.
+/// unrelated crash, where it reads as that crash's cause. `recorded_at` lets
+/// the reader tell the two apart by comparing it against the crash log line's
+/// own timestamp prefix.
 struct StashedPanic {
     payload: String,
     location: String,
@@ -99,7 +99,7 @@ struct StashedPanic {
 /// panic at the `extern "C"` boundary), and the second `set` is dropped.
 static PANIC_STASH: OnceLock<StashedPanic> = OnceLock::new();
 
-/// Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+/// Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
 ///
 /// Panic messages will be logged through `tracing` at the `ERROR` level, and
 /// stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
@@ -120,7 +120,6 @@ pub extern "C" fn RustPanicHook_Init() {
         // The log line above lands above the crash report's START marker,
         // outside the span users are asked to copy; the stash rides the
         // module INFO callback instead, which runs inside the report.
-        // A failed `set` means a panic was already stashed — first-write-wins.
         let _ = PANIC_STASH.set(StashedPanic {
             payload: panic_info.payload_as_str().unwrap_or("None").to_owned(),
             location: panic_info
@@ -134,8 +133,7 @@ pub extern "C" fn RustPanicHook_Init() {
     }));
 }
 
-/// Formats `now` as `YYYY-MM-DD HH:MM:SS UTC`: ISO-8601 with a space
-/// separator, seconds precision, literal ` UTC` suffix.
+/// Formats `now` as `YYYY-MM-DD HH:MM:SS UTC`.
 fn format_utc_timestamp(now: SystemTime) -> String {
     chrono::DateTime::<chrono::Utc>::from(now)
         .format("%Y-%m-%d %H:%M:%S UTC")
@@ -145,10 +143,10 @@ fn format_utc_timestamp(now: SystemTime) -> String {
 /// Converts `value` into the null-terminated C string expected by the
 /// `RedisModule_Info*` functions.
 ///
-/// For perf purposes, we strive to avoid allocating a new string if
-/// possible—i.e. if `value` doesn't contain any null bytes. Interior null
-/// bytes are replaced with `?`.
-fn info_cstring(value: String) -> CString {
+/// For perf purposes, we strive to avoid allocating a new buffer if possible,
+/// i.e. if `value` is already owned and doesn't contain any null bytes.
+/// Interior null bytes are replaced with `?`.
+fn info_cstring(value: impl Into<Vec<u8>>) -> CString {
     match CString::new(value) {
         Ok(cstr) => cstr,
         Err(err) => {
@@ -192,9 +190,9 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
     // `get` yields None if a crash races the first panic's `set`, losing the
     // fields rather than blocking the report.
     if let Some(stashed) = PANIC_STASH.get() {
-        let payload = info_cstring(stashed.payload.clone());
-        let location = info_cstring(stashed.location.clone());
-        let recorded_at = info_cstring(stashed.recorded_at.clone());
+        let payload = info_cstring(stashed.payload.as_str());
+        let location = info_cstring(stashed.location.as_str());
+        let recorded_at = info_cstring(stashed.recorded_at.as_str());
         // SAFETY: `ctx` is a valid pointer and `payload` is a valid null-terminated C string.
         unsafe {
             info_add_field_cstring(ctx.as_ptr(), c"panic_payload".as_ptr(), payload.as_ptr())
@@ -222,28 +220,6 @@ mod tests {
     use super::*;
     use std::time::{Duration, UNIX_EPOCH};
 
-    fn stashed_panic(payload: &str) -> StashedPanic {
-        StashedPanic {
-            payload: payload.to_owned(),
-            location: "src/crash.rs:1:1".to_owned(),
-            recorded_at: "2026-01-01 00:00:00 UTC".to_owned(),
-        }
-    }
-
-    // The hook fires twice per crash (the real panic, then the nested
-    // "cannot unwind" panic at the `extern "C"` boundary): the stash must
-    // keep the first panic's details.
-    #[test]
-    fn stash_is_first_write_wins() {
-        let stash: OnceLock<StashedPanic> = OnceLock::new();
-        assert!(stash.get().is_none());
-
-        let _ = stash.set(stashed_panic("first"));
-        let _ = stash.set(stashed_panic("second"));
-
-        assert_eq!(stash.get().map(|s| s.payload.as_str()), Some("first"));
-    }
-
     // Pins the crash-report timestamp format; the conversion itself is
     // chrono's.
     #[test]
@@ -257,7 +233,7 @@ mod tests {
 
     #[test]
     fn info_cstring_replaces_interior_null_bytes() {
-        assert_eq!(info_cstring("a\0b".to_owned()).to_bytes(), b"a?b");
-        assert_eq!(info_cstring("clean".to_owned()).to_bytes(), b"clean");
+        assert_eq!(info_cstring("a\0b").to_bytes(), b"a?b");
+        assert_eq!(info_cstring("clean").to_bytes(), b"clean");
     }
 }

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -9,8 +9,8 @@
 
 use std::ffi::{CStr, CString, c_char};
 use std::ptr::NonNull;
-use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::OnceLock;
+use std::time::SystemTime;
 use tracing::level_filters::LevelFilter;
 
 /// Parses a redis `loglevel` config value into a `tracing` level.
@@ -74,53 +74,30 @@ pub unsafe extern "C" fn TracingRedisModule_SetLogLevel(level: *const c_char) {
 ///
 /// Strings are stored as-is, without truncation. `payload` and `location`
 /// match the rendering of the hook's `tracing::error!` log line: the literal
-/// `None` for a non-string payload or a missing location. `timestamp` is
-/// captured at hook time, in the [`format_epoch_timestamp`] format.
-#[derive(Clone)]
+/// `None` for a non-string payload or a missing location. `recorded_at` is
+/// captured at hook time, in the [`format_utc_timestamp`] format.
+///
+/// The stash outlives the panic: a panic crossing an `extern "C"` boundary
+/// aborts right away, but a panic that unwinds and is caught, or one on a
+/// Rust-only thread, leaves the stash populated until a later, possibly
+/// unrelated crash — where it reads as that crash's cause. `recorded_at`
+/// lets the reader tell the two apart by comparing it against the crash log
+/// line's own timestamp prefix.
 struct StashedPanic {
     payload: String,
     location: String,
-    timestamp: String,
+    recorded_at: String,
 }
 
-/// A first-write-wins slot for the details of the process' first Rust panic.
-///
-/// The panic hook fires twice per crash: for the real panic, then for the
-/// nested "panic in a function that cannot unwind" panic at the `extern "C"`
-/// boundary. First-write-wins preserves the real panic's details. In
-/// production every panic is fatal, so a stashed panic can never go stale.
-struct PanicStash(Mutex<Option<StashedPanic>>);
-
-impl PanicStash {
-    const fn new() -> Self {
-        Self(Mutex::new(None))
-    }
-
-    /// Stores `panic` if no panic was stashed before; otherwise drops it.
-    fn stash(&self, panic: StashedPanic) {
-        // Tolerate poisoning: this runs from the panic hook, which must not
-        // itself panic, and the stashed value stays consistent either way.
-        let mut slot = self
-            .0
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if slot.is_none() {
-            *slot = Some(panic);
-        }
-    }
-
-    /// A copy of the stashed panic details, or `None` if no panic was stashed.
-    fn get(&self) -> Option<StashedPanic> {
-        self.0
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
-    }
-}
-
-/// The process-wide [`PanicStash`], written by the hook installed in
+/// The process-wide stash, written by the hook installed in
 /// [`RustPanicHook_Init`] and read by [`AddToInfo_RustBacktrace`].
-static PANIC_STASH: PanicStash = PanicStash::new();
+///
+/// A [`OnceLock`] rather than a mutex: [`AddToInfo_RustBacktrace`] runs from
+/// Redis's fatal signal handler, where pthread_mutex_lock is not
+/// async-signal-safe. First-write-wins: the hook fires twice per crash (the
+/// real panic, then the nested "panic in a function that cannot unwind"
+/// panic at the `extern "C"` boundary), and the second `set` is dropped.
+static PANIC_STASH: OnceLock<StashedPanic> = OnceLock::new();
 
 /// Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
 ///
@@ -143,12 +120,13 @@ pub extern "C" fn RustPanicHook_Init() {
         // The log line above lands above the crash report's START marker,
         // outside the span users are asked to copy; the stash rides the
         // module INFO callback instead, which runs inside the report.
-        PANIC_STASH.stash(StashedPanic {
+        // A failed `set` means a panic was already stashed — first-write-wins.
+        let _ = PANIC_STASH.set(StashedPanic {
             payload: panic_info.payload_as_str().unwrap_or("None").to_owned(),
             location: panic_info
                 .location()
                 .map_or_else(|| "None".to_owned(), |l| l.to_string()),
-            timestamp: format_utc_timestamp(SystemTime::now()),
+            recorded_at: format_utc_timestamp(SystemTime::now()),
         });
 
         // Invoke the previous panic hook, if any.
@@ -156,45 +134,12 @@ pub extern "C" fn RustPanicHook_Init() {
     }));
 }
 
-/// Formats `now` in the [`format_epoch_timestamp`] format.
+/// Formats `now` as `YYYY-MM-DD HH:MM:SS UTC`: ISO-8601 with a space
+/// separator, seconds precision, literal ` UTC` suffix.
 fn format_utc_timestamp(now: SystemTime) -> String {
-    let secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    format_epoch_timestamp(secs)
-}
-
-/// Formats seconds since the Unix epoch as `YYYY-MM-DD HH:MM:SS UTC`:
-/// ISO-8601 with a space separator, seconds precision, literal ` UTC` suffix.
-fn format_epoch_timestamp(secs: u64) -> String {
-    const SECS_PER_DAY: u64 = 24 * 60 * 60;
-    let days = (secs / SECS_PER_DAY) as i64;
-    let secs_of_day = secs % SECS_PER_DAY;
-    let (year, month, day) = civil_from_days(days);
-    format!(
-        "{year:04}-{month:02}-{day:02} {:02}:{:02}:{:02} UTC",
-        secs_of_day / 3600,
-        secs_of_day % 3600 / 60,
-        secs_of_day % 60,
-    )
-}
-
-/// The proleptic Gregorian date `(year, month, day)` falling `days` days
-/// after 1970-01-01, via Howard Hinnant's `civil_from_days` algorithm.
-const fn civil_from_days(days: i64) -> (i64, u32, u32) {
-    let days = days + 719_468;
-    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
-    let day_of_era = (days - era * 146_097) as u64;
-    let year_of_era =
-        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
-    let year = year_of_era as i64 + era * 400;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let month_prime = (5 * day_of_year + 2) / 153;
-    let day = (day_of_year - (153 * month_prime + 2) / 5 + 1) as u32;
-    let month = (if month_prime < 10 {
-        month_prime + 3
-    } else {
-        month_prime - 9
-    }) as u32;
-    (if month <= 2 { year + 1 } else { year }, month, day)
+    chrono::DateTime::<chrono::Utc>::from(now)
+        .format("%Y-%m-%d %H:%M:%S UTC")
+        .to_string()
 }
 
 /// Converts `value` into the null-terminated C string expected by the
@@ -244,10 +189,12 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
     // SAFETY: `ctx` is a valid pointer to a `RedisModuleInfoCtx`.
     unsafe { info_add_section(ctx.as_ptr(), c"rust_backtrace".as_ptr()) };
 
+    // `get` yields None if a crash races the first panic's `set`, losing the
+    // fields rather than blocking the report.
     if let Some(stashed) = PANIC_STASH.get() {
-        let payload = info_cstring(stashed.payload);
-        let location = info_cstring(stashed.location);
-        let timestamp = info_cstring(stashed.timestamp);
+        let payload = info_cstring(stashed.payload.clone());
+        let location = info_cstring(stashed.location.clone());
+        let recorded_at = info_cstring(stashed.recorded_at.clone());
         // SAFETY: `ctx` is a valid pointer and `payload` is a valid null-terminated C string.
         unsafe {
             info_add_field_cstring(ctx.as_ptr(), c"panic_payload".as_ptr(), payload.as_ptr())
@@ -256,12 +203,12 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
         unsafe {
             info_add_field_cstring(ctx.as_ptr(), c"panic_location".as_ptr(), location.as_ptr())
         };
-        // SAFETY: `ctx` is a valid pointer and `timestamp` is a valid null-terminated C string.
+        // SAFETY: `ctx` is a valid pointer and `recorded_at` is a valid null-terminated C string.
         unsafe {
             info_add_field_cstring(
                 ctx.as_ptr(),
-                c"panic_timestamp".as_ptr(),
-                timestamp.as_ptr(),
+                c"panic_recorded_at".as_ptr(),
+                recorded_at.as_ptr(),
             )
         };
     }
@@ -273,12 +220,13 @@ pub extern "C" fn AddToInfo_RustBacktrace(ctx: Option<NonNull<redis_module::Redi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, UNIX_EPOCH};
 
     fn stashed_panic(payload: &str) -> StashedPanic {
         StashedPanic {
             payload: payload.to_owned(),
             location: "src/crash.rs:1:1".to_owned(),
-            timestamp: "2026-01-01 00:00:00 UTC".to_owned(),
+            recorded_at: "2026-01-01 00:00:00 UTC".to_owned(),
         }
     }
 
@@ -287,38 +235,23 @@ mod tests {
     // keep the first panic's details.
     #[test]
     fn stash_is_first_write_wins() {
-        let stash = PanicStash::new();
+        let stash: OnceLock<StashedPanic> = OnceLock::new();
         assert!(stash.get().is_none());
 
-        stash.stash(stashed_panic("first"));
-        stash.stash(stashed_panic("second"));
+        let _ = stash.set(stashed_panic("first"));
+        let _ = stash.set(stashed_panic("second"));
 
-        assert_eq!(
-            stash.get().as_ref().map(|s| s.payload.as_str()),
-            Some("first")
-        );
+        assert_eq!(stash.get().map(|s| s.payload.as_str()), Some("first"));
     }
 
+    // Pins the crash-report timestamp format; the conversion itself is
+    // chrono's.
     #[test]
-    fn epoch_seconds_format_as_utc_civil_time() {
-        assert_eq!(format_epoch_timestamp(0), "1970-01-01 00:00:00 UTC");
+    fn formats_timestamp_as_utc() {
+        assert_eq!(format_utc_timestamp(UNIX_EPOCH), "1970-01-01 00:00:00 UTC");
         assert_eq!(
-            format_epoch_timestamp(1_000_000_000),
+            format_utc_timestamp(UNIX_EPOCH + Duration::from_secs(1_000_000_000)),
             "2001-09-09 01:46:40 UTC"
-        );
-        // 2024 is a leap year.
-        assert_eq!(
-            format_epoch_timestamp(1_709_164_800),
-            "2024-02-29 00:00:00 UTC"
-        );
-        // 2100 is divisible by 100 but not by 400: not a leap year.
-        assert_eq!(
-            format_epoch_timestamp(4_102_444_800),
-            "2100-01-01 00:00:00 UTC"
-        );
-        assert_eq!(
-            format_epoch_timestamp(253_402_300_799),
-            "9999-12-31 23:59:59 UTC"
         );
     }
 

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -31,7 +31,7 @@ extern "C" {
 void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
 
 /**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ * Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
  *
  * Panic messages will be logged through `tracing` at the `ERROR` level, and
  * stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -21,6 +21,9 @@ extern "C" {
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
  *
+ * When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+ * in the same section, ahead of the backtrace.
+ *
  * # Safety
  *
  * `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
@@ -30,7 +33,9 @@ void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
 /**
  * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
  *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
+ * Panic messages will be logged through `tracing` at the `ERROR` level, and
+ * stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+ * the crash report.
  */
 void RustPanicHook_Init(void);
 

--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -21,7 +21,47 @@ def prepare_index(env, terms=["hello"], doc_count=10):
         env.cmd("HSET", f"doc{i}", "text", " ".join(terms))
     waitForIndex(env, "idx")
 
-def extract_query_crash_output(env, expected_fragments, doc_count=10, crash_in_rust=False):
+# Redis brackets the crash report with these markers; only the lines between
+# them are copied when users paste a bug report.
+BUG_REPORT_START_MARKER = "=== REDIS BUG REPORT START"
+BUG_REPORT_END_MARKER = "=== REDIS BUG REPORT END"
+
+
+def log_file_path(env):
+    """Path to the server's log file. Requires a live server, so resolve it
+    before triggering a crash."""
+    logDir = env.cmd("config", "get", "dir")[1]
+    logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
+    return os.path.join(logDir, logFileName)
+
+
+def read_log_lines(path):
+    # A crash report can carry raw memory bytes, so the log is not necessarily
+    # valid UTF-8. The fragments asserted on are ASCII, so decode lossily.
+    with open(path, encoding="utf-8", errors="replace") as logFile:
+        return logFile.readlines()
+
+
+def bug_report_span(lines):
+    """The lines strictly between the bug-report START and END markers.
+
+    Returns [] when either marker is missing, so span-restricted assertions
+    fail rather than silently passing against the wrong lines.
+    """
+    start = next((i for i, line in enumerate(lines) if BUG_REPORT_START_MARKER in line), None)
+    if start is None:
+        return []
+    end = next(
+        (i for i, line in enumerate(lines) if i > start and BUG_REPORT_END_MARKER in line),
+        None,
+    )
+    if end is None:
+        return []
+    return lines[start + 1:end]
+
+
+def extract_query_crash_output(env, expected_fragments, doc_count=10, crash_in_rust=False,
+                               crash_report_only=False):
     """
     Extract values for each fragment from the crash log, checking they appear in order.
 
@@ -29,45 +69,46 @@ def extract_query_crash_output(env, expected_fragments, doc_count=10, crash_in_r
         env: Test environment
         expected_fragments: List of field names/fragments to extract in order (e.g., "search_num_docs:")
         crash_in_rust: Whether to crash in Rust code
+        crash_report_only: Restrict the scan to the bug-report span (between the
+            START and END markers) — the part of the log users are asked to copy
 
     Returns:
         Dictionary mapping fragment to extracted value (or None if not found)
         Fragments must appear in the order specified in expected_fragments
     """
-    logDir = env.cmd("config", "get", "dir")[1]
-    logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
-    logFilePath = os.path.join(logDir, logFileName)
+    logFilePath = log_file_path(env)
     runDebugQueryCommandAndCrash(
         env, ["FT.SEARCH", "idx", "*"], crash_in_rust=crash_in_rust
     )
+
+    lines = read_log_lines(logFilePath)
+    if crash_report_only:
+        lines = bug_report_span(lines)
 
     # Initialize result dictionary with None for all fragments
     results = {fragment: None for fragment in expected_fragments}
     pos = 0  # Track position in expected_fragments to enforce ordering
 
-    # A crash report can carry raw memory bytes, so the log is not necessarily
-    # valid UTF-8. The fragments below are ASCII, so decode lossily.
-    with open(logFilePath, encoding="utf-8", errors="replace") as logFile:
-        for line in logFile:
-            # Only look for the next expected fragment (enforces ordering)
-            if pos < len(expected_fragments):
-                fragment = expected_fragments[pos]
-                if fragment in line:
-                    # Extract the value after the fragment
-                    idx = line.find(fragment)
-                    if idx != -1:
-                        # Get the part after the fragment
-                        value_part = line[idx + len(fragment):].strip()
-                        # If there's a value after the colon, extract it
-                        if value_part:
-                            # Remove trailing comments or newlines
-                            value_part = value_part.split('#')[0].strip()
-                            results[fragment] = value_part if value_part else line.strip()
-                        else:
-                            # Just mark that we found the fragment (e.g., section headers)
-                            results[fragment] = line.strip()
-                    # Move to next fragment
-                    pos += 1
+    for line in lines:
+        # Only look for the next expected fragment (enforces ordering)
+        if pos < len(expected_fragments):
+            fragment = expected_fragments[pos]
+            if fragment in line:
+                # Extract the value after the fragment
+                idx = line.find(fragment)
+                if idx != -1:
+                    # Get the part after the fragment
+                    value_part = line[idx + len(fragment):].strip()
+                    # If there's a value after the colon, extract it
+                    if value_part:
+                        # Remove trailing comments or newlines
+                        value_part = value_part.split('#')[0].strip()
+                        results[fragment] = value_part if value_part else line.strip()
+                    else:
+                        # Just mark that we found the fragment (e.g., section headers)
+                        results[fragment] = line.strip()
+                # Move to next fragment
+                pos += 1
 
     return results
 
@@ -123,8 +164,10 @@ def test_query_thread_crash():
     env.assertGreater(run_time, 0)
 
 
-# we expect to see the Rust panic information in the crash report,
-# alongside the index information
+# The Rust panic hook logs before Redis prints the bug report, so scanning the
+# whole log would find the panic payload even when it is missing from the
+# report itself. Assert against the START..END span — the part users are asked
+# to paste into a bug report.
 @skip(cluster=True)
 def test_query_thread_crash_with_rust_panic():
     env = CrashingEnv(testName="test_query_thread_crash_with_rust_panic", freshEnv=True)
@@ -132,12 +175,14 @@ def test_query_thread_crash_with_rust_panic():
     doc_count = 10
     terms = ['hello', 'world']
     prepare_index(env, terms, doc_count=doc_count)
+
+    # Resolve the log path before the crash — the server is unreachable afterwards.
+    log_path = log_file_path(env)
+
     results = extract_query_crash_output(
         env,
         doc_count=doc_count,
         expected_fragments=[
-            # The panic message
-            'A panic occurred in the Rust code panic.payload="Crash in Rust code"',
             "search_current_thread",
             "search_run_time_ns:",
             # Index name is now a section header
@@ -148,15 +193,36 @@ def test_query_thread_crash_with_rust_panic():
             "# search_rust_backtrace",
         ],
         crash_in_rust=True,
+        crash_report_only=True,
     )
 
     # Verify all fragments were found
     for fragment, value in results.items():
         env.assertIsNotNone(value, message=f"Fragment '{fragment}' not found in crash log")
 
-    # Verify the panic location is present (the value after the panic.payload fragment)
-    env.assertIn("panic.location=", results['A panic occurred in the Rust code panic.payload="Crash in Rust code"'])
-    env.assertIn("crash.rs", results['A panic occurred in the Rust code panic.payload="Crash in Rust code"'])
+    # The panic payload and location must appear inside the bug-report span,
+    # not just in the log. Assert on content, not format — the section/field
+    # names used to emit them are an implementation detail of the fix.
+    log_lines = read_log_lines(log_path)
+    report_lines = bug_report_span(log_lines)
+    env.assertTrue(
+        any("Crash in Rust code" in line for line in report_lines),
+        message="panic payload not found inside the bug report (START..END span)",
+    )
+    env.assertTrue(
+        any("crash.rs" in line for line in report_lines),
+        message="panic location not found inside the bug report (START..END span)",
+    )
+
+    # The panic hook's tracing line predates the report and stays in the log;
+    # it is not a substitute for the in-report fields asserted above.
+    env.assertTrue(
+        any(
+            'A panic occurred in the Rust code panic.payload="Crash in Rust code"' in line
+            for line in log_lines
+        ),
+        message="panic hook tracing line missing from the log",
+    )
 
     # Verify index stats for empty index
     env.assertEqual(results["search_number_of_docs:"], f"{doc_count}")

--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -231,16 +231,18 @@ def test_query_thread_crash_with_rust_panic():
     )
     env.assertIn("crash.rs", location_line)
 
-    timestamp_line = next((l for l in report_lines if "search_panic_timestamp:" in l), None)
+    recorded_at_line = next(
+        (l for l in report_lines if "search_panic_recorded_at:" in l), None
+    )
     env.assertIsNotNone(
-        timestamp_line, message="search_panic_timestamp missing from the bug report"
+        recorded_at_line, message="search_panic_recorded_at missing from the bug report"
     )
     env.assertTrue(
         re.search(
-            r"search_panic_timestamp:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC",
-            timestamp_line,
+            r"search_panic_recorded_at:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC",
+            recorded_at_line,
         ),
-        message=f"unexpected search_panic_timestamp format: {timestamp_line}",
+        message=f"unexpected search_panic_recorded_at format: {recorded_at_line}",
     )
 
     # The panic hook's tracing line predates the report and stays in the log;

--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -46,8 +46,11 @@ def read_log_lines(path):
 def bug_report_span(lines):
     """The lines strictly between the bug-report START and END markers.
 
-    Returns [] when either marker is missing, so span-restricted assertions
-    fail rather than silently passing against the wrong lines.
+    Returns [] when the START marker is missing, so span-restricted assertions
+    fail rather than silently passing against the wrong lines. A missing END
+    marker means the crash handler died mid-report — sanitizer builds truncate
+    the report during its slow memory-test phase — so the span then runs to
+    the end of the log.
     """
     start = next((i for i, line in enumerate(lines) if BUG_REPORT_START_MARKER in line), None)
     if start is None:
@@ -57,7 +60,7 @@ def bug_report_span(lines):
         None,
     )
     if end is None:
-        return []
+        return lines[start + 1:]
     return lines[start + 1:end]
 
 

--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -1,4 +1,5 @@
 from common import *
+import re
 
 
 # EnterpriseStandaloneEnvBase (not RLTest.Env) so this still gets enterprise
@@ -121,6 +122,10 @@ def test_query_thread_crash():
     doc_count = 10
     terms = ['hello', 'world']
     prepare_index(env, terms=terms, doc_count=doc_count)
+
+    # Resolve the log path before the crash — the server is unreachable afterwards.
+    log_path = log_file_path(env)
+
     results = extract_query_crash_output(env, doc_count=doc_count, expected_fragments=[
         "search_current_thread",
         "search_run_time_ns:",
@@ -163,6 +168,14 @@ def test_query_thread_crash():
     run_time = int(results["search_run_time_ns:"])
     env.assertGreater(run_time, 0)
 
+    # A C crash stashes no Rust panic, so the bug report must not carry
+    # Rust-panic fields.
+    report_lines = bug_report_span(read_log_lines(log_path))
+    env.assertFalse(
+        any("search_panic_payload" in line for line in report_lines),
+        message="search_panic_payload found in the bug report of a C crash",
+    )
+
 
 # The Rust panic hook logs before Redis prints the bug report, so scanning the
 # whole log would find the panic payload even when it is missing from the
@@ -200,18 +213,34 @@ def test_query_thread_crash_with_rust_panic():
     for fragment, value in results.items():
         env.assertIsNotNone(value, message=f"Fragment '{fragment}' not found in crash log")
 
-    # The panic payload and location must appear inside the bug-report span,
-    # not just in the log. Assert on content, not format — the section/field
-    # names used to emit them are an implementation detail of the fix.
+    # The panic details must be emitted as INFO fields inside the bug-report
+    # span — the hook's tracing line is not enough, since it lands above the
+    # START marker.
     log_lines = read_log_lines(log_path)
     report_lines = bug_report_span(log_lines)
-    env.assertTrue(
-        any("Crash in Rust code" in line for line in report_lines),
-        message="panic payload not found inside the bug report (START..END span)",
+
+    payload_line = next((l for l in report_lines if "search_panic_payload:" in l), None)
+    env.assertIsNotNone(
+        payload_line, message="search_panic_payload missing from the bug report"
+    )
+    env.assertIn("Crash in Rust code", payload_line)
+
+    location_line = next((l for l in report_lines if "search_panic_location:" in l), None)
+    env.assertIsNotNone(
+        location_line, message="search_panic_location missing from the bug report"
+    )
+    env.assertIn("crash.rs", location_line)
+
+    timestamp_line = next((l for l in report_lines if "search_panic_timestamp:" in l), None)
+    env.assertIsNotNone(
+        timestamp_line, message="search_panic_timestamp missing from the bug report"
     )
     env.assertTrue(
-        any("crash.rs" in line for line in report_lines),
-        message="panic location not found inside the bug report (START..END span)",
+        re.search(
+            r"search_panic_timestamp:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC",
+            timestamp_line,
+        ),
+        message=f"unexpected search_panic_timestamp format: {timestamp_line}",
     )
 
     # The panic hook's tracing line predates the report and stays in the log;

--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -48,9 +48,9 @@ def bug_report_span(lines):
 
     Returns [] when the START marker is missing, so span-restricted assertions
     fail rather than silently passing against the wrong lines. A missing END
-    marker means the crash handler died mid-report — sanitizer builds truncate
-    the report during its slow memory-test phase — so the span then runs to
-    the end of the log.
+    marker means the crash handler died mid-report (sanitizer builds truncate
+    the report during its slow memory-test phase), so the span then runs to the
+    end of the log.
     """
     start = next((i for i, line in enumerate(lines) if BUG_REPORT_START_MARKER in line), None)
     if start is None:
@@ -73,8 +73,8 @@ def extract_query_crash_output(env, expected_fragments, doc_count=10, crash_in_r
         env: Test environment
         expected_fragments: List of field names/fragments to extract in order (e.g., "search_num_docs:")
         crash_in_rust: Whether to crash in Rust code
-        crash_report_only: Restrict the scan to the bug-report span (between the
-            START and END markers) — the part of the log users are asked to copy
+        crash_report_only: Restrict the scan to `bug_report_span`, the part of
+            the log users are asked to copy
 
     Returns:
         Dictionary mapping fragment to extracted value (or None if not found)
@@ -126,7 +126,7 @@ def test_query_thread_crash():
     terms = ['hello', 'world']
     prepare_index(env, terms=terms, doc_count=doc_count)
 
-    # Resolve the log path before the crash — the server is unreachable afterwards.
+    # Resolve the log path before the crash: the server is unreachable afterwards.
     log_path = log_file_path(env)
 
     results = extract_query_crash_output(env, doc_count=doc_count, expected_fragments=[
@@ -146,8 +146,6 @@ def test_query_thread_crash():
     for fragment, value in results.items():
         env.assertIsNotNone(value, message=f"Fragment '{fragment}' not found in crash log")
 
-    # Verify specific values
-    # Empty index should have 0 documents
     env.assertEqual(results["search_number_of_docs:"], f"{doc_count}")
 
     # Verify index_properties contains expected fields
@@ -174,15 +172,17 @@ def test_query_thread_crash():
     # A C crash stashes no Rust panic, so the bug report must not carry
     # Rust-panic fields.
     report_lines = bug_report_span(read_log_lines(log_path))
-    env.assertFalse(
-        any("search_panic_payload" in line for line in report_lines),
-        message="search_panic_payload found in the bug report of a C crash",
-    )
+    for field in ("search_panic_payload", "search_panic_location",
+                  "search_panic_recorded_at"):
+        env.assertFalse(
+            any(field in line for line in report_lines),
+            message=f"{field} found in the bug report of a C crash",
+        )
 
 
 # The Rust panic hook logs before Redis prints the bug report, so scanning the
 # whole log would find the panic payload even when it is missing from the
-# report itself. Assert against the START..END span — the part users are asked
+# report itself. Assert against the START..END span, the part users are asked
 # to paste into a bug report.
 @skip(cluster=True)
 def test_query_thread_crash_with_rust_panic():
@@ -192,7 +192,7 @@ def test_query_thread_crash_with_rust_panic():
     terms = ['hello', 'world']
     prepare_index(env, terms, doc_count=doc_count)
 
-    # Resolve the log path before the crash — the server is unreachable afterwards.
+    # Resolve the log path before the crash: the server is unreachable afterwards.
     log_path = log_file_path(env)
 
     results = extract_query_crash_output(
@@ -217,7 +217,7 @@ def test_query_thread_crash_with_rust_panic():
         env.assertIsNotNone(value, message=f"Fragment '{fragment}' not found in crash log")
 
     # The panic details must be emitted as INFO fields inside the bug-report
-    # span — the hook's tracing line is not enough, since it lands above the
+    # span: the hook's tracing line is not enough, since it lands above the
     # START marker.
     log_lines = read_log_lines(log_path)
     report_lines = bug_report_span(log_lines)
@@ -258,7 +258,6 @@ def test_query_thread_crash_with_rust_panic():
         message="panic hook tracing line missing from the log",
     )
 
-    # Verify index stats for empty index
     env.assertEqual(results["search_number_of_docs:"], f"{doc_count}")
 
     # Verify index_properties_in_mb contains inverted_size and it's > 0


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: When Rust code panics, the panic hook logs `panic.payload`/`panic.location` via `tracing::error!` before the process aborts — so the line lands in the log *above* the `=== REDIS BUG REPORT START ===` marker. Users and tooling copy only the START–END span, so the payload is effectively missing from crash reports (see [MOD-13507](https://redislabs.atlassian.net/browse/MOD-13507)); on a live case this cost a customer round trip because MOD-17877 and the already-fixed MOD-16877 could not be told apart.
2. Change: The panic hook now also stashes payload, location, and a UTC timestamp (first-write-wins via `OnceLock`, so the nested "cannot unwind" panic can't overwrite the real payload, and the signal-handler read never takes a lock), and the crash-report INFO callback emits them as `search_panic_payload` / `search_panic_location` / `search_panic_recorded_at` fields inside the existing `# search_rust_backtrace` section, ahead of the backtrace. The pre-crash log line is kept. The crash flow test now asserts these fields inside the START–END span, and the C-crash test asserts they are absent there.
3. Outcome: Crash reports pasted from START to END now include the Rust panic payload and location. Plain C crashes produce no panic fields (no stale output). No reply-shape, config, or default changes.

#### Which additional issues this PR fixes

1. MOD-13507

#### Main objects this PR modified

1. `module_init_ffi` (Rust) — panic stash in the hook (first-write-wins, hook-time timestamp) and emission of the `search_panic_*` fields in the crash-report section; `AddToInfo_RustBacktrace`'s exported signature is unchanged, so no C or header changes.
2. `tests/pytests/test_crash.py` — crash-log extraction can restrict to the START–END bug-report span; Rust-panic test asserts the exact fields there, C-crash test asserts their absence.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


[MOD-13507]: https://redislabs.atlassian.net/browse/MOD-13507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ