### PR TITLE
[MOD-16889] Allocate default KNN score field name on the heap

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -567,10 +567,9 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn,
     if (qn->vn.vq->scoreField) {
       // Since the KNN syntax allows specifying the distance field in two ways (...=>[KNN ... AS <dist_field>] and
       // ...=>[KNN ...]=>{$YIELD_DISTANCE_AS:<dist_field>), we validate that we got it only once.
-      const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, NULL);
-      char *default_score_field = NULL;  // buffer for __<field>_score
-      const int n_written = rm_asprintf(&default_score_field, "__%s_score", fieldName);
-      RS_ASSERT(n_written != -1);
+      size_t len;
+      const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, &len);
+      char *default_score_field = VectorQuery_GetDefaultScoreFieldName(fieldName, len);
       // If the saved score field is NOT the default one, we return an error, otherwise, just override it.
       const bool is_default_score_field =
           strcasecmp(qn->vn.vq->scoreField, default_score_field) == 0;

--- a/src/query.c
+++ b/src/query.c
@@ -567,12 +567,15 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn,
     if (qn->vn.vq->scoreField) {
       // Since the KNN syntax allows specifying the distance field in two ways (...=>[KNN ... AS <dist_field>] and
       // ...=>[KNN ...]=>{$YIELD_DISTANCE_AS:<dist_field>), we validate that we got it only once.
-      size_t len;
-      const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, &len);
-      char default_score_field[len + 9];  // buffer for __<field>_score
-      sprintf(default_score_field, "__%s_score", fieldName);
+      const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, NULL);
+      char *default_score_field = NULL;  // buffer for __<field>_score
+      const int n_written = rm_asprintf(&default_score_field, "__%s_score", fieldName);
+      RS_ASSERT(n_written != -1);
       // If the saved score field is NOT the default one, we return an error, otherwise, just override it.
-      if (strcasecmp(qn->vn.vq->scoreField, default_score_field) != 0) {
+      const bool is_default_score_field =
+          strcasecmp(qn->vn.vq->scoreField, default_score_field) == 0;
+      rm_free(default_score_field);
+      if (!is_default_score_field) {
         QueryError_SetWithUserDataFmt(q->status, QUERY_ERROR_CODE_DUP_FIELD,
                                "Distance field was specified twice for vector query", ": %s and %s",
                                qn->vn.vq->scoreField, qn->opts.distField);

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2505,6 +2505,30 @@ def test_score_name_case_sensitivity():
 
 
 @skip(cluster=True)
+def test_score_name_long_field_name():
+    """KNN derives the default `__<field>_score` name from the vector field name
+    when resolving the distance field. Cover that with a long name, including the
+    path that compares against the derived default."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    dim = 2
+    vec_fieldname = 'v' * (9 * 1024 * 1024)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', vec_fieldname, 'VECTOR', 'FLAT', '6',
+               'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2').ok()
+    blob = create_np_array_typed([0] * dim).tobytes()
+
+    # Naming the distance field through both syntaxes at once is the only path that compares
+    # the given name against the default derived from the field name.
+    env.expect('FT.SEARCH', 'idx', f'*=>[KNN 2 @{vec_fieldname} $BLOB AS score]=>{{$yield_distance_as: score2}}',
+               'PARAMS', 2, 'BLOB', blob).error().contains(
+                   'Distance field was specified twice for vector query: score and score2')
+
+    # Naming it through neither yields under the derived default, which the query must still
+    # be able to build from a name this long.
+    env.expect('FT.SEARCH', 'idx', f'*=>[KNN 2 @{vec_fieldname} $BLOB]',
+               'PARAMS', 2, 'BLOB', blob).equal([0])
+
+
+@skip(cluster=True)
 def test_tiered_index_gc():
     N = 100
     env = Env(moduleArgs=f'WORKERS 2 FORK_GC_RUN_INTERVAL 1000000000000 FORK_GC_CLEAN_THRESHOLD {N}')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: KNN evaluation derives the default `__<field>_score` name with a stack buffer sized from the vector field name.
2. Change: Derive that name on the heap instead, the same way the parser already builds the default when it is first assigned.
3. Outcome: Internal-only. Long field names no longer size a stack allocation while resolving the KNN distance field. Commands, replies, and schema rules are unchanged.

#### Which additional issues this PR fixes

1. https://redislabs.atlassian.net/browse/MOD-16889

#### Main objects this PR modified

1. `Query_EvalVectorNode` — heap-allocate the default score-field name used when both KNN distance-field syntaxes are present.
2. `test_vecsim` — cover the same path with a long vector field name.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
