### PR TITLE
Drop the no-op UTF-8 encoding cookie from Python tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,12 @@ as production code.
 - Use `#[expect(...)]` over `#[allow(...)]` for lint suppressions
 - Use `tracing` macros for logging (debug!, info!, warn!, error!)
 
+### Python
+
+- Python 3 source is UTF-8 by default, so never add a `# -*- coding: utf-8 -*-`
+  line — it is a no-op the parser accepts for Python 2 compatibility. Non-ASCII
+  literals need no declaration.
+
 ## C Code Architecture
 
 ### Module Entry and Command Dispatch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,8 @@ as production code.
 
 ### Python
 
-- Python 3 source is UTF-8 by default, so never add a `# -*- coding: utf-8 -*-`
-  line — it is a no-op the parser accepts for Python 2 compatibility. Non-ASCII
-  literals need no declaration.
+- Source is UTF-8, which Python 3 already assumes. Never add a
+  `# -*- coding: utf-8 -*-` line; non-ASCII literals need no declaration.
 
 ## C Code Architecture
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import redis
 import random
 import time

--- a/tests/pytests/test_cn.py
+++ b/tests/pytests/test_cn.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import redis
 import unittest
 import os

--- a/tests/pytests/test_dict_trie_encoding.py
+++ b/tests/pytests/test_dict_trie_encoding.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import *
 
 '''

--- a/tests/pytests/test_filter_no_field_refs.py
+++ b/tests/pytests/test_filter_no_field_refs.py
@@ -1,4 +1,3 @@
-#
 # A FILTER expression that references no schema fields leaves the rule's
 # filter-field arrays empty; writes to a matching prefix must still be
 # indexed or rejected without crashing the server.

--- a/tests/pytests/test_filter_no_field_refs.py
+++ b/tests/pytests/test_filter_no_field_refs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # A FILTER expression that references no schema fields leaves the rule's
 # filter-field arrays empty; writes to a matching prefix must still be

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 from includes import *
 from common import *

--- a/tests/pytests/test_highlight.py
+++ b/tests/pytests/test_highlight.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from includes import *
 from common import *
 

--- a/tests/pytests/test_hybrid_profile.py
+++ b/tests/pytests/test_hybrid_profile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from includes import *
 from common import *
 from RLTest import Env

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from common import *
 import random
 

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import bz2
 import numpy as np

--- a/tests/pytests/test_json_partial_load.py
+++ b/tests/pytests/test_json_partial_load.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2006-Present, Redis Ltd.
 # All rights reserved.
 #

--- a/tests/pytests/test_json_partial_load.py
+++ b/tests/pytests/test_json_partial_load.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2006-Present, Redis Ltd.
 # All rights reserved.

--- a/tests/pytests/test_language.py
+++ b/tests/pytests/test_language.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import getConnectionByEnv, waitForIndex, config_cmd, skip
 from RLTest import Env
 from common import index_info

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import *
 from RLTest import Env
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from common import *
 
 def initEnv(moduleArgs: str = 'WORKERS 1'):

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from includes import *
 from common import *
 from RLTest import Env

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import profile
 from includes import *
 from common import *

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import math
 import unittest
 from includes import *

--- a/tests/pytests/test_quotes.py
+++ b/tests/pytests/test_quotes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from RLTest import Env
 from includes import *
 from common import *

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from includes import *
 from common import getConnectionByEnv, waitForIndex, skip
 from RLTest import Env

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import collections
 import random
 import re

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from cmath import inf
 from email import message
 

--- a/tests/pytests/test_stemmer.py
+++ b/tests/pytests/test_stemmer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import waitForIndex, config_cmd, debug_cmd, skip
 
 def testHashMinStemLen(env):

--- a/tests/pytests/test_stemmer.py
+++ b/tests/pytests/test_stemmer.py
@@ -56,7 +56,7 @@ def testHashMinStemLen(env):
             'SCHEMA', 't', 'TEXT')
     env.cmd('HSET', '{doc}:1', 't', 'dar')
     
-    # altough MIN_STEMMING_LEN = 3, 'dar' does not need to be stemmed because
+    # although MIN_STEMMING_LEN = 3, 'dar' does not need to be stemmed because
     # the original word is equal to its stem
     res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx_es')
     env.assertEqual(res, ['dar'])
@@ -127,7 +127,7 @@ def testJsonMinStemLen(env):
             'SCHEMA', '$.t', 'AS', 't', 'TEXT')
     env.cmd('JSON.SET', '{doc}:1', '$', r'{"t":"dar"}')
     
-    # altough MIN_STEMMING_LEN = 3, 'dar' does not need to be stemmed because
+    # although MIN_STEMMING_LEN = 3, 'dar' does not need to be stemmed because
     # the original word is equal to its stem
     res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx_es')
     env.assertEqual(res, ['dar'])

--- a/tests/pytests/test_suffix_trie_encoding.py
+++ b/tests/pytests/test_suffix_trie_encoding.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import *
 
 '''

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 from includes import *
 from common import *

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from RLTest import Env
 from includes import *
 from common import *

--- a/tests/pytests/test_terms_trie_encoding.py
+++ b/tests/pytests/test_terms_trie_encoding.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from common import *
 
 '''

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 import time
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 26 Python test files carry a `# -*- coding: utf-8 -*-` line. Python 3 decodes source as UTF-8 by default (PEP 3120), so the cookie has been a no-op since the suite moved off Python 2, and agents keep re-adding it to any file that gains a non-ASCII literal.
2. Change: Removes the cookie from the Python 3 test files and documents in `AGENTS.md` that it should not be added. `tests/benchmark.legacy/` is still Python 2 source, where the cookie is load-bearing, so those files keep it.
3. Outcome: Internal-only — no runtime or test behavior changes. Gives the repo guideline something to point at so the line stops reappearing.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `tests/pytests/*.py` — encoding cookie removed from 26 files; comment-only deletions.
2. `AGENTS.md` — new `### Python` subsection under *Code Style*.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
