### PR TITLE
[8.8] [MOD-17877] Fix crash and missing results when writing documents while a cursor is open

### DIFF
--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -167,7 +167,38 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     }
 
     fn needs_revalidation(&self) -> bool {
-        self.gc_marker != self.ii.gc_marker.load(atomic::Ordering::Relaxed)
+        let ii = self.ii;
+        if self.gc_marker != ii.gc_marker.load(atomic::Ordering::Relaxed) {
+            return true;
+        }
+
+        // Appending to a block reallocates its buffer without bumping `gc_marker`, and either
+        // outcome invalidates what this reader cached. A moved buffer leaves the cached pointer
+        // dangling. A buffer grown in place keeps the pointer good but makes the cached length
+        // short, which would end the read at the old end of the block and drop the appended
+        // entries. Both are reported so the caller re-seeks, which repairs either.
+        //
+        // Only the cached pointer's address and length are read, never the pointee, which is
+        // what makes this safe to ask while the buffer it describes may already be freed.
+        //
+        // ABA-safe, and it is the length rather than the address that makes it so. Exactly two
+        // things write a block's buffer: GC repair, which bumps `gc_marker` as the last step of
+        // every pass, and appends, which start writing at `buffer.len()` and so only ever grow it.
+        // Freeing and reallocating the buffer therefore takes an append, which lengthens it
+        // whatever address the allocator hands back, and shortening it back takes a repair, which
+        // moves the marker. An unchanged marker, address and length together mean the block has
+        // not been written since the reader cached it.
+        let Some(block) = ii.blocks.get(self.current_block_idx) else {
+            // Nothing cached to go stale: an empty index leaves the reader on the empty slice,
+            // and blocks only ever disappear by GC, which the marker above already caught.
+            return false;
+        };
+
+        // Reading `as_ptr()` and `len()` off the cached slice inspects the fat pointer's own
+        // fields; it does not touch the bytes behind it.
+        let cached = *self.current_buffer.get_ref();
+        let live = block.buffer.as_slice();
+        !std::ptr::eq(cached.as_ptr(), live.as_ptr()) || cached.len() != live.len()
     }
 
     fn refresh_buffer_pointers(&mut self) {

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -51,8 +51,11 @@ pub trait IndexReader<'index> {
     /// Get the flags of the underlying index
     fn flags(&self) -> IndexFlags;
 
-    /// Check if the underlying index has been modified since the last time this reader read from it.
-    /// If it has, then the reader should be reset before reading from it again.
+    /// Check whether the underlying index changed under this reader in a way that invalidates
+    /// where it stands: a GC cycle shifting entries, or a write reallocating the block buffer it
+    /// is reading. The reader must then be reset and re-seeked before it reads again —
+    /// [`Self::refresh_buffer_pointers`] alone is not a substitute, since it only re-points the
+    /// cached buffer and does not repair a stale read position.
     fn needs_revalidation(&self) -> bool;
 
     /// Refresh buffer pointers in case blocks were reallocated without GC changes

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -80,3 +80,57 @@ impl<'a> PartialEq for TermRecordCompare<'a> {
         true
     }
 }
