### PR TITLE
[MOD-18017] Reduce replica stalls for FT.DROPINDEX DD

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -698,6 +698,40 @@ int CreateIndexIfNotExistsCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return CreateIndexCommand(ctx, argv, argc);
 }
 
+#define DROPINDEX_UNLINK_BATCH_SIZE 1024
+
+static void DropIndex_ReplicateDropIfExists(RedisModuleCtx *ctx, RedisModuleString *indexName) {
+  RedisModule_Replicate(ctx, CMD_FOR_ENV(RS_DROP_INDEX_IF_X_CMD), "sc", indexName,
+                        "_FORCEKEEPDOCS");
+}
+
+static void DropIndex_UnlinkKeyBatch(RedisModuleCtx *ctx, RedisModuleString **keys,
+                                     size_t *numKeys) {
+  if (*numKeys == 0) {
+    return;
+  }
+
+  Redis_UnlinkKeys(ctx, keys, *numKeys);
+  for (size_t i = 0; i < *numKeys; ++i) {
+    RedisModule_FreeString(ctx, keys[i]);
+  }
+  *numKeys = 0;
+}
+
+static void DropIndex_UnlinkDocumentKeys(RedisModuleCtx *ctx, DocTable *dt) {
+  RedisModuleString *keys[DROPINDEX_UNLINK_BATCH_SIZE];
+  size_t numKeys = 0;
+
+  DOCTABLE_FOREACH(dt, {
+    keys[numKeys++] = DMD_CreateKeyString(dmd, ctx);
+    if (numKeys == DROPINDEX_UNLINK_BATCH_SIZE) {
+      DropIndex_UnlinkKeyBatch(ctx, keys, &numKeys);
+    }
+  });
+
+  DropIndex_UnlinkKeyBatch(ctx, keys, &numKeys);
+}
+
 /*
  * FT.DROP <index> [KEEPDOCS]
  * FT.DROPINDEX <index> [DD]
@@ -774,8 +808,8 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     // delete key notification callbacks.
     Indexes_RemoveSpecFromGlobals(global_ref, false);
 
-    DocTable *dt = &sp->docs;
-    DOCTABLE_FOREACH(dt, Redis_DeleteKeyC(ctx, dmd->keyPtr));
+    DropIndex_ReplicateDropIfExists(ctx, argv[1]);
+    DropIndex_UnlinkDocumentKeys(ctx, &sp->docs);
 
     // Return call's references
     CurrentThread_ClearIndexSpec();
@@ -793,7 +827,9 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   RedisModule_Log(ctx, "notice", "Successfully dropped index %s", indexName);
   rm_free(indexName);
 
-  RedisModule_Replicate(ctx, CMD_FOR_ENV(RS_DROP_INDEX_IF_X_CMD), "sc", argv[1], "_FORCEKEEPDOCS");
+  if (dropMode == IndexDrop_KeepDocs) {
+    DropIndex_ReplicateDropIfExists(ctx, argv[1]);
+  }
 
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }

--- a/src/module.c
+++ b/src/module.c
@@ -699,8 +699,8 @@ int CreateIndexIfNotExistsCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 }
 
 static void DropIndex_ReplicateDropIfExists(RedisModuleCtx *ctx, RedisModuleString *indexName) {
-  RedisModule_Replicate(ctx, CMD_FOR_ENV(RS_DROP_INDEX_IF_X_CMD), "sc", indexName,
-                        "_FORCEKEEPDOCS");
+  const char *cmd = CMD_FOR_ENV(RS_DROP_INDEX_IF_X_CMD);
+  RedisModule_Replicate(ctx, cmd, "sc", indexName, "_FORCEKEEPDOCS");
 }
 
 static void DropIndex_UnlinkDocumentKeys(RedisModuleCtx *ctx, DocTable *dt) {
@@ -779,6 +779,8 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   sp->dropMode = dropMode;
 
+  DropIndex_ReplicateDropIfExists(ctx, argv[1]);
+
   if (sp->dropMode == IndexDrop_DeleteDocs) {
     // We take a strong reference to the index, so it will not be freed
     // and we can still use it's doc table to delete the keys.
@@ -787,7 +789,6 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     // delete key notification callbacks.
     Indexes_RemoveSpecFromGlobals(global_ref, false);
 
-    DropIndex_ReplicateDropIfExists(ctx, argv[1]);
     DropIndex_UnlinkDocumentKeys(ctx, &sp->docs);
 
     // Return call's references
@@ -805,10 +806,6 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // Log index deletion
   RedisModule_Log(ctx, "notice", "Successfully dropped index %s", indexName);
   rm_free(indexName);
-
-  if (dropMode == IndexDrop_KeepDocs) {
-    DropIndex_ReplicateDropIfExists(ctx, argv[1]);
-  }
 
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }

--- a/src/module.c
+++ b/src/module.c
@@ -704,11 +704,7 @@ static void DropIndex_ReplicateDropIfExists(RedisModuleCtx *ctx, RedisModuleStri
 }
 
 static void DropIndex_UnlinkDocumentKeys(RedisModuleCtx *ctx, DocTable *dt) {
-  DOCTABLE_FOREACH(dt, {
-    RedisModuleString *key = DMD_CreateKeyString(dmd, ctx);
-    Redis_UnlinkKey(ctx, key);
-    RedisModule_FreeString(ctx, key);
-  });
+  DOCTABLE_FOREACH(dt, Redis_UnlinkKeyC(ctx, dmd->keyPtr));
 }
 
 /*

--- a/src/module.c
+++ b/src/module.c
@@ -698,38 +698,17 @@ int CreateIndexIfNotExistsCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return CreateIndexCommand(ctx, argv, argc);
 }
 
-#define DROPINDEX_UNLINK_BATCH_SIZE 1024
-
 static void DropIndex_ReplicateDropIfExists(RedisModuleCtx *ctx, RedisModuleString *indexName) {
   RedisModule_Replicate(ctx, CMD_FOR_ENV(RS_DROP_INDEX_IF_X_CMD), "sc", indexName,
                         "_FORCEKEEPDOCS");
 }
 
-static void DropIndex_UnlinkKeyBatch(RedisModuleCtx *ctx, RedisModuleString **keys,
-                                     size_t *numKeys) {
-  if (*numKeys == 0) {
-    return;
-  }
-
-  Redis_UnlinkKeys(ctx, keys, *numKeys);
-  for (size_t i = 0; i < *numKeys; ++i) {
-    RedisModule_FreeString(ctx, keys[i]);
-  }
-  *numKeys = 0;
-}
-
 static void DropIndex_UnlinkDocumentKeys(RedisModuleCtx *ctx, DocTable *dt) {
-  RedisModuleString *keys[DROPINDEX_UNLINK_BATCH_SIZE];
-  size_t numKeys = 0;
-
   DOCTABLE_FOREACH(dt, {
-    keys[numKeys++] = DMD_CreateKeyString(dmd, ctx);
-    if (numKeys == DROPINDEX_UNLINK_BATCH_SIZE) {
-      DropIndex_UnlinkKeyBatch(ctx, keys, &numKeys);
-    }
+    RedisModuleString *key = DMD_CreateKeyString(dmd, ctx);
+    Redis_UnlinkKey(ctx, key);
+    RedisModule_FreeString(ctx, key);
   });
-
-  DropIndex_UnlinkKeyBatch(ctx, keys, &numKeys);
 }
 
 /*

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -317,12 +317,8 @@ int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s) {
   return res;
 }
 
-int Redis_UnlinkKeys(RedisModuleCtx *ctx, RedisModuleString **keys, size_t numKeys) {
-  if (numKeys == 0) {
-    return 0;
-  }
-
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "UNLINK", "!v", keys, numKeys);
+int Redis_UnlinkKey(RedisModuleCtx *ctx, RedisModuleString *key) {
+  RedisModuleCallReply *rep = RedisModule_Call(ctx, "UNLINK", "!s", key);
   RS_ASSERT(RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_INTEGER);
   long long res = RedisModule_CallReplyInteger(rep);
   RedisModule_FreeCallReply(rep);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -317,8 +317,8 @@ int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s) {
   return res;
 }
 
-int Redis_UnlinkKey(RedisModuleCtx *ctx, RedisModuleString *key) {
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "UNLINK", "!s", key);
+int Redis_UnlinkKeyC(RedisModuleCtx *ctx, char *cstr) {
+  RedisModuleCallReply *rep = RedisModule_Call(ctx, "UNLINK", "c!", cstr);
   RS_ASSERT(RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_INTEGER);
   long long res = RedisModule_CallReplyInteger(rep);
   RedisModule_FreeCallReply(rep);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -317,9 +317,12 @@ int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s) {
   return res;
 }
 
-int Redis_DeleteKeyC(RedisModuleCtx *ctx, char *cstr) {
-  // Send command and args to replicas and AOF
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "c!", cstr);
+int Redis_UnlinkKeys(RedisModuleCtx *ctx, RedisModuleString **keys, size_t numKeys) {
+  if (numKeys == 0) {
+    return 0;
+  }
+
+  RedisModuleCallReply *rep = RedisModule_Call(ctx, "UNLINK", "!v", keys, numKeys);
   RS_ASSERT(RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_INTEGER);
   long long res = RedisModule_CallReplyInteger(rep);
   RedisModule_FreeCallReply(rep);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -35,7 +35,7 @@ InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t
 #define CREATE_INDEX true
 
 int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s);
-int Redis_UnlinkKeys(RedisModuleCtx *ctx, RedisModuleString **keys, size_t numKeys);
+int Redis_UnlinkKey(RedisModuleCtx *ctx, RedisModuleString *key);
 
 /* Drop all the index's internal keys using this scan handler */
 int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -35,7 +35,7 @@ InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t
 #define CREATE_INDEX true
 
 int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s);
