### PR TITLE
[MOD-16530] Reject multi-value JSONPath for JSON HIGHLIGHT/SUMMARIZE fields

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1590,11 +1590,10 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   return REDISMODULE_OK;
 }
 
-// Check if a single FieldSpec has a multi-value JSONPath.
+// Check if a FieldSpec is backed by a multi-value JSONPath.
 // This request-time validation is used only for JSON HIGHLIGHT/SUMMARIZE fields.
-// Returns true if the field is a TEXT field with a multi-value JSONPath.
-static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
-  if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !fs->fieldPath) {
+static bool fieldSpecIsMultiValueJsonPath(const FieldSpec *fs) {
+  if (!fs || !fs->fieldPath) {
     return false;
   }
   RedisModuleString *err_msg = NULL;
@@ -1653,7 +1652,7 @@ static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *i
       continue;
     }
     const FieldSpec *fs = getHighlightFieldSpec(index, rf);
-    if (jsonPathIsMultiValue(rf->path) || (fs && fieldSpecIsMultiValueText(fs))) {
+    if (jsonPathIsMultiValue(rf->path) || (fs && fieldSpecIsMultiValueJsonPath(fs))) {
       hasMultiValue = true;
       break;
     }

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1615,6 +1615,7 @@ def test_highlight_multi_value_json_rejected(env):
 
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
                'SCHEMA', '$.tags[*]', 'AS', 'tags', 'TEXT',
+               '$.labels[*]', 'AS', 'labels', 'TAG',
                '$.name', 'AS', 'name', 'TEXT').ok()
 
     multi_value_error = "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath"
@@ -1632,6 +1633,15 @@ def test_highlight_multi_value_json_rejected(env):
 
         env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'tags',
                    'SUMMARIZE', 'FIELDS', '1', 'tags', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # Multi-value JSONPath is rejected even when the field is not TEXT.
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'labels',
+                   'HIGHLIGHT', 'FIELDS', '1', 'labels', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'labels',
+                   'SUMMARIZE', 'FIELDS', '1', 'labels', 'DIALECT', dialect).error()\
             .contains(multi_value_error)
 
         # HIGHLIGHT without FIELDS when any returned TEXT field has multi-value JSONPath


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: JSON HIGHLIGHT/SUMMARIZE rejects multi-value JSONPath fields only when the schema field is TEXT, so a multi-value JSONPath indexed as TAG can pass validation and reach highlighting/summarization.
2. Change: Validate whether the backing JSONPath is multi-value independent of the schema field type.
3. Outcome: JSON HIGHLIGHT/SUMMARIZE consistently rejects multi-value JSONPath fields while keeping single-value scalar JSON fields supported.

#### Which additional issues this PR fixes

1. MOD-16530

#### Main objects this PR modified

1. JSON HIGHLIGHT/SUMMARIZE validation: checks schema JSONPath expansion regardless of field type.
2. FT.SEARCH JSON tests: adds coverage for a multi-value JSON TAG field with HIGHLIGHT and SUMMARIZE.
3. MOD-16530 backport parity: matches the validation follow-up already included in the active release backports.

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

This is an API-visible bug fix: commands using HIGHLIGHT/SUMMARIZE on JSON multi-value paths indexed as non-TEXT fields now return the intended multi-value JSONPath error instead of being accepted accidentally.

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
