### PR TITLE
[Top K] isolate profile counters behaviour and unify it.

### DIFF
--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -159,8 +159,9 @@ pub struct NumericScoreSource<
     heap_old_size: usize,
     /// Number of expand-and-retry iterations performed so far.
     num_iterations: usize,
-    /// Number of value-ordered range batches materialized so far, surfaced as
-    /// the `Batches number` profile metric. Reset on rewind.
+    /// Number of value-ordered range batches materialized so far, the
+    /// source-side counterpart of the `Batches number` profile metric. Reset by
+    /// [`reset_profile`](ScoreSource::reset_profile).
     num_batches: usize,
     /// Document-level validity oracle: drops records for doc ids it reports
     /// invalid (deleted or whole-doc expired) before they reach the top-k heap.
@@ -488,10 +489,13 @@ impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext> ScoreSourc
         self.window = self.initial_window;
         self.last_limit_estimate = self.initial_window.limit;
         self.num_iterations = 0;
-        self.num_batches = 0;
         self.heap_old_size = 0;
         self.ranges.forget_emitted();
         self.ranges.refind(&self.filter, self.window);
+    }
+
+    fn reset_profile(&mut self) {
+        self.num_batches = 0;
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -801,8 +801,11 @@ fn profile_reports_batches_read_before_a_timeout() {
 
     let metrics = *it.metrics();
     assert!(metrics.num_batches > 0, "timeout fired mid-collection");
-    // The source-local counter is what the profile used to read.
-    assert_eq!(it.source().num_batches(), 0, "abort path reset the source");
+    assert_eq!(
+        it.source().num_batches(),
+        metrics.num_batches,
+        "the abort path rewinds the source without clearing its counter"
+    );
 
     let reply = render_profile(&it);
     assert_eq!(

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -598,6 +598,10 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         self.results.clear();
         *self.current = None;
         self.metrics = TopKMetrics::default();
+        // The source keeps its own profile counters, which `rewind` deliberately
+        // preserves for the abort path in `collect`. An explicit rewind starts a
+        // fresh evaluation, so clear them alongside ours.
+        self.source.reset_profile();
         self.source.rewind();
         if let Some(child) = &mut self.child {
             child.rewind();
@@ -784,9 +788,11 @@ pub trait TopKSourceProfile {
     /// the source renders the same iterator it read through — and thus the
     /// child's real read counts — rather than an unprofiled side handle.
     ///
-    /// Prefer `metrics` over any source-local equivalent: it spans the whole
-    /// evaluation, whereas a source counter is cleared by every mid-evaluation
-    /// source reset, including the one on the timeout path.
+    /// `metrics` carries what the iterator counts for every source; a source's
+    /// own fields carry what only it can measure, such as a requested batch
+    /// size. Both span one evaluation: cleared on an explicit rewind (see
+    /// [`ScoreSource::reset_profile`]), preserved across the reset that discards
+    /// an aborted collection.
     fn print_profile(
         &self,
         mode: TopKMode,

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -206,6 +206,8 @@ impl ScoreSource for MockScoreSource {
         self.batch_pos = 0;
     }
 
+    fn reset_profile(&mut self) {}
+
     fn build_result<'r>(&self, doc_id: DocId, _score: f64) -> RSIndexResult<'r>
     where
         Self: 'r,

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -191,7 +191,25 @@ pub trait ScoreSource {
     fn num_estimated(&self) -> usize;
 
     /// Rewind the source to its initial state so batch iteration can restart.
+    ///
+    /// Leaves any profile counters the source keeps untouched: [`TopKIterator`]
+    /// also rewinds when it discards a partially collected scan, whose profile
+    /// still has to report the work that scan did. Clearing them is
+    /// [`reset_profile`](Self::reset_profile)'s job.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
     fn rewind(&mut self);
+
+    /// Clear the profile counters the source keeps, so the next evaluation
+    /// reports only its own work.
+    ///
+    /// Called by [`TopKIterator`]'s [`RQEIterator::rewind`] implementation, and
+    /// only from there. A source that keeps no counters of its own implements
+    /// this as a no-op.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    /// [`RQEIterator::rewind`]: rqe_iterators::RQEIterator::rewind
+    fn reset_profile(&mut self);
 
     /// Build the [`RSIndexResult`] that the [`TopKIterator`] will yield for a
     /// given `(doc_id, score)` pair.

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -65,6 +65,8 @@ impl ScoreSource for CallCountingScoreSource {
 
     fn rewind(&mut self) {}
 
+    fn reset_profile(&mut self) {}
+
     fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
     where
         Self: 'r,

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -27,8 +27,13 @@ use top_k::{
 
 /// [`ScoreSource`] whose [`ScoreSource::next_batch`] unconditionally returns [`RQEIteratorError::TimedOut`].
 ///
-/// Used to verify that timeout errors propagate correctly through [`TopKIterator`].
-struct TimingOutSource;
+/// Used to verify that timeout errors propagate correctly through
+/// [`TopKIterator`], and which resets it asks of the source afterwards.
+#[derive(Default)]
+struct TimingOutSource {
+    rewinds: u32,
+    profile_resets: u32,
+}
 
 impl ScoreSource for TimingOutSource {
     type Batch = MockScoreBatch;
@@ -45,7 +50,13 @@ impl ScoreSource for TimingOutSource {
         0
     }
 
-    fn rewind(&mut self) {}
+    fn rewind(&mut self) {
+        self.rewinds += 1;
+    }
+
+    fn reset_profile(&mut self) {
+        self.profile_resets += 1;
+    }
 
     fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
     where
@@ -251,7 +262,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
 #[test]
 fn unfiltered_timeout_propagated() {
     let mut it = ContractChecker::new_unordered(TopKIterator::new_unfiltered(
-        TimingOutSource,
+        TimingOutSource::default(),
         NonZeroUsize::new(5).unwrap(),
         asc,
     ));
@@ -259,6 +270,27 @@ fn unfiltered_timeout_propagated() {
         it.read().unwrap_err(),
         rqe_iterators::RQEIteratorError::TimedOut
     ));
+}
+
+/// The iterator rewinds the source on two occasions with opposite profile
+/// intent: discarding an aborted collection, whose counters must survive so a
+/// timed-out profile still reports the work that run did, and an explicit
+/// rewind, which starts a fresh evaluation. Only the latter resets the profile.
+#[test]
+fn only_explicit_rewind_resets_source_profile() {
+    let mut it = TopKIterator::new_unfiltered(
+        TimingOutSource::default(),
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+    );
+
+    assert!(it.read().is_err());
+    let after_abort = (it.source().rewinds, it.source().profile_resets);
+
+    it.rewind();
+
+    assert_eq!(after_abort, (1, 0));
+    assert_eq!((it.source().rewinds, it.source().profile_resets), (2, 1));
 }
 
 // ── Batches intersection ──────────────────────────────────────────────────
@@ -587,6 +619,8 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             self.rewind_count += 1;
         }
 
+        fn reset_profile(&mut self) {}
+
         fn lookup_score(&mut self, _: DocId) -> Option<f64> {
             Some(10f64)
         }
@@ -820,6 +854,7 @@ fn adhoc_timeout_propagated() {
         fn rewind(&mut self) {
             self.adhoc_calls = 0;
         }
+        fn reset_profile(&mut self) {}
         fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
         where
             Self: 'r,

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -168,11 +168,11 @@ impl<E: ExpirationChecker> TopKSourceProfile for VectorScoreSource<'_, E> {
         let is_batch_mode = matches!(mode, TopKMode::Batches | TopKMode::ForcedBatches)
             || (matches!(mode, TopKMode::AdhocBF) && switches > 0);
         if is_batch_mode {
-            map.kv_long_long(c"Batches number", self.num_iterations as i64);
-            map.kv_long_long(c"Largest batch size", self.max_batch_size as i64);
+            map.kv_long_long(c"Batches number", self.profile.num_iterations as i64);
+            map.kv_long_long(c"Largest batch size", self.profile.max_batch_size as i64);
             map.kv_long_long(
                 c"Largest batch iteration (zero based)",
-                self.max_batch_iteration as i64,
+                self.profile.max_batch_iteration as i64,
             );
         }
 

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -91,14 +91,16 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// and reads the `timeoutCtx` referent, the `timeout_ctx` field, dropped no
     /// earlier than this iterator.
     batch_iter: Option<BatchIterator<'index, 'index>>,
-    /// Number of batches consumed over the whole evaluation.
+    /// Number of batches consumed over the whole evaluation. Reset by
+    /// [`ScoreSource::reset_profile`].
     pub num_iterations: usize,
-    /// Largest batch size used over the whole evaluation; only ever grows. Read
-    /// by the profile printer.
+    /// Largest batch size used over the whole evaluation; only ever grows within
+    /// it. Read by the profile printer. Reset by
+    /// [`ScoreSource::reset_profile`].
     pub max_batch_size: usize,
     /// Zero-based iteration index at which the current
     /// [`max_batch_size`](Self::max_batch_size) was reached.
-    /// Read by the profile printer.
+    /// Read by the profile printer. Reset by [`ScoreSource::reset_profile`].
     pub max_batch_iteration: usize,
     /// Rolling estimate of how many child docs pass the filter; seeded from
     /// [`initial_child_num_estimated`](Self::initial_child_num_estimated) and
@@ -451,15 +453,19 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         self.k.min(self.index_size())
     }
 
-    /// Restarts the scan from the beginning. The profile counters are
-    /// evaluation-scoped and left untouched: this also runs when the iterator
-    /// discards a partially collected scan, whose profile still has to report
-    /// the batches that scan consumed.
+    /// Restarts the scan from the beginning, leaving the batch counters for
+    /// [`reset_profile`](ScoreSource::reset_profile) to clear.
     fn rewind(&mut self) {
         self.batch_iter = None;
         self.k_remaining = self.k;
         self.child_num_estimated = self.initial_child_num_estimated;
         self.unfiltered_consumed = false;
+    }
+
+    fn reset_profile(&mut self) {
+        self.num_iterations = 0;
+        self.max_batch_size = 0;
+        self.max_batch_iteration = 0;
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
@@ -722,6 +728,37 @@ mod tests {
         source.next_batch().unwrap();
         assert_eq!(source.max_batch_size, grown_size, "re-seed only raises");
         assert_eq!(source.num_iterations, 3, "batches keep accumulating");
+
+        drop(source);
+        // SAFETY: no live references to the index remain.
+        unsafe { VecSimIndex_Free(index.as_ptr()) };
+    }
+
+    /// A fresh evaluation must report only its own batches, so `reset_profile`
+    /// clears every counter the profile printer reads — including the largest
+    /// batch and the iteration it was recorded at.
+    #[test]
+    #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+    fn reset_profile_clears_batch_metrics() {
+        let index = build_flat_index(20, 1);
+        // SAFETY: index is freed after the source is dropped at end of scope.
+        let mut source = unsafe { flat_source(index, 3, 20) };
+
+        // Two batches, the second computed larger, so every counter is non-zero.
+        source.next_batch().unwrap();
+        source.child_num_estimated = 5;
+        source.next_batch().unwrap();
+        assert_eq!(source.max_batch_iteration, 1, "the maximum moved off zero");
+
+        source.reset_profile();
+        assert_eq!(
+            (
+                source.num_iterations,
+                source.max_batch_size,
+                source.max_batch_iteration
+            ),
+            (0, 0, 0)
+        );
 
         drop(source);
         // SAFETY: no live references to the index remain.

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -49,6 +49,22 @@ enum AdhocPathState<'index> {
     },
 }
 
+/// Batch statistics of one evaluation, rendered by the profile printer.
+///
+/// Cleared as a whole by [`ScoreSource::reset_profile`], so a counter added here
+/// is covered by that reset without further wiring.
+#[derive(Default)]
+pub(crate) struct BatchProfile {
+    /// Number of batches consumed, including one cut short by a timeout.
+    pub(crate) num_iterations: usize,
+    /// Largest batch size used; only ever grows within an evaluation, so a scan
+    /// restarted mid-evaluation cannot lower it.
+    pub(crate) max_batch_size: usize,
+    /// Zero-based iteration index at which the current
+    /// [`max_batch_size`](Self::max_batch_size) was reached.
+    pub(crate) max_batch_iteration: usize,
+}
+
 /// A [`ScoreSource`] that drives top-k collection against a VecSim index.
 ///
 /// Two adhoc-BF execution paths are supported:
@@ -91,17 +107,9 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// and reads the `timeoutCtx` referent, the `timeout_ctx` field, dropped no
     /// earlier than this iterator.
     batch_iter: Option<BatchIterator<'index, 'index>>,
-    /// Number of batches consumed over the whole evaluation. Reset by
-    /// [`ScoreSource::reset_profile`].
-    pub num_iterations: usize,
-    /// Largest batch size used over the whole evaluation; only ever grows within
-    /// it. Read by the profile printer. Reset by
-    /// [`ScoreSource::reset_profile`].
-    pub max_batch_size: usize,
-    /// Zero-based iteration index at which the current
-    /// [`max_batch_size`](Self::max_batch_size) was reached.
-    /// Read by the profile printer. Reset by [`ScoreSource::reset_profile`].
-    pub max_batch_iteration: usize,
+    /// Counters the profile printer reads, holding no state the scan itself
+    /// depends on.
+    pub(crate) profile: BatchProfile,
     /// Rolling estimate of how many child docs pass the filter; seeded from
     /// [`initial_child_num_estimated`](Self::initial_child_num_estimated) and
     /// refined each batch. Reset on rewind.
@@ -204,9 +212,7 @@ impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
             should_rerank,
             batch_iter: None,
             fixed_batch_size,
-            num_iterations: 0,
-            max_batch_size: 0,
-            max_batch_iteration: 0,
+            profile: BatchProfile::default(),
             child_num_estimated,
             initial_child_num_estimated: child_num_estimated,
             k_remaining: k,
@@ -319,8 +325,7 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
             }
             // Seed the largest-batch tracker. A user-pinned size is constant, so
             // it is also the maximum; a dynamic size starts at 0 and grows below.
-            // Raise only, so a scan restarted mid-evaluation cannot lower it.
-            self.max_batch_size = self.max_batch_size.max(self.fixed_batch_size);
+            self.profile.max_batch_size = self.profile.max_batch_size.max(self.fixed_batch_size);
         }
 
         if !self
@@ -333,14 +338,14 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         }
 
         let batch_size = self.compute_next_batch_size();
-        self.num_iterations += 1;
+        self.profile.num_iterations += 1;
 
-        // Track the largest dynamically-computed batch and the (zero-based)
-        // iteration that produced it. A user-pinned size never varies, so the
-        // maximum stays at the seed above and the iteration index stays at 0.
-        if self.fixed_batch_size == 0 && batch_size.get() > self.max_batch_size {
-            self.max_batch_size = batch_size.get();
-            self.max_batch_iteration = self.num_iterations - 1;
+        // Track the largest dynamically-computed batch and the iteration that
+        // produced it. A user-pinned size never varies, so the maximum stays at
+        // the seed above and the iteration index stays at 0.
+        if self.fixed_batch_size == 0 && batch_size.get() > self.profile.max_batch_size {
+            self.profile.max_batch_size = batch_size.get();
+            self.profile.max_batch_iteration = self.profile.num_iterations - 1;
         }
 
         let batch_iter = self.batch_iter.as_mut().expect("just initialised above");
@@ -463,9 +468,7 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
     }
 
     fn reset_profile(&mut self) {
-        self.num_iterations = 0;
-        self.max_batch_size = 0;
-        self.max_batch_iteration = 0;
+        self.profile = BatchProfile::default();
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
@@ -702,10 +705,13 @@ mod tests {
         // drive two batches, shrinking the child estimate between them so
         // the second computed size is larger, then rewind.
         source.next_batch().unwrap();
-        let first = source.max_batch_size;
+        let first = source.profile.max_batch_size;
         source.child_num_estimated = 5;
         source.next_batch().unwrap();
-        let (grown_size, grown_iter) = (source.max_batch_size, source.max_batch_iteration);
+        let (grown_size, grown_iter) = (
+            source.profile.max_batch_size,
+            source.profile.max_batch_iteration,
+        );
         source.rewind();
 
         assert!(first > 0, "first batch seeds the maximum");
@@ -716,9 +722,9 @@ mod tests {
         assert_eq!(grown_iter, 1, "recorded at its iteration");
         assert_eq!(
             (
-                source.num_iterations,
-                source.max_batch_size,
-                source.max_batch_iteration
+                source.profile.num_iterations,
+                source.profile.max_batch_size,
+                source.profile.max_batch_iteration
             ),
             (2, grown_size, grown_iter),
             "rewind preserves the metrics"
@@ -726,8 +732,14 @@ mod tests {
 
         // The scan restarted by the rewind re-seeds the tracker without lowering it.
         source.next_batch().unwrap();
-        assert_eq!(source.max_batch_size, grown_size, "re-seed only raises");
-        assert_eq!(source.num_iterations, 3, "batches keep accumulating");
+        assert_eq!(
+            source.profile.max_batch_size, grown_size,
+            "re-seed only raises"
+        );
+        assert_eq!(
+            source.profile.num_iterations, 3,
+            "batches keep accumulating"
+        );
 
         drop(source);
         // SAFETY: no live references to the index remain.
@@ -748,14 +760,17 @@ mod tests {
         source.next_batch().unwrap();
         source.child_num_estimated = 5;
         source.next_batch().unwrap();
-        assert_eq!(source.max_batch_iteration, 1, "the maximum moved off zero");
+        assert_eq!(
+            source.profile.max_batch_iteration, 1,
+            "the maximum moved off zero"
+        );
 
         source.reset_profile();
         assert_eq!(
             (
-                source.num_iterations,
-                source.max_batch_size,
-                source.max_batch_iteration
+                source.profile.num_iterations,
+                source.profile.max_batch_size,
+                source.profile.max_batch_iteration
             ),
             (0, 0, 0)
         );


### PR DESCRIPTION

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