-int Redis_UnlinkKey(RedisModuleCtx *ctx, RedisModuleString *key);
+int Redis_UnlinkKeyC(RedisModuleCtx *ctx, char *cstr);
 
 /* Drop all the index's internal keys using this scan handler */
 int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -35,7 +35,7 @@ InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t
 #define CREATE_INDEX true
 
 int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s);
-int Redis_DeleteKeyC(RedisModuleCtx *ctx, char *cstr);
+int Redis_UnlinkKeys(RedisModuleCtx *ctx, RedisModuleString **keys, size_t numKeys);
 
 /* Drop all the index's internal keys using this scan handler */
 int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -57,6 +57,35 @@ def initEnv():
 
   return env
 
+def _decode_slowlog_arg(arg):
+  if isinstance(arg, bytes):
+    return arg.decode()
+  return str(arg)
+
+def _slowlog_entry_id_and_args(entry):
+  if isinstance(entry, dict):
+    command = entry['command']
+    entry_id = entry['id']
+  else:
+    command = entry[3]
+    entry_id = entry[0]
+
+  if isinstance(command, (bytes, str)):
+    return entry_id, _decode_slowlog_arg(command).split()
+
+  return entry_id, [_decode_slowlog_arg(arg) for arg in command]
+
+def _slowlog_commands(conn):
+  entries = conn.execute_command('SLOWLOG', 'GET', 128)
+  commands = [_slowlog_entry_id_and_args(entry) for entry in entries]
+  return [args for _, args in sorted(commands, key=lambda entry: entry[0])]
+
+def _config_get_value(conn, name):
+  res = conn.execute_command('CONFIG', 'GET', name)
+  if isinstance(res, dict):
+    return res[name]
+  return res[1]
+
 def testDelReplicate():
   env = initEnv()
   master = env.getConnection()