+
+/// Move a block's encoded-entry buffer to a different address, leaving its bytes and the index's
+/// `gc_marker` alone — what a write that outgrows the buffer's allocation does to a reader parked
+/// on that block.
+///
+/// Appending cannot stand in for this: whether `reserve_exact` growth moves the buffer or extends
+/// it in place is the allocator's choice, so a test that appends until the address changes may
+/// never see it change. Here the replacement is built while the original is still alive, so the
+/// two cannot share an address whatever the allocator does. The original is then freed, which is
+/// what makes a reader's cached pointer genuinely dangle.
+///
+/// Returns the buffer's new base address.
+///
+/// # Panics
+///
+/// If `block_idx` is out of range.
+pub fn relocate_block_buffer<E: crate::Encoder + crate::DecodedBy>(
+    index: &mut crate::InvertedIndex<E>,
+    block_idx: usize,
+) -> *const u8 {
+    let block = &mut index.blocks[block_idx];
+
+    // Hold the original allocation while the replacement is allocated, so they cannot overlap.
+    let original = std::mem::take(&mut block.buffer);
+    let mut relocated = Vec::with_capacity(original.len().max(1));
+    relocated.extend_from_slice(&original);
+
+    let base = relocated.as_ptr();
+    block.buffer = relocated;
+    drop(original);
+
+    assert_ne!(base, std::ptr::null(), "relocated buffer must be allocated");
+    base
+}
+
+/// Give a block's buffer enough spare capacity for `extra` more bytes, so that appends of up to
+/// that size grow it in place instead of reallocating.
+///
+/// The counterpart to [`relocate_block_buffer`]: it makes the *other* outcome of an append — the
+/// buffer keeping its address while its length grows — reachable on demand rather than at the
+/// allocator's discretion.
+///
+/// # Panics
+///
+/// If `block_idx` is out of range.
+pub fn reserve_block_buffer<E: crate::Encoder + crate::DecodedBy>(
+    index: &mut crate::InvertedIndex<E>,
+    block_idx: usize,
+    extra: usize,
+) -> *const u8 {
+    let buffer = &mut index.blocks[block_idx].buffer;
+    buffer.reserve(extra);
+    buffer.as_ptr()
+}

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -841,3 +841,38 @@ fn test_refresh_buffer_pointers_after_reallocation() {
     assert_eq!(doc_count, 990);
     assert_eq!(expected_doc_id, 1000);
 }
+
+/// A parked reader's cached buffer pointer can dangle after a plain write reallocates the block
+/// it was reading — without ever touching `gc_marker`. `needs_revalidation` must catch this on its
+/// own, since a reader-refresh path is not enough on its own to fix a stale read position.
+#[test]
+#[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]
+fn test_needs_revalidation_after_block_buffer_moved() {
+    use crate::IndexReader as _;
+
+    let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(10).build())
+        .unwrap();
+
+    // SAFETY: mirrors a suspended cursor — the reader is parked and untouched while the index is
+    // written to. The relocation below replaces the block's buffer in place, leaving the
+    // `InvertedIndex` itself in place.
+    let ii_ptr = &mut ii as *mut InvertedIndex<Dummy>;
+
+    let ir = ii.reader();
+    assert!(!ir.needs_revalidation(), "index was not modified yet");
+
+    // SAFETY: see the `ii_ptr` construction above.
+    let relocated = unsafe { crate::test_utils::relocate_block_buffer(&mut *ii_ptr, 0) };
+    assert_eq!(ii.gc_marker(), 0, "no GC ran");
+    assert_eq!(
+        ii.block_ref(0).unwrap().data().as_ptr(),
+        relocated,
+        "the block's buffer was supposed to move"
+    );
+
+    assert!(
+        ir.needs_revalidation(),
+        "the cached buffer pointer is now dangling"
+    );
+}

--- a/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
@@ -221,6 +221,53 @@ fn reader_needs_revalidation() {
     assert!(ir.needs_revalidation(), "index was modified");
 }
 
