### PR TITLE
[MOD-17999] Fall back to the LLVM tarball instead of failing bootstrap, and retry bootstrap in CI

### DIFF
--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -254,9 +254,16 @@ jobs:
         working-directory: redis
         env:
           MODULES_MANIFEST_FILE: ${{ github.workspace }}/redis/modules/modules-ci.yaml
+        # Bootstrap installs the whole dependency set over the network (apt,
+        # cmake, boost, rust, python, LLVM). Unlike "Setup platform
+        # dependencies" above -- which only installs git -- it was not covered
+        # by SETUP_RETRY_LOOP, so one transient blip fetching a dependency
+        # failed the nightly outright (MOD-17999). install_script.sh is
+        # re-runnable, so retry the whole bootstrap here rather than giving
+        # each individual download its own retry loop.
         run: |
           export PATH="${PATH:-}:$REDISEARCH_CI_SYSTEM_PATH"
-          make bootstrap redisearch
+          ${{ format(env.SETUP_RETRY_LOOP, 'make bootstrap redisearch') }}
 
       - name: Run make build redisearch
         timeout-minutes: ${{ inputs.test-timeout }}

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -254,13 +254,8 @@ jobs:
         working-directory: redis
         env:
           MODULES_MANIFEST_FILE: ${{ github.workspace }}/redis/modules/modules-ci.yaml
-        # Bootstrap installs the whole dependency set over the network (apt,
-        # cmake, boost, rust, python, LLVM). Unlike "Setup platform
-        # dependencies" above -- which only installs git -- it was not covered
-        # by SETUP_RETRY_LOOP, so one transient blip fetching a dependency
-        # failed the nightly outright (MOD-17999). install_script.sh is
-        # re-runnable, so retry the whole bootstrap here rather than giving
-        # each individual download its own retry loop.
+        # Bootstrap installs every dependency over the network, and
+        # install_script.sh is re-runnable, so retry it as a whole.
         run: |
           export PATH="${PATH:-}:$REDISEARCH_CI_SYSTEM_PATH"
           ${{ format(env.SETUP_RETRY_LOOP, 'make bootstrap redisearch') }}

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -31,7 +31,7 @@ if [[ "${DRY_RUN:-0}" == 1 ]]; then
         else
             processor=$(uname -m)
             if [[ $processor = 'x86_64' ]]; then filename=cmake-${version}-linux-x86_64.sh; else filename=cmake-${version}-linux-aarch64.sh; fi
-            _dry_line "wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}"
+            _dry_line "wget -O ${filename} https://github.com/Kitware/CMake/releases/download/v${version}/${filename}"
             _dry_line "chmod u+x ./${filename}"
             _dry_line "${MODE:+$MODE }./${filename} --skip-license --prefix=/usr/local --exclude-subdir"
             _dry_line "rm ./${filename}"
@@ -65,7 +65,11 @@ else
             filename=cmake-${version}-linux-aarch64.sh
         fi
 
-        wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+        # -O so a retry overwrites a partial left by an interrupted download,
+        # instead of saving the fresh copy alongside it as ${filename}.1 and
+        # re-executing the stale partial below. CI retries `make bootstrap`, so
+        # this has to be idempotent with respect to its own leftovers.
+        wget -O ${filename} https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
         chmod u+x ./${filename}
         $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
         cmake --version

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -65,19 +65,10 @@ else
             filename=cmake-${version}-linux-aarch64.sh
         fi
 
-        # Explicit output path, and the protocol pinned across redirects.
-        #
-        # The output path keeps this idempotent. The previous form was a bare
-        # `wget URL`, which preserves a partial left by an interrupted download
-        # and saves the fresh copy alongside it as ${filename}.1 -- so every
-        # retry chmod'd and executed the same stale partial. CI retries
-        # `make bootstrap`, so this has to survive its own leftovers.
-        #
-        # curl matches install_llvm.sh: the file is chmod +x'd and run with
-        # $MODE two lines down, so a redirect downgraded to http:// would be
-        # arbitrary code execution. GitHub release URLs do redirect (to
-        # release-assets.githubusercontent.com), so redirects stay allowed --
-        # they just cannot leave HTTPS.
+        # -o truncates, so a retried bootstrap overwrites a partial download
+        # instead of executing a stale one. --proto/--proto-redir hold the
+        # transfer on HTTPS across GitHub's redirect; the file is executed
+        # below, so an http:// downgrade would be code execution.
         curl -fsSL --proto '=https' --proto-redir '=https' \
              -o ${filename} \
              https://github.com/Kitware/CMake/releases/download/v${version}/${filename}

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -31,7 +31,7 @@ if [[ "${DRY_RUN:-0}" == 1 ]]; then
         else
             processor=$(uname -m)
             if [[ $processor = 'x86_64' ]]; then filename=cmake-${version}-linux-x86_64.sh; else filename=cmake-${version}-linux-aarch64.sh; fi
-            _dry_line "wget -O ${filename} https://github.com/Kitware/CMake/releases/download/v${version}/${filename}"
+            _dry_line "curl -fsSL --proto '=https' --proto-redir '=https' -o ${filename} https://github.com/Kitware/CMake/releases/download/v${version}/${filename}"
             _dry_line "chmod u+x ./${filename}"
             _dry_line "${MODE:+$MODE }./${filename} --skip-license --prefix=/usr/local --exclude-subdir"
             _dry_line "rm ./${filename}"
@@ -65,11 +65,22 @@ else
             filename=cmake-${version}-linux-aarch64.sh
         fi
 
-        # -O so a retry overwrites a partial left by an interrupted download,
-        # instead of saving the fresh copy alongside it as ${filename}.1 and
-        # re-executing the stale partial below. CI retries `make bootstrap`, so
-        # this has to be idempotent with respect to its own leftovers.
-        wget -O ${filename} https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+        # Explicit output path, and the protocol pinned across redirects.
+        #
+        # The output path keeps this idempotent. The previous form was a bare
+        # `wget URL`, which preserves a partial left by an interrupted download
+        # and saves the fresh copy alongside it as ${filename}.1 -- so every
+        # retry chmod'd and executed the same stale partial. CI retries
+        # `make bootstrap`, so this has to survive its own leftovers.
+        #
+        # curl matches install_llvm.sh: the file is chmod +x'd and run with
+        # $MODE two lines down, so a redirect downgraded to http:// would be
+        # arbitrary code execution. GitHub release URLs do redirect (to
+        # release-assets.githubusercontent.com), so redirects stay allowed --
+        # they just cannot leave HTTPS.
+        curl -fsSL --proto '=https' --proto-redir '=https' \
+             -o ${filename} \
+             https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
         chmod u+x ./${filename}
         $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
         cmake --version

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -214,40 +214,18 @@ install_llvm() {
             if apt-cache show software-properties-common &>/dev/null; then
                 spc_pkg="software-properties-common"
             fi
-            # wget stays in the list: llvm.sh itself uses it to fetch the repo
-            # signing key.
+            # wget stays: llvm.sh uses it to fetch the repo signing key.
             apt_get_cmd "$MODE" install -y --no-install-recommends \
                 lsb-release wget curl $spc_pkg gnupg ca-certificates
-            # Treat any failure to fetch or run llvm.sh as an apt.llvm.org
-            # failure (-> tarball below) rather than a bootstrap failure.
-            # Debian trixie ships no native clang-${LLVM_VER}, so it always
-            # reaches this path; as a bare command under `set -e`, a single
-            # transient blip here (wget exit 4 = network failure) aborted the
-            # whole bootstrap instead of falling through to step 3.
+            # Fetch, chmod and exec stay inside the condition: `set -e` does
+            # not fire there, so any failure falls through to the tarball
+            # instead of aborting bootstrap. Retrying is the caller's job --
+            # CI wraps this script and the bootstrap that runs it.
             #
-            # Retrying a transient network failure is the caller's job, not
-            # this script's: CI already wraps install_llvm.sh, and the
-            # bootstrap that runs it, in a 5-attempt retry loop. What the
-            # script owes is a fallback chain that degrades instead of
-            # aborting, so a persistent apt.llvm.org outage still ends in a
-            # working toolchain.
-            #
-            # curl rather than wget, matching install_from_tarball:
-            #   - `--proto`/`--proto-redir` pin the transfer to HTTPS even
-            #     across a redirect. That matters here specifically because we
-            #     chmod +x and run the result with $MODE, so a redirect
-            #     downgraded to http:// would be arbitrary code execution.
-            #   - `--connect-timeout`/`--max-time` bound the attempt, so a host
-            #     that accepts the connection and then stalls reaches the
-            #     tarball in ~1 min rather than hanging. GNU wget would have
-            #     retried internally first (--tries defaults to 20).
-            #   - `-fsSL` fails on HTTP errors and stays quiet on success while
-            #     still printing the reason on failure; the original `-q` hid
-            #     it entirely, which is why the failing log just stopped.
-            #
-            # chmod and the exec sit inside the condition so a failed download
-            # (no /tmp/llvm.sh) also routes to the tarball rather than
-            # tripping `set -e`.
+            # --proto/--proto-redir hold the transfer on HTTPS across
+            # redirects; the result is executed with $MODE, so an http://
+            # downgrade would be code execution. --connect-timeout/--max-time
+            # bound the attempt so a stalled host reaches the tarball.
             if curl -fsSL --proto '=https' --proto-redir '=https' \
                     --connect-timeout 20 --max-time 60 \
                     -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh \

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -216,9 +216,33 @@ install_llvm() {
             fi
             apt_get_cmd "$MODE" install -y --no-install-recommends \
                 lsb-release wget $spc_pkg gnupg ca-certificates
-            wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-            chmod +x /tmp/llvm.sh
-            if $MODE /tmp/llvm.sh "$LLVM_VER"; then
+            # Retry the llvm.sh download, and treat a persistent failure as an
+            # apt.llvm.org failure (-> tarball below) rather than a bootstrap
+            # failure. Debian trixie ships no native clang-${LLVM_VER}, so it
+            # always reaches this path; as a bare command under `set -e`, a
+            # single transient blip here (wget exit 4 = network failure) aborted
+            # the whole bootstrap instead of falling through to step 3. The loop
+            # lives in shell rather than in wget flags, and uses `-T 60`, to stay
+            # portable to BusyBox wget — same reasoning as install_boost.sh.
+            # `-nv` rather than `-q` so a failure says why in the CI log.
+            local llvm_sh_ok=0 attempt
+            for attempt in 1 2 3 4 5; do
+                if wget -nv -T 60 -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh; then
+                    llvm_sh_ok=1
+                    break
+                fi
+                if [[ "$attempt" -eq 5 ]]; then
+                    echo ">>> llvm.sh download failed after $attempt attempts" >&2
+                    break
+                fi
+                echo ">>> llvm.sh download failed (attempt $attempt), retrying in 10s..." >&2
+                sleep 10
+            done
+            # chmod sits inside the condition so a missing /tmp/llvm.sh (the
+            # download never succeeded) also routes to the tarball rather than
+            # tripping `set -e`.
+            if [[ "$llvm_sh_ok" -eq 1 ]] && chmod +x /tmp/llvm.sh \
+                    && $MODE /tmp/llvm.sh "$LLVM_VER"; then
                 rm -f /tmp/llvm.sh
                 # llvm.sh installs the toolchain but does not always leave the
                 # libclang development package/symlink that clang-sys and the

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -214,20 +214,35 @@ install_llvm() {
             if apt-cache show software-properties-common &>/dev/null; then
                 spc_pkg="software-properties-common"
             fi
+            # wget stays in the list: llvm.sh itself uses it to fetch the repo
+            # signing key.
             apt_get_cmd "$MODE" install -y --no-install-recommends \
-                lsb-release wget $spc_pkg gnupg ca-certificates
+                lsb-release wget curl $spc_pkg gnupg ca-certificates
             # Retry the llvm.sh download, and treat a persistent failure as an
             # apt.llvm.org failure (-> tarball below) rather than a bootstrap
             # failure. Debian trixie ships no native clang-${LLVM_VER}, so it
             # always reaches this path; as a bare command under `set -e`, a
-            # single transient blip here (wget exit 4 = network failure) aborted
-            # the whole bootstrap instead of falling through to step 3. The loop
-            # lives in shell rather than in wget flags, and uses `-T 60`, to stay
-            # portable to BusyBox wget — same reasoning as install_boost.sh.
-            # `-nv` rather than `-q` so a failure says why in the CI log.
+            # single transient blip here (exit 4 = network failure) aborted the
+            # whole bootstrap instead of falling through to step 3.
+            #
+            # curl rather than wget, matching install_from_tarball below:
+            #   - `--proto`/`--proto-redir` pin the transfer to HTTPS even
+            #     across a redirect. That matters here specifically because we
+            #     chmod +x and run the result with $MODE, so a redirect
+            #     downgraded to http:// would be arbitrary code execution.
+            #   - curl does not retry internally, so the five iterations below
+            #     are the real cap. GNU wget defaults to --tries=20, which with
+            #     a per-read timeout would have let one stalled host burn far
+            #     longer than intended before reaching the tarball.
+            #   - `--connect-timeout`/`--max-time` bound each attempt, so the
+            #     worst case is ~5 min rather than an open-ended hang.
+            #   - `-fsS` fails on HTTP errors and stays quiet on success while
+            #     still printing the reason on failure.
             local llvm_sh_ok=0 attempt
             for attempt in 1 2 3 4 5; do
-                if wget -nv -T 60 -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh; then
+                if curl -fsSL --proto '=https' --proto-redir '=https' \
+                        --connect-timeout 20 --max-time 60 \
+                        -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh; then
                     llvm_sh_ok=1
                     break
                 fi

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -218,45 +218,40 @@ install_llvm() {
             # signing key.
             apt_get_cmd "$MODE" install -y --no-install-recommends \
                 lsb-release wget curl $spc_pkg gnupg ca-certificates
-            # Retry the llvm.sh download, and treat a persistent failure as an
-            # apt.llvm.org failure (-> tarball below) rather than a bootstrap
-            # failure. Debian trixie ships no native clang-${LLVM_VER}, so it
-            # always reaches this path; as a bare command under `set -e`, a
-            # single transient blip here (exit 4 = network failure) aborted the
+            # Treat any failure to fetch or run llvm.sh as an apt.llvm.org
+            # failure (-> tarball below) rather than a bootstrap failure.
+            # Debian trixie ships no native clang-${LLVM_VER}, so it always
+            # reaches this path; as a bare command under `set -e`, a single
+            # transient blip here (wget exit 4 = network failure) aborted the
             # whole bootstrap instead of falling through to step 3.
             #
-            # curl rather than wget, matching install_from_tarball below:
+            # Retrying a transient network failure is the caller's job, not
+            # this script's: CI already wraps install_llvm.sh, and the
+            # bootstrap that runs it, in a 5-attempt retry loop. What the
+            # script owes is a fallback chain that degrades instead of
+            # aborting, so a persistent apt.llvm.org outage still ends in a
+            # working toolchain.
+            #
+            # curl rather than wget, matching install_from_tarball:
             #   - `--proto`/`--proto-redir` pin the transfer to HTTPS even
             #     across a redirect. That matters here specifically because we
             #     chmod +x and run the result with $MODE, so a redirect
             #     downgraded to http:// would be arbitrary code execution.
-            #   - curl does not retry internally, so the five iterations below
-            #     are the real cap. GNU wget defaults to --tries=20, which with
-            #     a per-read timeout would have let one stalled host burn far
-            #     longer than intended before reaching the tarball.
-            #   - `--connect-timeout`/`--max-time` bound each attempt, so the
-            #     worst case is ~5 min rather than an open-ended hang.
-            #   - `-fsS` fails on HTTP errors and stays quiet on success while
-            #     still printing the reason on failure.
-            local llvm_sh_ok=0 attempt
-            for attempt in 1 2 3 4 5; do
-                if curl -fsSL --proto '=https' --proto-redir '=https' \
-                        --connect-timeout 20 --max-time 60 \
-                        -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh; then
-                    llvm_sh_ok=1
-                    break
-                fi
-                if [[ "$attempt" -eq 5 ]]; then
-                    echo ">>> llvm.sh download failed after $attempt attempts" >&2
-                    break
-                fi
-                echo ">>> llvm.sh download failed (attempt $attempt), retrying in 10s..." >&2
-                sleep 10
-            done
-            # chmod sits inside the condition so a missing /tmp/llvm.sh (the
-            # download never succeeded) also routes to the tarball rather than
+            #   - `--connect-timeout`/`--max-time` bound the attempt, so a host
+            #     that accepts the connection and then stalls reaches the
+            #     tarball in ~1 min rather than hanging. GNU wget would have
+            #     retried internally first (--tries defaults to 20).
+            #   - `-fsSL` fails on HTTP errors and stays quiet on success while
+            #     still printing the reason on failure; the original `-q` hid
+            #     it entirely, which is why the failing log just stopped.
+            #
+            # chmod and the exec sit inside the condition so a failed download
+            # (no /tmp/llvm.sh) also routes to the tarball rather than
             # tripping `set -e`.
-            if [[ "$llvm_sh_ok" -eq 1 ]] && chmod +x /tmp/llvm.sh \
+            if curl -fsSL --proto '=https' --proto-redir '=https' \
+                    --connect-timeout 20 --max-time 60 \
+                    -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh \
+                    && chmod +x /tmp/llvm.sh \
                     && $MODE /tmp/llvm.sh "$LLVM_VER"; then
                 rm -f /tmp/llvm.sh
                 # llvm.sh installs the toolchain but does not always leave the


### PR DESCRIPTION
## What failed

The [2026-08-24 Nightly Flow](https://github.com/RediSearch/RediSearch/actions/runs/32774415943) failed in exactly one job — `redis-build-sanity / debian:trixie (x86_64)` — at `make bootstrap redisearch`, with no explanation in the log beyond:

```
Setting up lsb-release (12.1-1) ...
make[1]: *** [Makefile:240: bootstrap] Error 4
make: *** [Makefile:113: bootstrap] Error 1
```

`Error 4` is the tell. The command immediately after that `lsb-release` install was `.install/install_llvm.sh:219`:

```bash
wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
```

**wget exit 4 = "Network failure."** Nothing else in that block can return 4 (apt-get returns 100, `chmod` returns 1). The script runs under `set -eo pipefail`, so this bare `wget` aborted the entire bootstrap with its own status — and `-q` swallowed the message, which is why the log just stops.

## Why it's a real bug and not just a flake

`install_llvm.sh` is *designed* with a three-tier fallback for Debian/Ubuntu: native apt → apt.llvm.org → official LLVM tarball. That fallback was defeated for the download step:

- Line 221 guards *running* `llvm.sh` (`if ... else install_from_tarball`), so an llvm.sh failure correctly drops to tier 3.
- Line 219, which *fetches* `llvm.sh`, was a bare command **outside** that guard. `set -e` killed the script before control ever reached the `else`, so a hiccup reaching apt.llvm.org failed bootstrap outright instead of falling through to the tarball that exists precisely for this case.

Debian trixie ships no native `clang-21`, so tier 1 fails by design and trixie **always** takes this path. That left every trixie nightly one apt.llvm.org blip away from red.

That it was a transient blip rather than a regression is confirmed by the surrounding runs: the aarch64 twin in the *same* run passed, and this exact x86_64 job passed in the Aug 21, 22, and 23 nightlies. Same code, same script, one arch got a bad network moment.

## Why CI's retry loop never caught it

`task-redis-build-sanity.yml` does define `SETUP_RETRY_LOOP` (5 attempts, 30s backoff), but it only wraps two steps:

- `Install bash` — `apk add bash`, Alpine only
- `Setup platform dependencies` — and for trixie that step is just `apt update && apt install -y git`

`install_llvm.sh` runs from a different, **unwrapped** step, `Run make bootstrap redisearch`, a bare `run:`:

```
make bootstrap (redis) → scripts/bootstrap.sh redisearch
  → make -C modules/redisearch/src bootstrap → .install/install_script.sh:45
  → debian_gnu_linux_13.sh:10 → source install_llvm.sh
```

So the entire dependency install — apt, cmake, boost, rust, python, LLVM — had no retry, while the step that *did* have one installs almost nothing. Most other flows do wrap the same installer (`setup-build-env/action.yml` and `task-build-artifacts.yml` wrap `install_script.sh` in `retry-command`, and `setup-build-env` wraps `install_llvm.sh` itself); build-sanity was the outlier.

## The fix

Two changes, split along that line: **CI retries transient failures, the script guarantees its fallback degrades instead of aborting.**

### 1. `.install/install_llvm.sh` — make the fallback reachable

The download, `chmod` and exec now all sit inside the `if` condition:

```bash
if curl -fsSL --proto '=https' --proto-redir '=https' \
        --connect-timeout 20 --max-time 60 \
        -o /tmp/llvm.sh https://apt.llvm.org/llvm.sh \
        && chmod +x /tmp/llvm.sh \
        && $MODE /tmp/llvm.sh "$LLVM_VER"; then
    ...
else
    install_from_tarball
fi
```

`set -e` does not fire for commands in an `if` condition — that is the whole mechanism. Any failure (fetch, `chmod`, or running `llvm.sh`) now routes to the existing tier-3 tarball, and a missing `/tmp/llvm.sh` from a download that never succeeded no longer trips `set -e` on `chmod`.

There is deliberately **no retry loop in the script**. Retrying transient network failures is the caller's job, and `setup-build-env/action.yml` already wraps `install_llvm.sh` in `retry-command`; an in-script loop duplicated machinery that exists one level up. What the script owes is a fallback chain that degrades instead of aborting.

The download stays on `curl` rather than `wget`, matching `install_from_tarball` in this same file. Both reasons are independent of retries:

- **`--proto '=https' --proto-redir '=https'`** pin the transfer to HTTPS even across a redirect. This matters here specifically because the fetched script is `chmod +x`'d and run with `$MODE` — a redirect downgraded to `http://` would be arbitrary code execution. Also closes the SonarCloud finding on this line.
- **`--connect-timeout 20 --max-time 60`** bound the attempt, so a host that accepts the connection and then stalls reaches the tarball in ~1 min rather than hanging. GNU wget would have retried internally first (`--tries` defaults to 20).
- **`-fsSL`** fails on HTTP errors and stays quiet on success while still printing the reason on failure (the original `-q` hid it entirely).

`wget` stays in the apt prerequisite list because `llvm.sh` itself uses it to fetch the repo signing key; `curl` is added alongside.

### 2. `.github/workflows/task-redis-build-sanity.yml` — put the retry where the gap was

```diff
  run: |
    export PATH="${PATH:-}:$REDISEARCH_CI_SYSTEM_PATH"
-   make bootstrap redisearch
+   ${{ format(env.SETUP_RETRY_LOOP, 'make bootstrap redisearch') }}
```

Uses the retry template the workflow already defines and already applies to its other setup steps, so bootstrap's other network steps — none of which have a fallback tier — are covered too. `export PATH` stays outside the loop; only `make bootstrap redisearch` is retried. `make bootstrap` is purely dependency installation and is re-runnable, and `timeout-minutes` remains the hard backstop.

The env template rather than `retry-command` or `.install/retry.sh` because this job checks out only Redis (into `redis/`) — there is no RediSearch checkout, so neither the local composite action nor `retry.sh` is on disk there.

### 3. `.install/install_cmake.sh` — let a retry actually recover

Codex caught that the retry above had a dead spot, and it holds up. `install_cmake.sh` fetched the CMake installer with a bare `wget URL`, then `chmod`'d and executed the unsuffixed filename. wget writes straight to the target with no temp-file staging, so an interrupted download leaves a partial installer in `.install/`, and `rm ./${filename}` only runs on success. A later bare fetch does **not** overwrite that partial — GNU wget writes the fresh copy alongside it as `${filename}.1` — so every retry executed the same stale partial and failed identically.

`-O ${filename}` truncates and always writes the target, so a retry overwrites the partial instead of accumulating `.1` files. `-c` would be wrong here: resuming onto a corrupt partial is the failure being avoided. The dry-run line is updated to match, since this script's dry-run mode is held to printing the commands bootstrap actually runs.

This didn't regress correctness relative to master — the outcome was red either way — but a retry that can't recover is worse than no retry.

## Net effect and tradeoff

The Aug-24 failure would now self-heal via the tarball, and a genuine apt.llvm.org outage degrades to the tarball instead of failing the nightly. **Change 1 alone fixes MOD-17999**; change 2 closes the adjacent gap for the bootstrap steps that have no fallback.

The tradeoff: a single blip now degrades straight to tier 3, and that tarball is a heavier download than the apt path. The CI retry will not pull it back to tier 2, because bootstrap *succeeds* via the tarball. More robust, occasionally slower.

There is no portable middle ground. Measured locally: `curl --retry 3` does **not** retry a connection failure (one attempt, 0s), and `--retry-all-errors`, which does (4 attempts, 6s), requires curl ≥ 7.71 — Ubuntu 20.04 ships 7.68 and takes this same path. So it is either a shell loop or nothing, which is why the loop moved to CI rather than shrinking.

## Testing

Stubbed the downloader against the **real extracted block** (not a paraphrase) and exercised every path:

- **Download fails** (the Aug-24 scenario): exactly one network attempt, reaches `install_from_tarball`, and the script survives `set -e` — exit 0, where it previously aborted with exit 4.
- **Success path**: still runs `llvm.sh` and the follow-up `libclang-21-dev` install.
- **Exec failure** (download succeeds, `llvm.sh` fails): also routes to the tarball.

- **CMake partial-download recovery**, against the real installer URL: `timeout 2 wget` leaves a 20 MB fragment of the ~44 MB installer; a bare re-fetch preserves that fragment and writes `FILE.1`, while `wget -O` overwrites it and creates no `.1` (still exactly one file after four consecutive fetches).

HTTPS pinning verified live rather than assumed: `curl --proto '=https' --proto-redir '=https'` against an `http://` URL fails with `Protocol "http" disabled`, so a downgraded redirect routes to the tarball instead of executing. The real endpoint fetches successfully with the pinned flags.

Workflow: `format(env.SETUP_RETRY_LOOP, 'make bootstrap redisearch')` was hand-expanded and syntax-checked — `export PATH` stays outside the loop, `if make bootstrap redisearch; then` inside.

`bash -n` clean on the committed blob. Dry-run/list mode doesn't execute this branch (it prints a single `bash install_llvm.sh` line at :487), so it's unaffected. No behavior change on the success path or on any non-Debian distro.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: one CI workflow step plus two bootstrap installer scripts. No command, reply shape, default, or on-disk format changes.

Ticket: [MOD-17999](https://redislabs.atlassian.net/browse/MOD-17999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-17999]: https://redislabs.atlassian.net/browse/MOD-17999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