@@ -152,6 +181,51 @@ def testDropReplicate():
   slave_set = set(slave_keys)
   env.assertEqual(master_set.difference(slave_set), set([]))
   env.assertEqual(slave_set.difference(master_set), set([]))
+
+def testDropIndexDDReplicatesDropBeforeDocumentDeletes():
+  '''
+  DROPINDEX DD must replicate the internal index drop before document key deletion,
+  otherwise replicas deindex each deleted document while the index still exists.
+  '''
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
+  master.execute_command('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:', 'SCHEMA',
+                         't', 'TEXT')
+  for i in range(3):
+    master.execute_command('HSET', 'doc:%d' % i, 't', 'hello')
+
+  waitForIndex(env, 'idx')
+  env.assertEqual(master.execute_command('WAIT', '1', '10000'), 1)
+  checkSlaveSynced(env, slave, ('FT.SEARCH', 'idx', 'hello'), 3, time_out=20,
+                   mapping=lambda res: res[0])
+
+  old_slowlog_threshold = _config_get_value(slave, 'slowlog-log-slower-than')
+  try:
+    slave.execute_command('CONFIG', 'SET', 'slowlog-log-slower-than', '0')
+    slave.execute_command('SLOWLOG', 'RESET')
+
+    master.execute_command('FT.DROPINDEX', 'idx', 'DD')
+    env.assertEqual(master.execute_command('WAIT', '1', '10000'), 1)
+
+    commands = _slowlog_commands(slave)
+    drop_pos = next((i for i, args in enumerate(commands)
+                     if args and args[0].upper().endswith('FT._DROPINDEXIFX')), None)
+    delete_pos = next((i for i, args in enumerate(commands)
+                       if args and args[0].upper() in ('DEL', 'UNLINK')
+                       and any(arg.startswith('doc:') for arg in args[1:])), None)
+
+    env.assertTrue(drop_pos is not None, message='Replica did not execute _DROPINDEXIFX')
+    env.assertTrue(delete_pos is not None, message='Replica did not execute document deletes')
+    env.assertTrue(drop_pos < delete_pos,
+                   message='Replica deleted documents before dropping the index: %s' % commands)
+    delete_command = commands[delete_pos]
+    env.assertEqual(delete_command[0].upper(), 'UNLINK')
+    env.assertEqual(set(delete_command[1:]), {'doc:0', 'doc:1', 'doc:2'})
+  finally:
+    slave.execute_command('CONFIG', 'SET', 'slowlog-log-slower-than', old_slowlog_threshold)
+    slave.execute_command('SLOWLOG', 'RESET')
 
 def testDropTempReplicate():
   env = initEnv()

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -212,17 +212,19 @@ def testDropIndexDDReplicatesDropBeforeDocumentDeletes():
     commands = _slowlog_commands(slave)
     drop_pos = next((i for i, args in enumerate(commands)
                      if args and args[0].upper().endswith('FT._DROPINDEXIFX')), None)
-    delete_pos = next((i for i, args in enumerate(commands)
-                       if args and args[0].upper() in ('DEL', 'UNLINK')
-                       and any(arg.startswith('doc:') for arg in args[1:])), None)
+    delete_positions = [i for i, args in enumerate(commands)
+                        if args and args[0].upper() in ('DEL', 'UNLINK')
+                        and any(arg.startswith('doc:') for arg in args[1:])]
 
     env.assertTrue(drop_pos is not None, message='Replica did not execute _DROPINDEXIFX')
-    env.assertTrue(delete_pos is not None, message='Replica did not execute document deletes')
-    env.assertTrue(drop_pos < delete_pos,
+    env.assertTrue(delete_positions, message='Replica did not execute document deletes')
+    first_delete_pos = delete_positions[0]
+    env.assertTrue(drop_pos < first_delete_pos,
                    message='Replica deleted documents before dropping the index: %s' % commands)
-    delete_command = commands[delete_pos]
-    env.assertEqual(delete_command[0].upper(), 'UNLINK')
-    env.assertEqual(set(delete_command[1:]), {'doc:0', 'doc:1', 'doc:2'})
+    env.assertTrue(all(commands[pos][0].upper() == 'UNLINK' for pos in delete_positions))
+    deleted_keys = {arg for pos in delete_positions for arg in commands[pos][1:]
+                    if arg.startswith('doc:')}
+    env.assertEqual(deleted_keys, {'doc:0', 'doc:1', 'doc:2'})
   finally:
     slave.execute_command('CONFIG', 'SET', 'slowlog-log-slower-than', old_slowlog_threshold)
     slave.execute_command('SLOWLOG', 'RESET')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.DROPINDEX ... DD` can replicate document key deletion before replicas execute the internal index-drop command, so replicas may process each delete while the index is still registered.
2. Change: drop commands now replicate the internal drop-if-exists command once, after the final drop mode is known and before any document key removal is propagated.
3. Outcome: replicas drop the index before processing document removals from `DD`, avoiding per-document index cleanup during the drop while preserving the final delete-docs behavior.

#### Which additional issues this PR fixes

1. N/A
2. https://github.com/RediSearch/RediSearch/issues/4488

#### Main objects this PR modified

1. `FT.DROPINDEX` / `FT.DROP`: reorder internal drop replication so replicas remove the index before document key removals.
2. Redis key deletion helper: remove `DD` document keys with single-key `UNLINK` calls using the same C-string key path as the previous `DEL` helper.
3. Replication tests: assert replica command order for `FT.DROPINDEX DD` and verify all dropped document keys are unlinked.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.