+/// A reader on an index with no blocks has cached nothing, so it has nothing to find stale — and
+/// must not ask to be revalidated on every cursor read for the lack of a block to compare against.
+#[test]
+fn reader_needs_no_revalidation_when_index_has_no_blocks() {
+    let ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    assert_eq!(ii.number_of_blocks(), 0);
+
+    assert!(!ii.reader().needs_revalidation());
+}
+
+/// A block buffer that grows *in place* must be reported too. The reader's cached pointer still
+/// aims at live memory, so nothing dangles, but its cached length stops short of the appended
+/// entries — reading on would end the block early and drop them.
+#[test]
+#[cfg_attr(miri, ignore = "the memory hack below raises error in miri")]
+fn reader_needs_revalidation_when_block_buffer_grew_in_place() {
+    let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(10).build())
+        .unwrap();
+
+    // Spare capacity up front, so the append below cannot move the buffer.
+    let base_before = crate::test_utils::reserve_block_buffer(&mut ii, 0, 128);
+
+    // SAFETY: mirrors a suspended cursor — the reader is parked and untouched while the index is
+    // written to. The write only appends into the block's spare capacity, leaving the
+    // `InvertedIndex` itself in place.
+    let ii_ptr = &mut ii as *mut InvertedIndex<Dummy>;
+
+    let ir = ii.reader();
+    assert!(!ir.needs_revalidation(), "index was not modified yet");
+
+    // SAFETY: see the `ii_ptr` construction above.
+    unsafe {
+        (*ii_ptr)
+            .add_record(&RSIndexResult::build_virt().doc_id(11).build())
+            .unwrap();
+    }
+    assert_eq!(
+        ii.block_ref(0).unwrap().data().as_ptr(),
+        base_before,
+        "the append was supposed to grow the buffer in place"
+    );
+    assert_eq!(ii.gc_marker(), 0, "no GC ran");
+
+    assert!(ir.needs_revalidation(), "the cached length is now short");
+}
+
 #[test]
 fn reader_unique_docs() {
     let blocks = medium_thin_vec![

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -434,6 +434,48 @@ mod not_miri {
         );
     }
 
+    /// Term records carry borrowed offsets into the block buffer, so a moved buffer puts both the
+    /// reader's cursor and the current record's offsets on freed memory.
+    #[test]
+    fn term_revalidate_after_block_buffer_moved() {
+        let test = TermRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        let ii = {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+        };
+
+        test.test
+            .revalidate_after_block_buffer_moved(&mut it, ii, appended_record);
+    }
+
+    /// Driven bare, deliberately: this test garbage-collects the index while the iterator is
+    /// parked. `num_estimated()` shrinks with the collected document, while the checker's upper
+    /// bound counts every result yielded since the last rewind, including those yielded before the
+    /// GC. That bound only holds for an index that does not shrink underneath the iterator.
+    #[test]
+    fn term_revalidate_after_block_buffer_moved_and_gc() {
+        let test = TermRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        let ii = {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+        };
+
+        test.test
+            .revalidate_after_block_buffer_moved_and_gc(&mut it, ii, appended_record);
+    }
+
+    /// Build a record shaped like the ones [`TermRevalidateTest`] seeds the index with.
+    fn appended_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        const OFFSETS: &[u8] = &[0, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+
+        let mut term = RSQueryTerm::new("term", 1, 0);
+        term.set_idf(5.0);
+        term.set_bm25_idf(10.0);
+        expected_record(doc_id, u32::MAX as t_fieldMask, term, OFFSETS)
+    }
+
     #[test]
     fn term_revalidate_after_document_deleted() {
         let test = TermRevalidateTest::new(10);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -524,6 +524,121 @@ impl RevalidateTest {
         );
     }
 
+    /// A write that moves a block's buffer must cost the iterator nothing.
+    ///
+    /// A suspended iterator whose block buffer moved holds a pointer into freed memory, while the
+    /// GC marker still says the index is untouched. Reading on decodes recycled bytes — a short
+    /// read that silently drops documents, or a decode error — so the complete document set is
+    /// asserted rather than merely the absence of a crash.
+    pub fn revalidate_after_block_buffer_moved<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(t_docId) -> RSIndexResult<'static>,
+    {
+        self.block_buffer_moved(it, ii, make_record, false);
+    }
+
+    /// [`revalidate_after_block_buffer_moved`](Self::revalidate_after_block_buffer_moved) with a GC
+    /// cycle interleaved: both invalidate the iterator, and a repair that handles only one of them
+    /// fails here.
+    pub fn revalidate_after_block_buffer_moved_and_gc<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(t_docId) -> RSIndexResult<'static>,
+    {
+        self.block_buffer_moved(it, ii, make_record, true);
+    }
+
+    fn block_buffer_moved<'index, I, E, F>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+        make_record: F,
+        interleave_gc: bool,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+        E: Encoder + DecodedBy,
+        F: Fn(t_docId) -> RSIndexResult<'static>,
+    {
+        // Appends land in the last block, so the iterator has to be parked in that same block for
+        // this to exercise anything; the assertion catches a codec whose block size changes.
+        assert_eq!(
+            ii.number_of_blocks(),
+            1,
+            "the fixture must fit in a single block"
+        );
+
+        // Park the iterator mid-block.
+        for expected in &self.doc_ids[..2] {
+            let doc = it
+                .read()
+                .expect("failed to read")
+                .expect("should not be at EOF");
+            assert_eq!(doc.doc_id, *expected);
+        }
+
+        // Append documents the iterator has not reached, then move the buffer they live in.
+        // Appending alone would leave it to the allocator whether the address changes at all — see
+        // `inverted_index::test_utils::relocate_block_buffer`.
+        let base_before = ii.block_ref(0).unwrap().data().as_ptr();
+        let appended: Vec<t_docId> = (1..=3)
+            .map(|i| self.doc_ids.last().unwrap() + 2 * i)
+            .collect();
+        for doc_id in &appended {
+            ii.add_record(&make_record(*doc_id)).expect("append failed");
+        }
+        assert_eq!(
+            ii.number_of_blocks(),
+            1,
+            "the appends must stay in the block the iterator is parked in"
+        );
+
+        let base_after = inverted_index::test_utils::relocate_block_buffer(ii, 0);
+        assert_ne!(base_before, base_after, "the buffer did not move");
+        let gc_marker_before = ii.gc_marker();
+
+        // Removing a document the iterator already passed leaves the expected set below
+        // untouched, and bumps the GC marker on top of the moved buffer.
+        if interleave_gc {
+            self.remove_document(ii, self.doc_ids[0]);
+            assert_ne!(ii.gc_marker(), gc_marker_before, "GC did not run");
+        } else {
+            assert_eq!(
+                ii.gc_marker(),
+                gc_marker_before,
+                "a plain append must not touch the GC marker — that is what makes it undetected"
+            );
+        }
+
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed");
+        assert_eq!(
+            status,
+            RQEValidateStatus::Ok,
+            "the iterator's position still exists, so revalidation must preserve it"
+        );
+
+        // Everything the iterator had not yielded yet, still in order and without repeats.
+        let mut expected = self.doc_ids[2..].to_vec();
+        expected.extend_from_slice(&appended);
+
+        let mut read = Vec::new();
+        while let Some(doc) = it.read().expect("failed to read") {
+            read.push(doc.doc_id);
+        }
+        assert_eq!(read, expected);
+    }
+
     /// Remove the document with the given id from the inverted index.
     pub fn remove_document<E: Encoder + DecodedBy>(
         &self,


### PR DESCRIPTION
Backport of #11038 (MOD-17877) to `8.8`.

### Backport notes

Cherry-picked from the `8.10` backport (#11113). **One conflict, in the fix itself.**

- **Conflict:** `needs_revalidation` in `src/redisearch_rs/inverted_index/src/reader/core.rs`. This branch predates both the `ResumableReader` work and the `SharedPtr` refactor, so master's `self.buf.as_raw()` and `self.ii.get()` do not exist. The reader here holds `current_buffer: Cursor<&'index [u8]>` and `ii: &'index InvertedIndex<E>`.
- **Resolution:** read the cached slice out of the cursor with `*self.current_buffer.get_ref()` and compare `as_ptr()` and `len()` against the live block, keeping the property that matters: this inspects the fat pointer's own fields and never dereferences the bytes behind it, which may already be freed. The comment says so at the comparison. `self.ii` is used directly instead of `self.ii.get()`.
- The test files auto-merged; only the predicate conflicted.
- **Not backported:** master's follow-up commits, which delete `refresh_buffer_pointers` and rename `IndexReader_Revalidate`. Those are cleanup rather than fix, and `refresh_buffer_pointers` is still referenced on this branch.
- **Not ported:** master's Python flow test in `tests/pytests/test_cursors.py`. The Rust reader-level and iterator-level tests are ported.

## Describe the changes in the pull request

1. Current: `FT.AGGREGATE ... WITHCURSOR` parks its iterators between `FT.CURSOR READ` calls with the index lock released. An ordinary write appends to a block, which reallocates that block's buffer. `needs_revalidation` only compared `gc_marker`, which appends never touch, so a parked leaf was told nothing had changed while its cached buffer pointer was dangling (buffer moved) or its cached length stopped short (buffer grown in place).
2. Change: `needs_revalidation` also compares the cached buffer's address and length against the live block, so both outcomes take the rewind-and-re-seek path the GC case already used.
3. Outcome: cursors over a write-heavy index no longer crash the shard or come back silently short.

#### Which additional issues this PR fixes

1. MOD-17877

#### Main objects this PR modified

1. `IndexReader::needs_revalidation` — the fix, one hunk. Reads only the cached pointer's address and length, never the pointee, which may already be freed.
2. `inverted_index::test_utils` — `relocate_block_buffer` and `reserve_block_buffer`, which force a move and an in-place growth rather than leaving it to the allocator.
3. Tests — reader-level for each outcome, and iterator-level for a moved buffer with and without an interleaved GC cycle.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
