### PR TITLE
[MOD-16400] Trie - honor a caller deadline in term dictionary walks

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3066,6 +3066,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_dictionary"
+version = "0.0.1"
+dependencies = [
+ "trie_rs",
+ "workspace_hack",
+]
+
+[[package]]
 name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3069,6 +3069,7 @@ dependencies = [
 name = "term_dictionary"
 version = "0.0.1"
 dependencies = [
+ "string_utils",
  "trie_rs",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "spellcheck_dictionary",
     "string_utils",
     "tag_index",
+    "term_dictionary",
     "term_suffix_index",
     "timeout",
     "tools/license_header_linter",
@@ -164,6 +165,7 @@ slots_tracker = { path = "./slots_tracker" }
 sorting_vector = { path = "./sorting_vector" }
 string_utils = { path = "./string_utils" }
 tag_index = { path = "./tag_index" }
+term_dictionary = { path = "./term_dictionary" }
 term_suffix_index = { path = "./term_suffix_index" }
 thin_vec = { path = "./thin_vec" }
 timeout = { path = "timeout" }

--- a/src/redisearch_rs/term_dictionary/Cargo.toml
+++ b/src/redisearch_rs/term_dictionary/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "term_dictionary"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+trie_rs.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/term_dictionary/Cargo.toml
+++ b/src/redisearch_rs/term_dictionary/Cargo.toml
@@ -9,5 +9,6 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+string_utils.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -53,6 +53,14 @@
 //! [`TermDictionary::prefixed_iter`] needs no such guard: C's prefix-only
 //! mode also yields every term for an empty prefix, so the trie's own
 //! semantics already agree.
+//!
+//! ## Deadlines
+//!
+//! The dictionary holds no clock. Callers with a query deadline install a
+//! `should_stop` predicate on the returned iterator — see
+//! [`PrefixedIter::set_should_stop`] for the polling contract (the other
+//! iterators expose the same method). [`TermDictionary::fuzzy_iter`] is the
+//! exception: the fuzzy walk it replaces carries no deadline.
 
 use string_utils::unicode;
 use trie_rs::str_trie_map::{

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -9,9 +9,10 @@
 
 //! Term dictionary keyed by case-folded UTF-8 strings.
 //!
-//! Wraps a [`StrTrieMap<TermEntry>`] with the per-term bookkeeping used by
-//! the FT.SEARCH terms trie (`sp->terms`). The wrapper owns the `numDocs`
-//! accounting and the "delete when the last doc disappears" policy.
+//! [`TermDictionary`] wraps a [`StrTrieMap<TermEntry>`] with the per-term
+//! bookkeeping used by the FT.SEARCH terms trie (`sp->terms`). The wrapper
+//! owns the `numDocs` accounting and the "delete when the last doc
+//! disappears" policy.
 //!
 //! ## Case-folding contract
 //!
@@ -24,10 +25,8 @@
 //!
 //! Folding lower-cases each [`char`] independently via [`char::to_lowercase`],
 //! matching RediSearch's C `unicode_tolower` (libnu-backed, context-free
-//! per-codepoint) — verified byte-identical against the vendored libnu's
-//! Unicode 17.0 tables over the full codepoint range. A future Unicode bump
-//! on either side (Rust toolchain or libnu) requires re-verifying that the
-//! two lowercase tables still agree. This is intentionally *not* Unicode default
+//! per-codepoint); the equivalence is pinned by the differential tests in
+//! `string_utils`. This is intentionally *not* Unicode default
 //! case folding: terms enter the dictionary already lower-cased by the C
 //! tokenizer, and re-folding must be byte-identical so the Rust and C paths
 //! agree on the stored key. Default folding would diverge on codepoints like
@@ -51,12 +50,14 @@ use trie_rs::str_trie_map::{
 
 /// Per-term metadata stored at each terminal in the term dictionary.
 ///
-/// Holds the subset of fields the FT.SEARCH terms trie actually reads:
-/// score (constant `1.0` in current call sites) plus the number of
-/// indexed documents containing this term.
+/// Holds the subset of fields the FT.SEARCH terms trie actually reads.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TermEntry {
+    /// Sum of the per-document scores contributed for this term.
     pub score: f32,
+    /// Number of indexed documents that contain this term. The entry is
+    /// removed once this reaches zero — see
+    /// [`TermDictionary::decrement_num_docs`].
     pub num_docs: usize,
 }
 
@@ -65,9 +66,9 @@ pub struct TermEntry {
 pub enum DecrResult {
     /// No terminal entry exists for the given term.
     NotFound,
-    /// `num_docs` was decremented and is still `> 0`.
+    /// [`TermEntry::num_docs`] was decremented and is still `> 0`.
     Updated,
-    /// `num_docs` reached `0`; the entry was removed.
+    /// [`TermEntry::num_docs`] reached `0`; the entry was removed.
     Deleted,
 }
 
@@ -82,16 +83,12 @@ pub enum InsertOutcome {
 
 /// Term dictionary used by the FT.SEARCH index (`sp->terms`).
 ///
-/// Maps each indexed term to its [`TermEntry`]. Two production insert
-/// modes are exposed: [`Self::add_term`] (ADD_INCR — accumulate `score`
-/// and `num_docs`) and [`Self::replace_term`] (ADD_REPLACE — overwrite
-/// `score`, still accumulate `num_docs`). The primitive [`Self::insert`]
-/// stays available for bulk-seeding scenarios where neither accumulation
-/// mode applies.
+/// Maps each indexed term to its [`TermEntry`]. Inserts go through
+/// [`Self::add_term`], [`Self::replace_term`], or the primitive
+/// [`Self::insert`]; each documents its own accumulation semantics.
 ///
-/// All terms and lookup patterns are case-folded internally via
-/// [`char::to_lowercase`] — see the module docs for the case-folding
-/// contract.
+/// All terms and lookup patterns are case-folded internally — see the
+/// [module docs](self) for the case-folding contract.
 pub struct TermDictionary {
     inner: StrTrieMap<TermEntry>,
 }
@@ -103,37 +100,40 @@ impl Default for TermDictionary {
 }
 
 impl TermDictionary {
+    /// Create an empty dictionary.
     pub const fn new() -> Self {
         Self {
             inner: StrTrieMap::new(),
         }
     }
 
+    /// The number of terms stored.
     pub const fn len(&self) -> usize {
         self.inner.len()
     }
 
+    /// `true` when no terms are stored.
     pub const fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
-    /// Estimated heap memory currently held by this dictionary — O(1).
+    /// Estimated heap memory currently held by this dictionary.
     /// See [`StrTrieMap::mem_usage`] for what the cached counter covers.
     pub const fn mem_usage(&self) -> usize {
         self.inner.mem_usage()
     }
 
     /// Primitive overwrite — distinct from [`Self::replace_term`] in that
-    /// it does NOT accumulate `num_docs`. Useful for bulk seeding and for
+    /// it does NOT accumulate [`TermEntry::num_docs`]. Useful for bulk seeding and for
     /// re-installing a fully formed entry; production indexing paths
     /// should use [`Self::add_term`] / [`Self::replace_term`].
     pub fn insert(&mut self, term: &str, entry: TermEntry) -> Option<TermEntry> {
         self.inner.insert(&fold(term), entry)
     }
 
-    /// ADD_INCR insert: accumulate both `score` and `num_docs` onto the
-    /// existing entry, or create a fresh terminal if absent. `term` is
-    /// case-folded before lookup.
+    /// ADD_INCR insert: accumulate both [`TermEntry::score`] and
+    /// [`TermEntry::num_docs`] onto the existing entry, or create a fresh
+    /// terminal if absent.
     pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
         let mut outcome = InsertOutcome::New;
         self.inner.insert_with(&fold(term), |prior| match prior {
@@ -148,9 +148,9 @@ impl TermDictionary {
         outcome
     }
 
-    /// ADD_REPLACE insert: overwrite `score`, but still accumulate
-    /// `num_docs` onto the existing count. Creates a fresh terminal if
-    /// absent. `term` is case-folded before lookup.
+    /// ADD_REPLACE insert: overwrite [`TermEntry::score`], but still
+    /// accumulate [`TermEntry::num_docs`] onto the existing count. Creates
+    /// a fresh terminal if absent.
     pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
         let mut outcome = InsertOutcome::New;
         self.inner.insert_with(&fold(term), |prior| {
@@ -169,19 +169,23 @@ impl TermDictionary {
         outcome
     }
 
+    /// Removes the entry for `term`, returning the previous [`TermEntry`].
     pub fn remove(&mut self, term: &str) -> Option<TermEntry> {
         self.inner.remove(&fold(term))
     }
 
+    /// Returns the [`TermEntry`] stored for `term`, if any.
     pub fn get(&self, term: &str) -> Option<&TermEntry> {
         self.inner.get(&fold(term))
     }
 
+    /// Iterate over all entries in lexicographical key order.
+    /// See [`StrTrieMap::iter`].
     pub fn iter(&self) -> Iter<'_, TermEntry> {
         self.inner.iter()
     }
 
-    /// Case-folds `target`; see [`StrTrieMap::contains_iter`] and
+    /// Yield every entry whose key contains `target` as a substring. See
     /// [`ContainsIter`] for the lazy-vs-drained behaviour when folding
     /// allocates.
     pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> ContainsIter<'tm, 'p> {
@@ -194,37 +198,35 @@ impl TermDictionary {
         }
     }
 
-    /// Case-folds `prefix`; see [`StrTrieMap::prefixed_iter`].
+    /// See [`StrTrieMap::prefixed_iter`].
     pub fn prefixed_iter(&self, prefix: &str) -> PrefixedIter<'_, TermEntry> {
         self.inner.prefixed_iter(&fold(prefix))
     }
 
-    /// Case-folds `suffix`; see [`StrTrieMap::suffixed_iter`].
+    /// See [`StrTrieMap::suffixed_iter`].
     pub fn suffixed_iter(&self, suffix: &str) -> SuffixedIter<'_, TermEntry> {
         self.inner.suffixed_iter(&fold(suffix))
     }
 
-    /// Case-folds `pattern`; see [`StrTrieMap::wildcard_iter`] for the
-    /// codepoint matching model (`?` consumes one codepoint). `?` and `*`
-    /// are ASCII so wildcard semantics survive folding. The returned
-    /// iterator owns the parsed pattern, so it stays lazy regardless of
-    /// whether folding allocated.
+    /// See [`StrTrieMap::wildcard_iter`] for the codepoint matching model.
+    /// `?` and `*` are ASCII so wildcard semantics survive folding. The
+    /// returned iterator owns the parsed pattern, so it stays lazy
+    /// regardless of whether folding allocated.
     pub fn wildcard_iter(&self, pattern: &str) -> StrWildcardIter<'_, TermEntry> {
         self.inner.wildcard_iter(&fold(pattern))
     }
 
-    /// See [`StrTrieMap::fuzzy_iter`] for the matching model — Levenshtein
-    /// distance in codepoints under per-codepoint case folding. The
+    /// See [`StrTrieMap::fuzzy_iter`] for the matching model. The
     /// underlying automaton already folds the pattern (and each candidate
     /// key) with the same per-[`char`] lowering, so no fold is applied here.
     pub fn fuzzy_iter(&self, pattern: &str, max_dist: u32) -> FuzzyIter<'_, TermEntry> {
         self.inner.fuzzy_iter(pattern, max_dist)
     }
 
-    /// Decrement the `num_docs` count for `term` by `delta`. Saturating
-    /// subtract — when `num_docs` reaches zero the entry is removed.
-    /// Returns [`DecrResult::NotFound`] if no terminal entry exists for
-    /// `term`. `term` is case-folded before lookup.
+    /// Subtracts `delta` from [`TermEntry::num_docs`]; if `delta` meets or
+    /// exceeds the count, the entry is removed and [`DecrResult::Deleted`]
+    /// is returned. Returns [`DecrResult::NotFound`] if no terminal entry
+    /// exists for `term`.
     pub fn decrement_num_docs(&mut self, term: &str, delta: usize) -> DecrResult {
         let term = fold(term);
         let Some(entry) = self.inner.get_mut(&term) else {
@@ -244,14 +246,16 @@ impl TermDictionary {
 ///
 /// Case-folding the target may allocate. When it does (mixed-case input),
 /// the folded buffer cannot outlive this iterator, so the matches are
-/// drained eagerly into a `Vec` at construction ([`Self::Drained`]). When
+/// drained eagerly into a [`Vec`] at construction ([`Self::Drained`]). When
 /// folding borrows (already-folded input) the iterator stays lazy
 /// ([`Self::Lazy`]) and streams directly from the trie. Both yield the same
 /// items in the same order.
 pub enum ContainsIter<'tm, 'p> {
+    /// Streams matches directly from the trie (folding borrowed).
     // Boxed: the streaming iterator's traversal stack dwarfs the drained
     // variant, and clippy::large_enum_variant rejects the imbalance.
     Lazy(Box<StrContainsIter<'tm, 'p, TermEntry>>),
+    /// Matches collected at construction (folding allocated).
     Drained(std::vec::IntoIter<(String, &'tm TermEntry)>),
 }
 

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -226,15 +226,18 @@ impl TermDictionary {
     /// exists for `term`.
     pub fn decrement_num_docs(&mut self, term: &str, delta: usize) -> DecrResult {
         let term = fold(term);
-        let Some(entry) = self.inner.get_mut(&term) else {
-            return DecrResult::NotFound;
-        };
-        if delta < entry.num_docs {
-            entry.num_docs -= delta;
-            DecrResult::Updated
-        } else {
-            self.inner.remove(&term);
-            DecrResult::Deleted
+
+        match self.inner.get_mut(&term) {
+            Some(entry) => {
+                if delta >= entry.num_docs {
+                    self.inner.remove(&term);
+                    DecrResult::Deleted
+                } else {
+                    entry.num_docs -= delta;
+                    DecrResult::Updated
+                }
+            }
+            None => DecrResult::NotFound,
         }
     }
 }

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -129,21 +129,24 @@ impl TermDictionary {
     /// re-installing a fully formed entry; production indexing paths
     /// should use [`Self::add_term`] / [`Self::replace_term`].
     pub fn insert(&mut self, term: &str, entry: TermEntry) -> Option<TermEntry> {
-        self.inner.insert(&fold(term), entry)
+        self.inner.insert(&unicode::tolower_cow(term), entry)
     }
 
     /// ADD_INCR insert: accumulate both [`TermEntry::score`] and
     /// [`TermEntry::num_docs`] onto the existing entry, or create a fresh
     /// terminal if absent.
     pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        if self.inner.insert_with(&fold(term), |prior| match prior {
-            Some(mut entry) => {
-                entry.score += score;
-                entry.num_docs += num_docs;
-                entry
-            }
-            None => TermEntry { score, num_docs },
-        }) {
+        if self
+            .inner
+            .insert_with(&unicode::tolower_cow(term), |prior| match prior {
+                Some(mut entry) => {
+                    entry.score += score;
+                    entry.num_docs += num_docs;
+                    entry
+                }
+                None => TermEntry { score, num_docs },
+            })
+        {
             InsertOutcome::New
         } else {
             InsertOutcome::Updated
@@ -154,13 +157,16 @@ impl TermDictionary {
     /// accumulate [`TermEntry::num_docs`] onto the existing count. Creates
     /// a fresh terminal if absent.
     pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        if self.inner.insert_with(&fold(term), |prior| {
-            let prior_num_docs = prior.map_or(0, |entry| entry.num_docs);
-            TermEntry {
-                score,
-                num_docs: prior_num_docs + num_docs,
-            }
-        }) {
+        if self
+            .inner
+            .insert_with(&unicode::tolower_cow(term), |prior| {
+                let prior_num_docs = prior.map_or(0, |entry| entry.num_docs);
+                TermEntry {
+                    score,
+                    num_docs: prior_num_docs + num_docs,
+                }
+            })
+        {
             InsertOutcome::New
         } else {
             InsertOutcome::Updated
@@ -169,12 +175,12 @@ impl TermDictionary {
 
     /// Removes the entry for `term`, returning the previous [`TermEntry`].
     pub fn remove(&mut self, term: &str) -> Option<TermEntry> {
-        self.inner.remove(&fold(term))
+        self.inner.remove(&unicode::tolower_cow(term))
     }
 
     /// Returns the [`TermEntry`] stored for `term`, if any.
     pub fn get(&self, term: &str) -> Option<&TermEntry> {
-        self.inner.get(&fold(term))
+        self.inner.get(&unicode::tolower_cow(term))
     }
 
     /// Iterate over all entries in lexicographical key order.
@@ -187,7 +193,7 @@ impl TermDictionary {
     /// [`ContainsIter`] for the lazy-vs-drained behaviour when folding
     /// allocates.
     pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> ContainsIter<'tm, 'p> {
-        match fold(target) {
+        match unicode::tolower_cow(target) {
             Cow::Borrowed(s) => ContainsIter::Lazy(Box::new(self.inner.contains_iter(s))),
             Cow::Owned(s) => {
                 let drained: Vec<(String, &'tm TermEntry)> = self.inner.contains_iter(&s).collect();
@@ -198,12 +204,12 @@ impl TermDictionary {
 
     /// See [`StrTrieMap::prefixed_iter`].
     pub fn prefixed_iter(&self, prefix: &str) -> PrefixedIter<'_, TermEntry> {
-        self.inner.prefixed_iter(&fold(prefix))
+        self.inner.prefixed_iter(&unicode::tolower_cow(prefix))
     }
 
     /// See [`StrTrieMap::suffixed_iter`].
     pub fn suffixed_iter(&self, suffix: &str) -> SuffixedIter<'_, TermEntry> {
-        self.inner.suffixed_iter(&fold(suffix))
+        self.inner.suffixed_iter(&unicode::tolower_cow(suffix))
     }
 
     /// See [`StrTrieMap::wildcard_iter`] for the codepoint matching model.
@@ -211,7 +217,7 @@ impl TermDictionary {
     /// returned iterator owns the parsed pattern, so it stays lazy
     /// regardless of whether folding allocated.
     pub fn wildcard_iter(&self, pattern: &str) -> StrWildcardIter<'_, TermEntry> {
-        self.inner.wildcard_iter(&fold(pattern))
+        self.inner.wildcard_iter(&unicode::tolower_cow(pattern))
     }
 
     /// See [`StrTrieMap::fuzzy_iter`] for the matching model. The
@@ -226,7 +232,7 @@ impl TermDictionary {
     /// is returned. Returns [`DecrResult::NotFound`] if no terminal entry
     /// exists for `term`.
     pub fn decrement_num_docs(&mut self, term: &str, delta: usize) -> DecrResult {
-        let term = fold(term);
+        let term = unicode::tolower_cow(term);
 
         match self.inner.get_mut(&term) {
             Some(entry) => {
@@ -269,11 +275,4 @@ impl<'tm, 'p> Iterator for ContainsIter<'tm, 'p> {
             Self::Drained(it) => it.next(),
         }
     }
-}
-
-/// Lower-case a term the way RediSearch's C tokenizer does. See
-/// [`unicode::tolower_cow`] for the folding model and its equivalence to the
-/// libnu-backed C `unicode_tolower`.
-fn fold(term: &str) -> Cow<'_, str> {
-    unicode::tolower_cow(term)
 }

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -38,8 +38,6 @@
 //! The underlying [`StrTrieMap`] stays byte-exact; case-folding is a
 //! property of `TermDictionary` alone.
 
-use std::borrow::Cow;
-
 use string_utils::unicode;
 use trie_rs::str_trie_map::{
     StrTrieMap,
@@ -189,17 +187,14 @@ impl TermDictionary {
         self.inner.iter()
     }
 
-    /// Yield every entry whose key contains `target` as a substring. See
-    /// [`ContainsIter`] for the lazy-vs-drained behaviour when folding
-    /// allocates.
-    pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> ContainsIter<'tm, 'p> {
-        match unicode::tolower_cow(target) {
-            Cow::Borrowed(s) => ContainsIter::Lazy(Box::new(self.inner.contains_iter(s))),
-            Cow::Owned(s) => {
-                let drained: Vec<(String, &'tm TermEntry)> = self.inner.contains_iter(&s).collect();
-                ContainsIter::Drained(drained.into_iter())
-            }
-        }
+    /// Yield every entry whose key contains the case-folded `target` as a
+    /// substring. See [`StrTrieMap::contains_iter`]. The iterator owns the
+    /// folded target when folding allocates, so it stays lazy either way.
+    pub fn contains_iter<'tm, 'p>(
+        &'tm self,
+        target: &'p str,
+    ) -> StrContainsIter<'tm, 'p, TermEntry> {
+        self.inner.contains_iter(unicode::tolower_cow(target))
     }
 
     /// See [`StrTrieMap::prefixed_iter`].
@@ -245,34 +240,6 @@ impl TermDictionary {
                 }
             }
             None => DecrResult::NotFound,
-        }
-    }
-}
-
-/// Iterator returned by [`TermDictionary::contains_iter`].
-///
-/// Case-folding the target may allocate. When it does (mixed-case input),
-/// the folded buffer cannot outlive this iterator, so the matches are
-/// drained eagerly into a [`Vec`] at construction ([`Self::Drained`]). When
-/// folding borrows (already-folded input) the iterator stays lazy
-/// ([`Self::Lazy`]) and streams directly from the trie. Both yield the same
-/// items in the same order.
-pub enum ContainsIter<'tm, 'p> {
-    /// Streams matches directly from the trie (folding borrowed).
-    // Boxed: the streaming iterator's traversal stack dwarfs the drained
-    // variant, and clippy::large_enum_variant rejects the imbalance.
-    Lazy(Box<StrContainsIter<'tm, 'p, TermEntry>>),
-    /// Matches collected at construction (folding allocated).
-    Drained(std::vec::IntoIter<(String, &'tm TermEntry)>),
-}
-
-impl<'tm, 'p> Iterator for ContainsIter<'tm, 'p> {
-    type Item = (String, &'tm TermEntry);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Lazy(it) => it.next(),
-            Self::Drained(it) => it.next(),
         }
     }
 }

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -135,38 +135,37 @@ impl TermDictionary {
     /// [`TermEntry::num_docs`] onto the existing entry, or create a fresh
     /// terminal if absent.
     pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let mut outcome = InsertOutcome::New;
-        self.inner.insert_with(&fold(term), |prior| match prior {
+        let is_new = self.inner.insert_with(&fold(term), |prior| match prior {
             Some(mut entry) => {
-                outcome = InsertOutcome::Updated;
                 entry.score += score;
                 entry.num_docs += num_docs;
                 entry
             }
             None => TermEntry { score, num_docs },
         });
-        outcome
+        if is_new {
+            InsertOutcome::New
+        } else {
+            InsertOutcome::Updated
+        }
     }
 
     /// ADD_REPLACE insert: overwrite [`TermEntry::score`], but still
     /// accumulate [`TermEntry::num_docs`] onto the existing count. Creates
     /// a fresh terminal if absent.
     pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let mut outcome = InsertOutcome::New;
-        self.inner.insert_with(&fold(term), |prior| {
-            let prior_num_docs = match prior {
-                Some(entry) => {
-                    outcome = InsertOutcome::Updated;
-                    entry.num_docs
-                }
-                None => 0,
-            };
+        let is_new = self.inner.insert_with(&fold(term), |prior| {
+            let prior_num_docs = prior.map_or(0, |entry| entry.num_docs);
             TermEntry {
                 score,
                 num_docs: prior_num_docs + num_docs,
             }
         });
-        outcome
+        if is_new {
+            InsertOutcome::New
+        } else {
+            InsertOutcome::Updated
+        }
     }
 
     /// Removes the entry for `term`, returning the previous [`TermEntry`].

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -23,7 +23,7 @@
 //! inside `TermDictionary` lets future C-to-Rust call sites stop repeating
 //! the obligation.
 //!
-//! Folding lower-cases each [`char`] independently via [`char::to_lowercase`],
+//! Folding is [`unicode::tolower_cow`]: each [`char`] lowered independently,
 //! matching RediSearch's C `unicode_tolower` (libnu-backed, context-free
 //! per-codepoint); the equivalence is pinned by the differential tests in
 //! `string_utils`. This is intentionally *not* Unicode default
@@ -40,6 +40,7 @@
 
 use std::borrow::Cow;
 
+use string_utils::unicode;
 use trie_rs::str_trie_map::{
     StrTrieMap,
     iter::{
@@ -270,17 +271,9 @@ impl<'tm, 'p> Iterator for ContainsIter<'tm, 'p> {
     }
 }
 
-/// Lower-case a term the way RediSearch's C tokenizer does: each [`char`]
-/// independently via [`char::to_lowercase`], matching the libnu-backed C
-/// `unicode_tolower`.
+/// Lower-case a term the way RediSearch's C tokenizer does. See
+/// [`unicode::tolower_cow`] for the folding model and its equivalence to the
+/// libnu-backed C `unicode_tolower`.
 fn fold(term: &str) -> Cow<'_, str> {
-    let unchanged = term.chars().all(|c| {
-        let mut lower = c.to_lowercase();
-        lower.next() == Some(c) && lower.next().is_none()
-    });
-    if unchanged {
-        Cow::Borrowed(term)
-    } else {
-        Cow::Owned(term.chars().flat_map(char::to_lowercase).collect())
-    }
+    unicode::tolower_cow(term)
 }

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -37,6 +37,22 @@
 //!
 //! The underlying [`StrTrieMap`] stays byte-exact; case-folding is a
 //! property of `TermDictionary` alone.
+//!
+//! ## Empty patterns
+//!
+//! [`TermDictionary::contains_iter`] and [`TermDictionary::suffixed_iter`]
+//! yield nothing for an empty pattern, whereas the underlying [`StrTrieMap`]
+//! yields every entry — the empty string is a substring and a suffix of every
+//! key. The C walk this dictionary replaces (`TrieNode_IterateContains`)
+//! yields nothing in both modes: its full-match test compares against the
+//! pattern's last byte, which no position satisfies when the pattern is
+//! empty. Matching that here keeps the two implementations
+//! interchangeable, and matches the guard the existing C wrapper applies at
+//! the same boundary (`TermsTrie::iterate_contains`).
+//!
+//! [`TermDictionary::prefixed_iter`] needs no such guard: C's prefix-only
+//! mode also yields every term for an empty prefix, so the trie's own
+//! semantics already agree.
 
 use string_utils::unicode;
 use trie_rs::str_trie_map::{
@@ -190,10 +206,16 @@ impl TermDictionary {
     /// Yield every entry whose key contains the case-folded `target` as a
     /// substring. See [`StrTrieMap::contains_iter`]. The iterator owns the
     /// folded target when folding allocates, so it stays lazy either way.
+    ///
+    /// An empty `target` yields nothing, unlike [`StrTrieMap::contains_iter`]
+    /// — see the [module docs](self#empty-patterns).
     pub fn contains_iter<'tm, 'p>(
         &'tm self,
         target: &'p str,
     ) -> StrContainsIter<'tm, 'p, TermEntry> {
+        if target.is_empty() {
+            return StrContainsIter::empty();
+        }
         self.inner.contains_iter(unicode::tolower_cow(target))
     }
 
@@ -203,7 +225,13 @@ impl TermDictionary {
     }
 
     /// See [`StrTrieMap::suffixed_iter`].
+    ///
+    /// An empty `suffix` yields nothing, unlike [`StrTrieMap::suffixed_iter`]
+    /// — see the [module docs](self#empty-patterns).
     pub fn suffixed_iter(&self, suffix: &str) -> SuffixedIter<'_, TermEntry> {
+        if suffix.is_empty() {
+            return SuffixedIter::empty();
+        }
         self.inner.suffixed_iter(&unicode::tolower_cow(suffix))
     }
 

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -17,8 +17,10 @@
 //!
 //! All keys and patterns are case-folded on the way in before reaching the
 //! underlying [`StrTrieMap`], so the trie itself only ever holds folded
-//! keys. Moving the fold inside `TermDictionary` lets future C-to-Rust call
-//! sites stop repeating the obligation.
+//! keys. (The one exception is [`TermDictionary::fuzzy_iter`], whose
+//! underlying automaton applies the identical fold itself.) Moving the fold
+//! inside `TermDictionary` lets future C-to-Rust call sites stop repeating
+//! the obligation.
 //!
 //! Folding lower-cases each [`char`] independently via [`char::to_lowercase`],
 //! exactly matching RediSearch's C `unicode_tolower` (libnu-backed,
@@ -109,8 +111,8 @@ impl TermDictionary {
         self.inner.is_empty()
     }
 
-    /// Estimated heap memory currently held by this index. Mirrors the cached
-    /// counter on the underlying StrTrieMap — O(1). See [`StrTrieMap::mem_usage`].
+    /// Estimated heap memory currently held by this dictionary — O(1).
+    /// See [`StrTrieMap::mem_usage`] for what the cached counter covers.
     pub const fn mem_usage(&self) -> usize {
         self.inner.mem_usage()
     }
@@ -127,30 +129,38 @@ impl TermDictionary {
     /// existing entry, or create a fresh terminal if absent. `term` is
     /// case-folded before lookup.
     pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let term = fold(term);
-        if let Some(entry) = self.inner.get_mut(&term) {
-            entry.score += score;
-            entry.num_docs += num_docs;
-            InsertOutcome::Updated
-        } else {
-            self.inner.insert(&term, TermEntry { score, num_docs });
-            InsertOutcome::New
-        }
+        let mut outcome = InsertOutcome::New;
+        self.inner.insert_with(&fold(term), |prior| match prior {
+            Some(mut entry) => {
+                outcome = InsertOutcome::Updated;
+                entry.score += score;
+                entry.num_docs += num_docs;
+                entry
+            }
+            None => TermEntry { score, num_docs },
+        });
+        outcome
     }
 
     /// ADD_REPLACE insert: overwrite `score`, but still accumulate
     /// `num_docs` onto the existing count. Creates a fresh terminal if
     /// absent. `term` is case-folded before lookup.
     pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let term = fold(term);
-        if let Some(entry) = self.inner.get_mut(&term) {
-            entry.score = score;
-            entry.num_docs += num_docs;
-            InsertOutcome::Updated
-        } else {
-            self.inner.insert(&term, TermEntry { score, num_docs });
-            InsertOutcome::New
-        }
+        let mut outcome = InsertOutcome::New;
+        self.inner.insert_with(&fold(term), |prior| {
+            let prior_num_docs = match prior {
+                Some(entry) => {
+                    outcome = InsertOutcome::Updated;
+                    entry.num_docs
+                }
+                None => 0,
+            };
+            TermEntry {
+                score,
+                num_docs: prior_num_docs + num_docs,
+            }
+        });
+        outcome
     }
 
     pub fn remove(&mut self, term: &str) -> Option<TermEntry> {
@@ -197,12 +207,12 @@ impl TermDictionary {
         self.inner.wildcard_iter(&fold(pattern))
     }
 
-    /// Case-folds `pattern`; see [`StrTrieMap::fuzzy_iter`] for the
-    /// matching model — Levenshtein distance in codepoints under
-    /// per-codepoint case folding. The returned iterator owns the folded
-    /// needle, so it stays lazy regardless of whether folding allocated.
+    /// See [`StrTrieMap::fuzzy_iter`] for the matching model — Levenshtein
+    /// distance in codepoints under per-codepoint case folding. The
+    /// underlying automaton already folds the pattern (and each candidate
+    /// key) with the same per-[`char`] lowering, so no fold is applied here.
     pub fn fuzzy_iter(&self, pattern: &str, max_dist: u32) -> FuzzyIter<'_, TermEntry> {
-        self.inner.fuzzy_iter(&fold(pattern), max_dist)
+        self.inner.fuzzy_iter(pattern, max_dist)
     }
 
     /// Decrement the `num_docs` count for `term` by `delta`. Saturating

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -56,11 +56,13 @@
 //!
 //! ## Deadlines
 //!
-//! The dictionary holds no clock. Callers with a query deadline install a
-//! `should_stop` predicate on the returned iterator — see
-//! [`PrefixedIter::set_should_stop`] for the polling contract (the other
-//! iterators expose the same method). [`TermDictionary::fuzzy_iter`] is the
-//! exception: the fuzzy walk it replaces carries no deadline.
+//! The dictionary holds no clock. Every pattern walk takes a `should_stop`
+//! predicate, so the caller owns the deadline (or whatever else signals
+//! cancellation) and a call site cannot forget to pass one; a caller with no
+//! deadline passes `|| false`. See
+//! [`TIMEOUT_CHECK_GRANULARITY`](trie_rs::iter::TIMEOUT_CHECK_GRANULARITY)
+//! for the polling contract. [`TermDictionary::fuzzy_iter`] is the exception:
+//! the fuzzy walk it replaces carries no deadline.
 
 use string_utils::unicode;
 use trie_rs::str_trie_map::{
@@ -212,43 +214,64 @@ impl TermDictionary {
     }
 
     /// Yield every entry whose key contains the case-folded `target` as a
-    /// substring. See [`StrTrieMap::contains_iter`]. The iterator owns the
-    /// folded target when folding allocates, so it stays lazy either way.
+    /// substring, abandoning the walk once `should_stop` returns `true`. See
+    /// [`StrTrieMap::contains_iter`]. The iterator owns the folded target
+    /// when folding allocates, so it stays lazy either way.
     ///
     /// An empty `target` yields nothing, unlike [`StrTrieMap::contains_iter`]
     /// — see the [module docs](self#empty-patterns).
     pub fn contains_iter<'tm, 'p>(
         &'tm self,
         target: &'p str,
+        should_stop: impl FnMut() -> bool + 'tm,
     ) -> StrContainsIter<'tm, 'p, TermEntry> {
         if target.is_empty() {
             return StrContainsIter::empty();
         }
-        self.inner.contains_iter(unicode::tolower_cow(target))
+        self.inner
+            .contains_iter_with_should_stop(unicode::tolower_cow(target), should_stop)
     }
 
-    /// See [`StrTrieMap::prefixed_iter`].
-    pub fn prefixed_iter(&self, prefix: &str) -> PrefixedIter<'_, TermEntry> {
-        self.inner.prefixed_iter(&unicode::tolower_cow(prefix))
+    /// See [`StrTrieMap::prefixed_iter`]. Abandons the walk once
+    /// `should_stop` returns `true`.
+    pub fn prefixed_iter<'tm>(
+        &'tm self,
+        prefix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> PrefixedIter<'tm, TermEntry> {
+        self.inner
+            .prefixed_iter_with_should_stop(&unicode::tolower_cow(prefix), should_stop)
     }
 
-    /// See [`StrTrieMap::suffixed_iter`].
+    /// See [`StrTrieMap::suffixed_iter`]. Abandons the walk once
+    /// `should_stop` returns `true`.
     ///
     /// An empty `suffix` yields nothing, unlike [`StrTrieMap::suffixed_iter`]
     /// — see the [module docs](self#empty-patterns).
-    pub fn suffixed_iter(&self, suffix: &str) -> SuffixedIter<'_, TermEntry> {
+    pub fn suffixed_iter<'tm>(
+        &'tm self,
+        suffix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> SuffixedIter<'tm, TermEntry> {
         if suffix.is_empty() {
             return SuffixedIter::empty();
         }
-        self.inner.suffixed_iter(&unicode::tolower_cow(suffix))
+        self.inner
+            .suffixed_iter_with_should_stop(&unicode::tolower_cow(suffix), should_stop)
     }
 
     /// See [`StrTrieMap::wildcard_iter`] for the codepoint matching model.
     /// `?` and `*` are ASCII so wildcard semantics survive folding. The
     /// returned iterator owns the parsed pattern, so it stays lazy
-    /// regardless of whether folding allocated.
-    pub fn wildcard_iter(&self, pattern: &str) -> StrWildcardIter<'_, TermEntry> {
-        self.inner.wildcard_iter(&unicode::tolower_cow(pattern))
+    /// regardless of whether folding allocated. Abandons the walk once
+    /// `should_stop` returns `true`.
+    pub fn wildcard_iter<'tm>(
+        &'tm self,
+        pattern: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> StrWildcardIter<'tm, TermEntry> {
+        self.inner
+            .wildcard_iter_with_should_stop(&unicode::tolower_cow(pattern), should_stop)
     }
 
     /// See [`StrTrieMap::fuzzy_iter`] for the matching model. The

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Term dictionary keyed by case-folded UTF-8 strings.
+//!
+//! Wraps a [`StrTrieMap<TermEntry>`] with the per-term bookkeeping used by
+//! the FT.SEARCH terms trie (`sp->terms`). The wrapper owns the `numDocs`
+//! accounting and the "delete when the last doc disappears" policy.
+//!
+//! ## Case-folding contract
+//!
+//! All keys and patterns are case-folded on the way in before reaching the
+//! underlying [`StrTrieMap`], so the trie itself only ever holds folded
+//! keys. Moving the fold inside `TermDictionary` lets future C-to-Rust call
+//! sites stop repeating the obligation.
+//!
+//! Folding lower-cases each [`char`] independently via [`char::to_lowercase`],
+//! exactly matching RediSearch's C `unicode_tolower` (libnu-backed,
+//! context-free per-codepoint). This is intentionally *not* Unicode default
+//! case folding: terms enter the dictionary already lower-cased by the C
+//! tokenizer, and re-folding must be byte-identical so the Rust and C paths
+//! agree on the stored key. Default folding would diverge on codepoints like
+//! `ß` (→ `ss`) or `ς` (→ `σ`), splitting a term across two keys.
+//!
+//! Iteration outputs are already folded by construction — the keys were
+//! folded at insert — and are returned as-is.
+//!
+//! The underlying [`StrTrieMap`] stays byte-exact; case-folding is a
+//! property of `TermDictionary` alone.
+
+use std::borrow::Cow;
+
+use trie_rs::str_trie_map::{
+    StrTrieMap,
+    iter::{
+        ContainsIter as StrContainsIter, FuzzyIter, Iter, PrefixedIter, SuffixedIter,
+        WildcardIter as StrWildcardIter,
+    },
+};
+
+/// Per-term metadata stored at each terminal in the term dictionary.
+///
+/// Holds the subset of fields the FT.SEARCH terms trie actually reads:
+/// score (constant `1.0` in current call sites) plus the number of
+/// indexed documents containing this term.
+pub struct TermEntry {
+    pub score: f32,
+    pub num_docs: usize,
+}
+
+/// Outcome of [`TermDictionary::decrement_num_docs`].
+pub enum DecrResult {
+    /// No terminal entry exists for the given term.
+    NotFound,
+    /// `num_docs` was decremented and is still `> 0`.
+    Updated,
+    /// `num_docs` reached `0`; the entry was removed.
+    Deleted,
+}
+
+/// Outcome of [`TermDictionary::add_term`] / [`TermDictionary::replace_term`].
+pub enum InsertOutcome {
+    /// No prior entry existed; a new terminal was created.
+    New,
+    /// An existing entry was modified in place.
+    Updated,
+}
+
+/// Term dictionary used by the FT.SEARCH index (`sp->terms`).
+///
+/// Maps each indexed term to its [`TermEntry`]. Two production insert
+/// modes are exposed: [`Self::add_term`] (ADD_INCR — accumulate `score`
+/// and `num_docs`) and [`Self::replace_term`] (ADD_REPLACE — overwrite
+/// `score`, still accumulate `num_docs`). The primitive [`Self::insert`]
+/// stays available for bulk-seeding scenarios where neither accumulation
+/// mode applies.
+///
+/// All terms and lookup patterns are case-folded internally via
+/// [`char::to_lowercase`] — see the module docs for the case-folding
+/// contract.
+pub struct TermDictionary {
+    inner: StrTrieMap<TermEntry>,
+}
+
+impl Default for TermDictionary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TermDictionary {
+    pub const fn new() -> Self {
+        Self {
+            inner: StrTrieMap::new(),
+        }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Estimated heap memory currently held by this index. Mirrors the cached
+    /// counter on the underlying StrTrieMap — O(1). See [`StrTrieMap::mem_usage`].
+    pub const fn mem_usage(&self) -> usize {
+        self.inner.mem_usage()
+    }
+
+    /// Primitive overwrite — distinct from [`Self::replace_term`] in that
+    /// it does NOT accumulate `num_docs`. Useful for bulk seeding and for
+    /// re-installing a fully formed entry; production indexing paths
+    /// should use [`Self::add_term`] / [`Self::replace_term`].
+    pub fn insert(&mut self, term: &str, entry: TermEntry) -> Option<TermEntry> {
+        self.inner.insert(&fold(term), entry)
+    }
+
+    /// ADD_INCR insert: accumulate both `score` and `num_docs` onto the
+    /// existing entry, or create a fresh terminal if absent. `term` is
+    /// case-folded before lookup.
+    pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
+        let term = fold(term);
+        if let Some(entry) = self.inner.get_mut(&term) {
+            entry.score += score;
+            entry.num_docs += num_docs;
+            InsertOutcome::Updated
+        } else {
+            self.inner.insert(&term, TermEntry { score, num_docs });
+            InsertOutcome::New
+        }
+    }
+
+    /// ADD_REPLACE insert: overwrite `score`, but still accumulate
+    /// `num_docs` onto the existing count. Creates a fresh terminal if
+    /// absent. `term` is case-folded before lookup.
+    pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
+        let term = fold(term);
+        if let Some(entry) = self.inner.get_mut(&term) {
+            entry.score = score;
+            entry.num_docs += num_docs;
+            InsertOutcome::Updated
+        } else {
+            self.inner.insert(&term, TermEntry { score, num_docs });
+            InsertOutcome::New
+        }
+    }
+
+    pub fn remove(&mut self, term: &str) -> Option<TermEntry> {
+        self.inner.remove(&fold(term))
+    }
+
+    pub fn get(&self, term: &str) -> Option<&TermEntry> {
+        self.inner.get(&fold(term))
+    }
+
+    pub fn iter(&self) -> Iter<'_, TermEntry> {
+        self.inner.iter()
+    }
+
+    /// Case-folds `target`; see [`StrTrieMap::contains_iter`] and
+    /// [`ContainsIter`] for the lazy-vs-drained behaviour when folding
+    /// allocates.
+    pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> ContainsIter<'tm, 'p> {
+        match fold(target) {
+            Cow::Borrowed(s) => ContainsIter::Lazy(self.inner.contains_iter(s)),
+            Cow::Owned(s) => {
+                let drained: Vec<(String, &'tm TermEntry)> = self.inner.contains_iter(&s).collect();
+                ContainsIter::Drained(drained.into_iter())
+            }
+        }
+    }
+
+    /// Case-folds `prefix`; see [`StrTrieMap::prefixed_iter`].
+    pub fn prefixed_iter(&self, prefix: &str) -> PrefixedIter<'_, TermEntry> {
+        self.inner.prefixed_iter(&fold(prefix))
+    }
+
+    /// Case-folds `suffix`; see [`StrTrieMap::suffixed_iter`].
+    pub fn suffixed_iter(&self, suffix: &str) -> SuffixedIter<'_, TermEntry> {
+        self.inner.suffixed_iter(&fold(suffix))
+    }
+
+    /// Case-folds `pattern`; see [`StrTrieMap::wildcard_iter`] for the
+    /// codepoint matching model (`?` consumes one codepoint). `?` and `*`
+    /// are ASCII so wildcard semantics survive folding. The returned
+    /// iterator owns the parsed pattern, so it stays lazy regardless of
+    /// whether folding allocated.
+    pub fn wildcard_iter(&self, pattern: &str) -> StrWildcardIter<'_, TermEntry> {
+        self.inner.wildcard_iter(&fold(pattern))
+    }
+
+    /// Case-folds `pattern`; see [`StrTrieMap::fuzzy_iter`] for the
+    /// matching model — Levenshtein distance in codepoints under
+    /// per-codepoint case folding. The returned iterator owns the folded
+    /// needle, so it stays lazy regardless of whether folding allocated.
+    pub fn fuzzy_iter(&self, pattern: &str, max_dist: u32) -> FuzzyIter<'_, TermEntry> {
+        self.inner.fuzzy_iter(&fold(pattern), max_dist)
+    }
+
+    /// Decrement the `num_docs` count for `term` by `delta`. Saturating
+    /// subtract — when `num_docs` reaches zero the entry is removed.
+    /// Returns [`DecrResult::NotFound`] if no terminal entry exists for
+    /// `term`. `term` is case-folded before lookup.
+    pub fn decrement_num_docs(&mut self, term: &str, delta: usize) -> DecrResult {
+        let term = fold(term);
+        let Some(entry) = self.inner.get_mut(&term) else {
+            return DecrResult::NotFound;
+        };
+        if delta < entry.num_docs {
+            entry.num_docs -= delta;
+            DecrResult::Updated
+        } else {
+            self.inner.remove(&term);
+            DecrResult::Deleted
+        }
+    }
+}
+
+/// Iterator returned by [`TermDictionary::contains_iter`].
+///
+/// Case-folding the target may allocate. When it does (mixed-case input),
+/// the folded buffer cannot outlive this iterator, so the matches are
+/// drained eagerly into a `Vec` at construction ([`Self::Drained`]). When
+/// folding borrows (already-folded input) the iterator stays lazy
+/// ([`Self::Lazy`]) and streams directly from the trie. Both yield the same
+/// items in the same order.
+pub enum ContainsIter<'tm, 'p> {
+    Lazy(StrContainsIter<'tm, 'p, TermEntry>),
+    Drained(std::vec::IntoIter<(String, &'tm TermEntry)>),
+}
+
+impl<'tm, 'p> Iterator for ContainsIter<'tm, 'p> {
+    type Item = (String, &'tm TermEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Lazy(it) => it.next(),
+            Self::Drained(it) => it.next(),
+        }
+    }
+}
+
+/// Lower-case a term the way RediSearch's C tokenizer does: each [`char`]
+/// independently via [`char::to_lowercase`], matching the libnu-backed C
+/// `unicode_tolower`.
+fn fold(term: &str) -> Cow<'_, str> {
+    let unchanged = term.chars().all(|c| {
+        let mut lower = c.to_lowercase();
+        lower.next() == Some(c) && lower.next().is_none()
+    });
+    if unchanged {
+        Cow::Borrowed(term)
+    } else {
+        Cow::Owned(term.chars().flat_map(char::to_lowercase).collect())
+    }
+}

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -135,15 +135,14 @@ impl TermDictionary {
     /// [`TermEntry::num_docs`] onto the existing entry, or create a fresh
     /// terminal if absent.
     pub fn add_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let is_new = self.inner.insert_with(&fold(term), |prior| match prior {
+        if self.inner.insert_with(&fold(term), |prior| match prior {
             Some(mut entry) => {
                 entry.score += score;
                 entry.num_docs += num_docs;
                 entry
             }
             None => TermEntry { score, num_docs },
-        });
-        if is_new {
+        }) {
             InsertOutcome::New
         } else {
             InsertOutcome::Updated
@@ -154,14 +153,13 @@ impl TermDictionary {
     /// accumulate [`TermEntry::num_docs`] onto the existing count. Creates
     /// a fresh terminal if absent.
     pub fn replace_term(&mut self, term: &str, score: f32, num_docs: usize) -> InsertOutcome {
-        let is_new = self.inner.insert_with(&fold(term), |prior| {
+        if self.inner.insert_with(&fold(term), |prior| {
             let prior_num_docs = prior.map_or(0, |entry| entry.num_docs);
             TermEntry {
                 score,
                 num_docs: prior_num_docs + num_docs,
             }
-        });
-        if is_new {
+        }) {
             InsertOutcome::New
         } else {
             InsertOutcome::Updated

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -23,8 +23,11 @@
 //! the obligation.
 //!
 //! Folding lower-cases each [`char`] independently via [`char::to_lowercase`],
-//! exactly matching RediSearch's C `unicode_tolower` (libnu-backed,
-//! context-free per-codepoint). This is intentionally *not* Unicode default
+//! matching RediSearch's C `unicode_tolower` (libnu-backed, context-free
+//! per-codepoint) — verified byte-identical against the vendored libnu's
+//! Unicode 17.0 tables over the full codepoint range. A future Unicode bump
+//! on either side (Rust toolchain or libnu) requires re-verifying that the
+//! two lowercase tables still agree. This is intentionally *not* Unicode default
 //! case folding: terms enter the dictionary already lower-cased by the C
 //! tokenizer, and re-folding must be byte-identical so the Rust and C paths
 //! agree on the stored key. Default folding would diverge on codepoints like
@@ -51,12 +54,14 @@ use trie_rs::str_trie_map::{
 /// Holds the subset of fields the FT.SEARCH terms trie actually reads:
 /// score (constant `1.0` in current call sites) plus the number of
 /// indexed documents containing this term.
+#[derive(Debug, Clone, PartialEq)]
 pub struct TermEntry {
     pub score: f32,
     pub num_docs: usize,
 }
 
 /// Outcome of [`TermDictionary::decrement_num_docs`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecrResult {
     /// No terminal entry exists for the given term.
     NotFound,
@@ -67,6 +72,7 @@ pub enum DecrResult {
 }
 
 /// Outcome of [`TermDictionary::add_term`] / [`TermDictionary::replace_term`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertOutcome {
     /// No prior entry existed; a new terminal was created.
     New,
@@ -180,7 +186,7 @@ impl TermDictionary {
     /// allocates.
     pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> ContainsIter<'tm, 'p> {
         match fold(target) {
-            Cow::Borrowed(s) => ContainsIter::Lazy(self.inner.contains_iter(s)),
+            Cow::Borrowed(s) => ContainsIter::Lazy(Box::new(self.inner.contains_iter(s))),
             Cow::Owned(s) => {
                 let drained: Vec<(String, &'tm TermEntry)> = self.inner.contains_iter(&s).collect();
                 ContainsIter::Drained(drained.into_iter())
@@ -243,7 +249,9 @@ impl TermDictionary {
 /// ([`Self::Lazy`]) and streams directly from the trie. Both yield the same
 /// items in the same order.
 pub enum ContainsIter<'tm, 'p> {
-    Lazy(StrContainsIter<'tm, 'p, TermEntry>),
+    // Boxed: the streaming iterator's traversal stack dwarfs the drained
+    // variant, and clippy::large_enum_variant rejects the imbalance.
+    Lazy(Box<StrContainsIter<'tm, 'p, TermEntry>>),
     Drained(std::vec::IntoIter<(String, &'tm TermEntry)>),
 }
 

--- a/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
@@ -17,24 +17,15 @@ use term_dictionary::{DecrResult, InsertOutcome, TermDictionary, TermEntry};
 #[test]
 fn add_term_reports_new_then_updated() {
     let mut dict = TermDictionary::new();
-    assert!(matches!(dict.add_term("foo", 1.0, 1), InsertOutcome::New));
-    assert!(matches!(
-        dict.add_term("foo", 1.0, 1),
-        InsertOutcome::Updated
-    ));
+    assert_eq!(dict.add_term("foo", 1.0, 1), InsertOutcome::New);
+    assert_eq!(dict.add_term("foo", 1.0, 1), InsertOutcome::Updated);
 }
 
 #[test]
 fn replace_term_reports_new_then_updated() {
     let mut dict = TermDictionary::new();
-    assert!(matches!(
-        dict.replace_term("foo", 1.0, 1),
-        InsertOutcome::New
-    ));
-    assert!(matches!(
-        dict.replace_term("foo", 2.0, 1),
-        InsertOutcome::Updated
-    ));
+    assert_eq!(dict.replace_term("foo", 1.0, 1), InsertOutcome::New);
+    assert_eq!(dict.replace_term("foo", 2.0, 1), InsertOutcome::Updated);
 }
 
 #[test]
@@ -60,8 +51,13 @@ fn insert_returns_prior_entry() {
             },
         )
         .expect("overwrite must hand back the displaced entry");
-    assert_eq!(prior.score, 1.0);
-    assert_eq!(prior.num_docs, 2);
+    assert_eq!(
+        prior,
+        TermEntry {
+            score: 1.0,
+            num_docs: 2,
+        }
+    );
     // The overwrite did not accumulate — that is what distinguishes
     // `insert` from `replace_term`.
     assert_eq!(dict.get("foo").unwrap().num_docs, 7);
@@ -71,10 +67,7 @@ fn insert_returns_prior_entry() {
 fn decrement_num_docs_missing_term_is_not_found() {
     let mut dict = TermDictionary::new();
     dict.add_term("foo", 1.0, 1);
-    assert!(matches!(
-        dict.decrement_num_docs("bar", 1),
-        DecrResult::NotFound
-    ));
+    assert_eq!(dict.decrement_num_docs("bar", 1), DecrResult::NotFound);
     assert_eq!(dict.len(), 1, "a miss must not disturb other entries");
 }
 
@@ -85,10 +78,7 @@ fn decrement_num_docs_exact_delta_deletes() {
     // with `num_docs == 0` that the over-shoot case cannot catch.
     let mut dict = TermDictionary::new();
     dict.add_term("foo", 1.0, 3);
-    assert!(matches!(
-        dict.decrement_num_docs("foo", 3),
-        DecrResult::Deleted
-    ));
+    assert_eq!(dict.decrement_num_docs("foo", 3), DecrResult::Deleted);
     assert!(dict.get("foo").is_none());
     assert_eq!(dict.len(), 0);
 }

--- a/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Per-term bookkeeping contract for [`TermDictionary`]: the reported
+//! outcomes ([`InsertOutcome`], [`DecrResult`], prior-entry returns) and
+//! the delete-on-last-doc boundary. Case-folding behaviour is pinned in
+//! the sibling `case_folding` module.
+
+use term_dictionary::{DecrResult, InsertOutcome, TermDictionary, TermEntry};
+
+#[test]
+fn add_term_reports_new_then_updated() {
+    let mut dict = TermDictionary::new();
+    assert!(matches!(dict.add_term("foo", 1.0, 1), InsertOutcome::New));
+    assert!(matches!(
+        dict.add_term("foo", 1.0, 1),
+        InsertOutcome::Updated
+    ));
+}
+
+#[test]
+fn replace_term_reports_new_then_updated() {
+    let mut dict = TermDictionary::new();
+    assert!(matches!(
+        dict.replace_term("foo", 1.0, 1),
+        InsertOutcome::New
+    ));
+    assert!(matches!(
+        dict.replace_term("foo", 2.0, 1),
+        InsertOutcome::Updated
+    ));
+}
+
+#[test]
+fn insert_returns_prior_entry() {
+    let mut dict = TermDictionary::new();
+    assert!(
+        dict.insert(
+            "foo",
+            TermEntry {
+                score: 1.0,
+                num_docs: 2,
+            },
+        )
+        .is_none(),
+        "first insert has no prior entry"
+    );
+    let prior = dict
+        .insert(
+            "foo",
+            TermEntry {
+                score: 5.0,
+                num_docs: 7,
+            },
+        )
+        .expect("overwrite must hand back the displaced entry");
+    assert_eq!(prior.score, 1.0);
+    assert_eq!(prior.num_docs, 2);
+    // The overwrite did not accumulate — that is what distinguishes
+    // `insert` from `replace_term`.
+    assert_eq!(dict.get("foo").unwrap().num_docs, 7);
+}
+
+#[test]
+fn decrement_num_docs_missing_term_is_not_found() {
+    let mut dict = TermDictionary::new();
+    dict.add_term("foo", 1.0, 1);
+    assert!(matches!(
+        dict.decrement_num_docs("bar", 1),
+        DecrResult::NotFound
+    ));
+    assert_eq!(dict.len(), 1, "a miss must not disturb other entries");
+}
+
+#[test]
+fn decrement_num_docs_exact_delta_deletes() {
+    // `delta == num_docs` must take the removal path: a regression to
+    // `delta <= num_docs` staying in place would leave a zombie entry
+    // with `num_docs == 0` that the over-shoot case cannot catch.
+    let mut dict = TermDictionary::new();
+    dict.add_term("foo", 1.0, 3);
+    assert!(matches!(
+        dict.decrement_num_docs("foo", 3),
+        DecrResult::Deleted
+    ));
+    assert!(dict.get("foo").is_none());
+    assert_eq!(dict.len(), 0);
+}

--- a/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
@@ -28,6 +28,20 @@ fn replace_term_reports_new_then_updated() {
     assert_eq!(dict.replace_term("foo", 2.0, 1), InsertOutcome::Updated);
 }
 
+/// Both halves take a non-zero value: at `num_docs` of `0` accumulation and
+/// a plain carry-over of the prior count are indistinguishable.
+#[test]
+fn replace_term_overwrites_score_and_accumulates_num_docs() {
+    let mut dict = TermDictionary::new();
+    dict.add_term("foo", 5.0, 2);
+
+    dict.replace_term("foo", 1.0, 3);
+
+    let entry = dict.get("foo").expect("entry");
+    assert_eq!(entry.score, 1.0, "score is overwritten, not accumulated");
+    assert_eq!(entry.num_docs, 5, "num_docs accumulates the delta");
+}
+
 #[test]
 fn insert_returns_prior_entry() {
     let mut dict = TermDictionary::new();

--- a/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/bookkeeping.rs
@@ -10,7 +10,7 @@
 //! Per-term bookkeeping contract for [`TermDictionary`]: the reported
 //! outcomes ([`InsertOutcome`], [`DecrResult`], prior-entry returns) and
 //! the delete-on-last-doc boundary. Case-folding behaviour is pinned in
-//! the sibling `case_folding` module.
+//! the sibling [`case_folding`](crate::case_folding) module.
 
 use term_dictionary::{DecrResult, InsertOutcome, TermDictionary, TermEntry};
 
@@ -58,8 +58,7 @@ fn insert_returns_prior_entry() {
             num_docs: 2,
         }
     );
-    // The overwrite did not accumulate — that is what distinguishes
-    // `insert` from `replace_term`.
+    // Pins the non-accumulating half of `insert`'s contract.
     assert_eq!(dict.get("foo").unwrap().num_docs, 7);
 }
 

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Case-folding contract for [`TermDictionary`].
+//!
+//! Every key and pattern is lowercased on entry — see the module doc on
+//! [`TermDictionary`] for the rationale (it mirrors the C terms-trie's
+//! `runeBufFill` pre-fold). These tests pin the contract at every entry
+//! point: insert/lookup, remove, decrement, and all five iteration paths
+//! (prefixed, suffixed, contains, wildcard, fuzzy).
+//!
+//! The underlying [`StrTrieMap`](trie_rs::str_trie_map::StrTrieMap) stays
+//! byte-exact; tests in sibling files exercise its raw byte semantics
+//! and must continue to pass.
+
+use term_dictionary::{DecrResult, TermDictionary, TermEntry};
+
+fn seed(dict: &mut TermDictionary, terms: &[&str]) {
+    for term in terms {
+        dict.insert(
+            term,
+            TermEntry {
+                score: 1.0,
+                num_docs: 1,
+            },
+        );
+    }
+}
+
+fn collect_prefixed(dict: &TermDictionary, prefix: &str) -> Vec<String> {
+    let mut keys: Vec<String> = dict.prefixed_iter(prefix).map(|(k, _)| k).collect();
+    keys.sort();
+    keys
+}
+
+fn collect_suffixed(dict: &TermDictionary, suffix: &str) -> Vec<String> {
+    let mut keys: Vec<String> = dict.suffixed_iter(suffix).map(|(k, _)| k).collect();
+    keys.sort();
+    keys
+}
+
+fn collect_contains(dict: &TermDictionary, target: &str) -> Vec<String> {
+    let mut keys: Vec<String> = dict.contains_iter(target).map(|(k, _)| k).collect();
+    keys.sort();
+    keys
+}
+
+fn collect_wildcard(dict: &TermDictionary, pattern: &str) -> Vec<String> {
+    let mut keys: Vec<String> = dict.wildcard_iter(pattern).map(|(k, _)| k).collect();
+    keys.sort();
+    keys
+}
+
+fn collect_fuzzy(dict: &TermDictionary, pattern: &str, max_dist: u32) -> Vec<String> {
+    let mut keys: Vec<String> = dict.fuzzy_iter(pattern, max_dist).map(|(k, _)| k).collect();
+    keys.sort();
+    keys
+}
+
+#[test]
+fn insert_uppercase_then_get_lowercase() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "Foo",
+        TermEntry {
+            score: 2.0,
+            num_docs: 3,
+        },
+    );
+    let entry = dict
+        .get("foo")
+        .expect("get(\"foo\") should find folded key");
+    assert_eq!(entry.score, 2.0);
+    assert_eq!(entry.num_docs, 3);
+}
+
+#[test]
+fn insert_lowercase_then_get_uppercase() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "foo",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    assert!(
+        dict.get("FOO").is_some(),
+        "get(\"FOO\") should fold to \"foo\""
+    );
+    assert!(
+        dict.get("Foo").is_some(),
+        "get(\"Foo\") should fold to \"foo\""
+    );
+}
+
+#[test]
+fn iteration_yields_folded_keys() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "Hello",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    let keys: Vec<String> = dict.iter().map(|(k, _)| k).collect();
+    assert_eq!(
+        keys,
+        vec!["hello".to_string()],
+        "iteration must yield the folded key, not the raw input"
+    );
+}
+
+#[test]
+fn add_term_collapses_case_variants() {
+    let mut dict = TermDictionary::new();
+    dict.add_term("Foo", 1.0, 1);
+    dict.add_term("FOO", 1.0, 1);
+    dict.add_term("foo", 1.0, 1);
+    assert_eq!(dict.len(), 1, "case variants must collapse to one entry");
+    let entry = dict.get("foo").expect("folded entry");
+    assert_eq!(entry.score, 3.0);
+    assert_eq!(entry.num_docs, 3);
+}
+
+#[test]
+fn replace_term_overwrites_case_variant() {
+    let mut dict = TermDictionary::new();
+    dict.add_term("Foo", 5.0, 2);
+    dict.replace_term("FOO", 1.0, 0);
+    let entry = dict.get("foo").expect("folded entry");
+    assert_eq!(entry.score, 1.0, "replace must overwrite score");
+    assert_eq!(entry.num_docs, 2, "replace still accumulates num_docs (+0)");
+}
+
+#[test]
+fn remove_folds_case() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "Foo",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    assert!(dict.remove("FOO").is_some(), "remove must fold case");
+    assert_eq!(dict.len(), 0);
+}
+
+#[test]
+fn decrement_num_docs_folds_case() {
+    let mut dict = TermDictionary::new();
+    dict.add_term("Foo", 1.0, 3);
+    assert!(matches!(
+        dict.decrement_num_docs("FOO", 1),
+        DecrResult::Updated
+    ));
+    assert_eq!(dict.get("foo").unwrap().num_docs, 2);
+    assert!(matches!(
+        dict.decrement_num_docs("foo", 10),
+        DecrResult::Deleted
+    ));
+    assert!(dict.get("foo").is_none());
+}
+
+#[test]
+fn prefixed_iter_folds_pattern() {
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["foobar", "foobaz", "qux"]);
+    assert_eq!(
+        collect_prefixed(&dict, "FOO"),
+        vec!["foobar".to_string(), "foobaz".to_string()]
+    );
+}
+
+#[test]
+fn suffixed_iter_folds_pattern() {
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["foobar", "carbar", "baz"]);
+    assert_eq!(
+        collect_suffixed(&dict, "BAR"),
+        vec!["carbar".to_string(), "foobar".to_string()]
+    );
+}
+
+#[test]
+fn contains_iter_folds_pattern() {
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["xfooy", "afoob", "qux"]);
+    assert_eq!(
+        collect_contains(&dict, "FOO"),
+        vec!["afoob".to_string(), "xfooy".to_string()]
+    );
+}
+
+#[test]
+fn wildcard_iter_folds_pattern() {
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["foo", "fob", "qux"]);
+    assert_eq!(
+        collect_wildcard(&dict, "F?O"),
+        vec!["foo".to_string()],
+        "uppercase wildcard literals must fold (the metacharacters \\? \\* are ASCII)"
+    );
+}
+
+#[test]
+fn fuzzy_iter_folds_pattern() {
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["foo", "bar"]);
+    assert_eq!(
+        collect_fuzzy(&dict, "FOO", 0),
+        vec!["foo".to_string()],
+        "fuzzy pattern must fold before the automaton is built"
+    );
+}
+
+#[test]
+fn fold_preserves_sharp_s() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "Straße",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    // `char::to_lowercase` keeps `ß` as `ß` (matching C `unicode_tolower`),
+    // so the stored key is "straße". It must NOT be default-folded to
+    // "strasse", which would split the term from its C-indexed form.
+    assert!(dict.get("straße").is_some());
+    assert!(dict.get("STRAßE").is_some(), "ASCII letters still fold");
+    assert!(dict.get("strasse").is_none(), "ß must not expand to ss");
+    let keys: Vec<String> = dict.iter().map(|(k, _)| k).collect();
+    assert_eq!(keys, vec!["straße".to_string()]);
+}
+
+#[test]
+fn fold_lowercases_uppercase_sigma() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "ΟΔΥΣΣΕΥΣ",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    // Per-char lowering maps every uppercase Σ to σ (no context-sensitive
+    // final-sigma rule at the codepoint level), so the all-caps input folds
+    // to "οδυσσευσ".
+    assert!(dict.get("οδυσσευσ").is_some());
+}
+
+#[test]
+fn fuzzy_iter_round_trips_sharp_s_through_fold() {
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "Straße",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    // ß is preserved by the fold, so the stored key is "straße". An exact
+    // fuzzy match over the same input round-trips at distance 0.
+    assert_eq!(
+        collect_fuzzy(&dict, "Straße", 0),
+        vec!["straße".to_string()]
+    );
+    // A single leading-letter substitution (ASCII, so byte/codepoint
+    // counting agree) is one edit away — and outside a zero budget.
+    assert_eq!(
+        collect_fuzzy(&dict, "Xtraße", 1),
+        vec!["straße".to_string()]
+    );
+    assert!(collect_fuzzy(&dict, "Xtraße", 0).is_empty());
+}
+
+#[test]
+fn fuzzy_iter_handles_multibyte_lowercase_expansion() {
+    // `İ` folds to `i` + combining dot above (two codepoints) — pin the
+    // round-trip so a regression to per-char folding fails.
+    let mut dict = TermDictionary::new();
+    dict.insert(
+        "İstanbul",
+        TermEntry {
+            score: 1.0,
+            num_docs: 1,
+        },
+    );
+    let hits = collect_fuzzy(&dict, "İstanbul", 0);
+    assert_eq!(
+        hits.len(),
+        1,
+        "fuzzy matching must round-trip the multi-codepoint fold"
+    );
+}

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -10,8 +10,10 @@
 //! Case-folding contract for [`TermDictionary`].
 //!
 //! Every key and pattern is lowercased on entry — see the module doc on
-//! [`TermDictionary`] for the rationale (it mirrors the C terms-trie's
-//! `runeBufFill` pre-fold). These tests pin the contract at every entry
+//! [`TermDictionary`] for the rationale (it mirrors the C pipeline, where
+//! the tokenizer lower-cases terms via `unicode_tolower` before they reach
+//! the trie, and query-side lookups fold their patterns the same way).
+//! These tests pin the contract at every entry
 //! point: insert/lookup, remove, decrement, and all five iteration paths
 //! (prefixed, suffixed, contains, wildcard, fuzzy).
 //!
@@ -196,6 +198,19 @@ fn contains_iter_folds_pattern() {
     seed(&mut dict, &["xfooy", "afoob", "qux"]);
     assert_eq!(
         collect_contains(&dict, "FOO"),
+        vec!["afoob".to_string(), "xfooy".to_string()]
+    );
+}
+
+#[test]
+fn contains_iter_already_folded_target_stays_lazy() {
+    // An already-lowercase target folds to a borrow, taking the
+    // `ContainsIter::Lazy` arm instead of the eager drain the mixed-case
+    // test above exercises. Both arms must yield the same matches.
+    let mut dict = TermDictionary::new();
+    seed(&mut dict, &["xfooy", "afoob", "qux"]);
+    assert_eq!(
+        collect_contains(&dict, "foo"),
         vec!["afoob".to_string(), "xfooy".to_string()]
     );
 }

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -160,15 +160,9 @@ fn remove_folds_case() {
 fn decrement_num_docs_folds_case() {
     let mut dict = TermDictionary::new();
     dict.add_term("Foo", 1.0, 3);
-    assert!(matches!(
-        dict.decrement_num_docs("FOO", 1),
-        DecrResult::Updated
-    ));
+    assert_eq!(dict.decrement_num_docs("FOO", 1), DecrResult::Updated);
     assert_eq!(dict.get("foo").unwrap().num_docs, 2);
-    assert!(matches!(
-        dict.decrement_num_docs("foo", 10),
-        DecrResult::Deleted
-    ));
+    assert_eq!(dict.decrement_num_docs("foo", 10), DecrResult::Deleted);
     assert!(dict.get("foo").is_none());
 }
 

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -33,25 +33,37 @@ fn seed(dict: &mut TermDictionary, terms: &[&str]) {
 }
 
 fn collect_prefixed(dict: &TermDictionary, prefix: &str) -> Vec<String> {
-    let mut keys: Vec<String> = dict.prefixed_iter(prefix).map(|(k, _)| k).collect();
+    let mut keys: Vec<String> = dict
+        .prefixed_iter(prefix, || false)
+        .map(|(k, _)| k)
+        .collect();
     keys.sort();
     keys
 }
 
 fn collect_suffixed(dict: &TermDictionary, suffix: &str) -> Vec<String> {
-    let mut keys: Vec<String> = dict.suffixed_iter(suffix).map(|(k, _)| k).collect();
+    let mut keys: Vec<String> = dict
+        .suffixed_iter(suffix, || false)
+        .map(|(k, _)| k)
+        .collect();
     keys.sort();
     keys
 }
 
 fn collect_contains(dict: &TermDictionary, target: &str) -> Vec<String> {
-    let mut keys: Vec<String> = dict.contains_iter(target).map(|(k, _)| k).collect();
+    let mut keys: Vec<String> = dict
+        .contains_iter(target, || false)
+        .map(|(k, _)| k)
+        .collect();
     keys.sort();
     keys
 }
 
 fn collect_wildcard(dict: &TermDictionary, pattern: &str) -> Vec<String> {
-    let mut keys: Vec<String> = dict.wildcard_iter(pattern).map(|(k, _)| k).collect();
+    let mut keys: Vec<String> = dict
+        .wildcard_iter(pattern, || false)
+        .map(|(k, _)| k)
+        .collect();
     keys.sort();
     keys
 }

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -195,10 +195,10 @@ fn contains_iter_folds_pattern() {
 
 #[test]
 fn contains_iter_already_folded_target_stays_lazy() {
-    // An already-lowercase target folds to a borrow, taking the
-    // `ContainsIter::Lazy` arm instead of the eager drain that
-    // `contains_iter_folds_pattern` exercises. Both arms must yield the
-    // same matches.
+    // An already-lowercase target folds to a borrow, so the iterator
+    // borrows the target instead of owning a folded copy as in
+    // `contains_iter_folds_pattern`. Both paths must yield the same
+    // matches.
     let mut dict = TermDictionary::new();
     seed(&mut dict, &["xfooy", "afoob", "qux"]);
     assert_eq!(

--- a/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/case_folding.rs
@@ -9,17 +9,14 @@
 
 //! Case-folding contract for [`TermDictionary`].
 //!
-//! Every key and pattern is lowercased on entry — see the module doc on
-//! [`TermDictionary`] for the rationale (it mirrors the C pipeline, where
-//! the tokenizer lower-cases terms via `unicode_tolower` before they reach
-//! the trie, and query-side lookups fold their patterns the same way).
-//! These tests pin the contract at every entry
-//! point: insert/lookup, remove, decrement, and all five iteration paths
-//! (prefixed, suffixed, contains, wildcard, fuzzy).
+//! Every key and pattern is lowercased on entry — see the
+//! [`term_dictionary`] crate docs for the contract and rationale. These
+//! tests pin it at every entry point: insert/lookup, remove, decrement,
+//! and all five iteration paths (prefixed, suffixed, contains, wildcard,
+//! fuzzy).
 //!
 //! The underlying [`StrTrieMap`](trie_rs::str_trie_map::StrTrieMap) stays
-//! byte-exact; tests in sibling files exercise its raw byte semantics
-//! and must continue to pass.
+//! byte-exact; its raw byte semantics are covered by `trie_rs`'s own tests.
 
 use term_dictionary::{DecrResult, TermDictionary, TermEntry};
 
@@ -199,8 +196,9 @@ fn contains_iter_folds_pattern() {
 #[test]
 fn contains_iter_already_folded_target_stays_lazy() {
     // An already-lowercase target folds to a borrow, taking the
-    // `ContainsIter::Lazy` arm instead of the eager drain the mixed-case
-    // test above exercises. Both arms must yield the same matches.
+    // `ContainsIter::Lazy` arm instead of the eager drain that
+    // `contains_iter_folds_pattern` exercises. Both arms must yield the
+    // same matches.
     let mut dict = TermDictionary::new();
     seed(&mut dict, &["xfooy", "afoob", "qux"]);
     assert_eq!(
@@ -241,9 +239,8 @@ fn fold_preserves_sharp_s() {
             num_docs: 1,
         },
     );
-    // `char::to_lowercase` keeps `ß` as `ß` (matching C `unicode_tolower`),
-    // so the stored key is "straße". It must NOT be default-folded to
-    // "strasse", which would split the term from its C-indexed form.
+    // Default Unicode folding would expand `ß` to `ss`, splitting the
+    // term from its C-indexed form.
     assert!(dict.get("straße").is_some());
     assert!(dict.get("STRAßE").is_some(), "ASCII letters still fold");
     assert!(dict.get("strasse").is_none(), "ß must not expand to ss");
@@ -261,9 +258,9 @@ fn fold_lowercases_uppercase_sigma() {
             num_docs: 1,
         },
     );
-    // Per-char lowering maps every uppercase Σ to σ (no context-sensitive
-    // final-sigma rule at the codepoint level), so the all-caps input folds
-    // to "οδυσσευσ".
+    // Per-char lowering has no context-sensitive final-sigma rule, so
+    // every uppercase Σ maps to σ and the all-caps input folds to
+    // "οδυσσευσ".
     assert!(dict.get("οδυσσευσ").is_some());
 }
 
@@ -277,8 +274,8 @@ fn fuzzy_iter_round_trips_sharp_s_through_fold() {
             num_docs: 1,
         },
     );
-    // ß is preserved by the fold, so the stored key is "straße". An exact
-    // fuzzy match over the same input round-trips at distance 0.
+    // The stored key is the folded "straße"; an exact fuzzy match over
+    // the same input round-trips at distance 0.
     assert_eq!(
         collect_fuzzy(&dict, "Straße", 0),
         vec!["straße".to_string()]
@@ -294,8 +291,9 @@ fn fuzzy_iter_round_trips_sharp_s_through_fold() {
 
 #[test]
 fn fuzzy_iter_handles_multibyte_lowercase_expansion() {
-    // `İ` folds to `i` + combining dot above (two codepoints) — pin the
-    // round-trip so a regression to per-char folding fails.
+    // `İ` lowercases to `i` + combining dot above (two codepoints) — pin
+    // the round-trip so a fold that kept only the first output char per
+    // input char would fail.
     let mut dict = TermDictionary::new();
     dict.insert(
         "İstanbul",

--- a/src/redisearch_rs/term_dictionary/tests/integration/empty_pattern.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/empty_pattern.rs
@@ -31,14 +31,14 @@ fn seeded() -> TermDictionary {
 fn contains_iter_empty_target_yields_nothing() {
     let dict = seeded();
 
-    assert_eq!(dict.contains_iter("").count(), 0);
+    assert_eq!(dict.contains_iter("", || false).count(), 0);
 }
 
 #[test]
 fn suffixed_iter_empty_suffix_yields_nothing() {
     let dict = seeded();
 
-    assert_eq!(dict.suffixed_iter("").count(), 0);
+    assert_eq!(dict.suffixed_iter("", || false).count(), 0);
 }
 
 /// The guard is specific to the substring and suffix walks: an empty prefix
@@ -47,7 +47,7 @@ fn suffixed_iter_empty_suffix_yields_nothing() {
 fn prefixed_iter_empty_prefix_yields_every_term() {
     let dict = seeded();
 
-    assert_eq!(dict.prefixed_iter("").count(), dict.len());
+    assert_eq!(dict.prefixed_iter("", || false).count(), dict.len());
 }
 
 /// A non-empty pattern must still reach the trie — the guard keys off
@@ -56,6 +56,6 @@ fn prefixed_iter_empty_prefix_yields_every_term() {
 fn non_empty_patterns_are_unaffected() {
     let dict = seeded();
 
-    assert_eq!(dict.contains_iter("an").count(), 1);
-    assert_eq!(dict.suffixed_iter("y").count(), 1);
+    assert_eq!(dict.contains_iter("an", || false).count(), 1);
+    assert_eq!(dict.suffixed_iter("y", || false).count(), 1);
 }

--- a/src/redisearch_rs/term_dictionary/tests/integration/empty_pattern.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/empty_pattern.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Empty-pattern semantics, which deliberately diverge from the underlying
+//! `StrTrieMap` to match the C walk this dictionary replaces. See the
+//! `term_dictionary` module docs.
+
+use term_dictionary::{TermDictionary, TermEntry};
+
+fn seeded() -> TermDictionary {
+    let mut dict = TermDictionary::new();
+    for term in ["apple", "banana", "cherry"] {
+        dict.insert(
+            term,
+            TermEntry {
+                score: 1.0,
+                num_docs: 1,
+            },
+        );
+    }
+    dict
+}
+
+#[test]
+fn contains_iter_empty_target_yields_nothing() {
+    let dict = seeded();
+
+    assert_eq!(dict.contains_iter("").count(), 0);
+}
+
+#[test]
+fn suffixed_iter_empty_suffix_yields_nothing() {
+    let dict = seeded();
+
+    assert_eq!(dict.suffixed_iter("").count(), 0);
+}
+
+/// The guard is specific to the substring and suffix walks: an empty prefix
+/// matches every term in C too, so the trie's own semantics stand.
+#[test]
+fn prefixed_iter_empty_prefix_yields_every_term() {
+    let dict = seeded();
+
+    assert_eq!(dict.prefixed_iter("").count(), dict.len());
+}
+
+/// A non-empty pattern must still reach the trie — the guard keys off
+/// emptiness alone, not off the walk being cheap.
+#[test]
+fn non_empty_patterns_are_unaffected() {
+    let dict = seeded();
+
+    assert_eq!(dict.contains_iter("an").count(), 1);
+    assert_eq!(dict.suffixed_iter("y").count(), 1);
+}

--- a/src/redisearch_rs/term_dictionary/tests/integration/main.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/main.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod case_folding;

--- a/src/redisearch_rs/term_dictionary/tests/integration/main.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/main.rs
@@ -7,4 +7,5 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+mod bookkeeping;
 mod case_folding;

--- a/src/redisearch_rs/term_dictionary/tests/integration/main.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/main.rs
@@ -9,3 +9,4 @@
 
 mod bookkeeping;
 mod case_folding;
+mod empty_pattern;

--- a/src/redisearch_rs/term_dictionary/tests/integration/main.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/main.rs
@@ -10,3 +10,4 @@
 mod bookkeeping;
 mod case_folding;
 mod empty_pattern;
+mod should_stop;

--- a/src/redisearch_rs/term_dictionary/tests/integration/should_stop.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/should_stop.rs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Every pattern walk carries the caller's stop signal all the way down to
+//! the trie, across the case-folding layer that sits between them. The
+//! polling contract itself is covered in `trie_rs`; these tests pin the
+//! forwarding at this crate's boundary.
+
+use term_dictionary::{TermDictionary, TermEntry};
+
+/// Enough terms that any full walk takes well over the trie's polling
+/// granularity, so an always-true predicate fires before the walk ends.
+const N_TERMS: usize = 300;
+
+/// Every term shares the `term` prefix, the `z` suffix, and `term` as a
+/// substring, so each walk under test matches all of them.
+fn seeded() -> TermDictionary {
+    let mut dict = TermDictionary::new();
+    for i in 0..N_TERMS {
+        dict.insert(
+            &format!("term{i:04}z"),
+            TermEntry {
+                score: 1.0,
+                num_docs: 1,
+            },
+        );
+    }
+    dict
+}
+
+#[test]
+fn contains_iter_forwards_the_stop_signal() {
+    let dict = seeded();
+
+    assert_eq!(dict.contains_iter("term", || false).count(), N_TERMS);
+    assert!(dict.contains_iter("term", || true).count() < N_TERMS);
+}
+
+#[test]
+fn prefixed_iter_forwards_the_stop_signal() {
+    let dict = seeded();
+
+    assert_eq!(dict.prefixed_iter("term", || false).count(), N_TERMS);
+    assert!(dict.prefixed_iter("term", || true).count() < N_TERMS);
+}
+
+#[test]
+fn suffixed_iter_forwards_the_stop_signal() {
+    let dict = seeded();
+
+    assert_eq!(dict.suffixed_iter("z", || false).count(), N_TERMS);
+    assert!(dict.suffixed_iter("z", || true).count() < N_TERMS);
+}
+
+#[test]
+fn wildcard_iter_forwards_the_stop_signal() {
+    let dict = seeded();
+
+    assert_eq!(dict.wildcard_iter("term*", || false).count(), N_TERMS);
+    assert!(dict.wildcard_iter("term*", || true).count() < N_TERMS);
+}

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -8,6 +8,7 @@
 */
 
 use crate::{TrieMap, iter, str_trie_map::iter::unfiltered::key_to_string};
+use std::borrow::Cow;
 
 /// Substring-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
 /// in lexicographical key order.
@@ -19,8 +20,12 @@ use crate::{TrieMap, iter, str_trie_map::iter::unfiltered::key_to_string};
 pub struct ContainsIter<'tm, 'p, Data: 'tm>(iter::ContainsIter<'tm, 'p, Data>);
 
 impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
-    pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
-        Self(trie.contains_iter(target.as_bytes()))
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, target: impl Into<Cow<'p, str>>) -> Self {
+        let target: Cow<'p, [u8]> = match target.into() {
+            Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+            Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+        };
+        Self(trie.contains_iter(target))
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -35,6 +35,13 @@ impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
     pub fn empty() -> Self {
         Self(iter::ContainsIter::empty())
     }
+
+    /// Stop the traversal when `should_stop` returns `true`. See
+    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
+    /// polling contract.
+    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.0.set_should_stop(should_stop);
+    }
 }
 
 impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -27,6 +27,14 @@ impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
         };
         Self(trie.contains_iter(target))
     }
+
+    /// An iterator that yields no entries, for callers whose substring
+    /// semantics differ from this iterator's on some input — see
+    /// [`StrTrieMap::contains_iter`](crate::str_trie_map::StrTrieMap::contains_iter)
+    /// for what it does with an empty target.
+    pub fn empty() -> Self {
+        Self(iter::ContainsIter::empty())
+    }
 }
 
 impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -36,11 +36,14 @@ impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
         Self(iter::ContainsIter::empty())
     }
 
-    /// Stop the traversal when `should_stop` returns `true`. See
-    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
-    /// polling contract.
-    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
-        self.0.set_should_stop(should_stop);
+    pub(crate) fn new_with_should_stop(
+        trie: &'tm TrieMap<Data>,
+        target: impl Into<Cow<'p, str>>,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> Self {
+        let mut iter = Self::new(trie, target);
+        iter.0.set_should_stop(should_stop);
+        iter
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
@@ -26,6 +26,13 @@ impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
         Self(trie.prefixed_iter(prefix.as_bytes()))
     }
+
+    /// Stop the traversal when `should_stop` returns `true`. See
+    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
+    /// polling contract.
+    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.0.set_should_stop(should_stop);
+    }
 }
 
 impl<'tm, Data: 'tm> Iterator for PrefixedIter<'tm, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
@@ -27,11 +27,14 @@ impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
         Self(trie.prefixed_iter(prefix.as_bytes()))
     }
 
-    /// Stop the traversal when `should_stop` returns `true`. See
-    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
-    /// polling contract.
-    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
-        self.0.set_should_stop(should_stop);
+    pub(crate) fn new_with_should_stop(
+        trie: &'tm TrieMap<Data>,
+        prefix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> Self {
+        let mut iter = Self::new(trie, prefix);
+        iter.0.set_should_stop(should_stop);
+        iter
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -46,6 +46,13 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
             iter: iter::Iter::empty(),
         }
     }
+
+    /// Stop the traversal when `should_stop` returns `true`. See
+    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
+    /// polling contract.
+    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.iter.set_should_stop(should_stop);
+    }
 }
 
 impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -47,11 +47,14 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
         }
     }
 
-    /// Stop the traversal when `should_stop` returns `true`. See
-    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
-    /// polling contract.
-    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
-        self.iter.set_should_stop(should_stop);
+    pub(crate) fn new_with_should_stop(
+        trie: &'tm TrieMap<Data>,
+        suffix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> Self {
+        let mut iter = Self::new(trie, suffix);
+        iter.iter.set_should_stop(should_stop);
+        iter
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -35,6 +35,17 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
             iter: trie.iter(),
         }
     }
+
+    /// An iterator that yields no entries, for callers whose suffix
+    /// semantics differ from this iterator's on some input — see
+    /// [`StrTrieMap::suffixed_iter`](crate::str_trie_map::StrTrieMap::suffixed_iter)
+    /// for what it does with an empty suffix.
+    pub fn empty() -> Self {
+        Self {
+            target_bytes: Box::new([]),
+            iter: iter::Iter::empty(),
+        }
+    }
 }
 
 impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
@@ -59,15 +59,18 @@ impl<'tm, Data: 'tm> WildcardIter<'tm, Data> {
         Self(backend)
     }
 
-    /// Stop the traversal when `should_stop` returns `true`. See
-    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
-    /// polling contract.
-    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
-        match &mut self.0 {
-            Backend::Nfa64(iter) => iter.set_should_stop(should_stop),
-            Backend::Nfa128(iter) => iter.set_should_stop(should_stop),
+    pub(crate) fn new_with_should_stop(
+        trie: &'tm TrieMap<Data>,
+        pattern: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> Self {
+        let mut iter = Self::new(trie, pattern);
+        match &mut iter.0 {
+            Backend::Nfa64(inner) => inner.set_should_stop(should_stop),
+            Backend::Nfa128(inner) => inner.set_should_stop(should_stop),
             Backend::Filter { candidates, .. } => candidates.set_should_stop(should_stop),
         }
+        iter
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
@@ -58,6 +58,17 @@ impl<'tm, Data: 'tm> WildcardIter<'tm, Data> {
         };
         Self(backend)
     }
+
+    /// Stop the traversal when `should_stop` returns `true`. See
+    /// [`Iter::set_should_stop`](crate::iter::Iter::set_should_stop) for the
+    /// polling contract.
+    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        match &mut self.0 {
+            Backend::Nfa64(iter) => iter.set_should_stop(should_stop),
+            Backend::Nfa128(iter) => iter.set_should_stop(should_stop),
+            Backend::Filter { candidates, .. } => candidates.set_should_stop(should_stop),
+        }
+    }
 }
 
 impl<'tm, Data: 'tm> Iterator for WildcardIter<'tm, Data> {

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -12,6 +12,7 @@
 pub mod iter;
 
 use crate::TrieMap;
+use std::borrow::Cow;
 use std::fmt;
 
 /// UTF-8 keyed view over [`TrieMap`].
@@ -126,8 +127,12 @@ impl<Data> StrTrieMap<Data> {
 
     /// Yield every entry whose key contains `target` as a substring.
     /// Empty `target` yields every entry — the empty string is a substring
-    /// of every key.
-    pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> iter::ContainsIter<'tm, 'p, Data> {
+    /// of every key. An owned `target` is stored inside the iterator, so
+    /// callers holding only a temporary buffer still get a lazy iterator.
+    pub fn contains_iter<'tm, 'p>(
+        &'tm self,
+        target: impl Into<Cow<'p, str>>,
+    ) -> iter::ContainsIter<'tm, 'p, Data> {
         iter::ContainsIter::new(&self.inner, target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -41,11 +41,11 @@ impl<Data> StrTrieMap<Data> {
 
     /// Insert or update a `&str`-keyed entry via a callback.
     /// See [`TrieMap::insert_with`].
-    pub fn insert_with<F>(&mut self, key: &str, f: F)
+    pub fn insert_with<F>(&mut self, key: &str, f: F) -> bool
     where
         F: FnOnce(Option<Data>) -> Data,
     {
-        self.inner.insert_with(key.as_bytes(), f);
+        self.inner.insert_with(key.as_bytes(), f)
     }
 
     /// Remove a `&str`-keyed entry. See [`TrieMap::remove`].

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -106,6 +106,17 @@ impl<Data> StrTrieMap<Data> {
         iter::PrefixedIter::new(&self.inner, prefix)
     }
 
+    /// [`Self::prefixed_iter`], abandoned once `should_stop` returns `true`.
+    /// See [`TIMEOUT_CHECK_GRANULARITY`](crate::iter::TIMEOUT_CHECK_GRANULARITY)
+    /// for the polling contract.
+    pub fn prefixed_iter_with_should_stop<'tm>(
+        &'tm self,
+        prefix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> iter::PrefixedIter<'tm, Data> {
+        iter::PrefixedIter::new_with_should_stop(&self.inner, prefix, should_stop)
+    }
+
     /// Yield a reference to the value of every entry whose key starts with
     /// `prefix`, in lexicographical order. See [`TrieMap::prefixed_values`].
     ///
@@ -125,6 +136,17 @@ impl<Data> StrTrieMap<Data> {
         iter::SuffixedIter::new(&self.inner, suffix)
     }
 
+    /// [`Self::suffixed_iter`], abandoned once `should_stop` returns `true`.
+    /// See [`TIMEOUT_CHECK_GRANULARITY`](crate::iter::TIMEOUT_CHECK_GRANULARITY)
+    /// for the polling contract.
+    pub fn suffixed_iter_with_should_stop<'tm>(
+        &'tm self,
+        suffix: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> iter::SuffixedIter<'tm, Data> {
+        iter::SuffixedIter::new_with_should_stop(&self.inner, suffix, should_stop)
+    }
+
     /// Yield every entry whose key contains `target` as a substring.
     /// Empty `target` yields every entry — the empty string is a substring
     /// of every key. An owned `target` is stored inside the iterator, so
@@ -134,6 +156,17 @@ impl<Data> StrTrieMap<Data> {
         target: impl Into<Cow<'p, str>>,
     ) -> iter::ContainsIter<'tm, 'p, Data> {
         iter::ContainsIter::new(&self.inner, target)
+    }
+
+    /// [`Self::contains_iter`], abandoned once `should_stop` returns `true`.
+    /// See [`TIMEOUT_CHECK_GRANULARITY`](crate::iter::TIMEOUT_CHECK_GRANULARITY)
+    /// for the polling contract.
+    pub fn contains_iter_with_should_stop<'tm, 'p>(
+        &'tm self,
+        target: impl Into<Cow<'p, str>>,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> iter::ContainsIter<'tm, 'p, Data> {
+        iter::ContainsIter::new_with_should_stop(&self.inner, target, should_stop)
     }
 
     /// Yield every entry whose key equals `needle` after per-codepoint case
@@ -170,6 +203,17 @@ impl<Data> StrTrieMap<Data> {
     /// for the matching model.
     pub fn wildcard_iter(&self, pattern: &str) -> iter::WildcardIter<'_, Data> {
         iter::WildcardIter::new(&self.inner, pattern)
+    }
+
+    /// [`Self::wildcard_iter`], abandoned once `should_stop` returns `true`.
+    /// See [`TIMEOUT_CHECK_GRANULARITY`](crate::iter::TIMEOUT_CHECK_GRANULARITY)
+    /// for the polling contract.
+    pub fn wildcard_iter_with_should_stop<'tm>(
+        &'tm self,
+        pattern: &str,
+        should_stop: impl FnMut() -> bool + 'tm,
+    ) -> iter::WildcardIter<'tm, Data> {
+        iter::WildcardIter::new_with_should_stop(&self.inner, pattern, should_stop)
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -62,6 +62,11 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
         }
     }
 
+    /// Creates a new empty iterator, that yields no entries.
+    pub(crate) fn empty() -> Self {
+        Self::new(None, &[][..])
+    }
+
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into()
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -71,7 +71,8 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
         self.timeout = timeout.into()
     }
 
-    /// See [`Iter::set_should_stop`](super::Iter::set_should_stop) for the
+    /// Stop the traversal when `should_stop` returns `true`, per the
+    /// [`TIMEOUT_CHECK_GRANULARITY`](super::TIMEOUT_CHECK_GRANULARITY)
     /// polling contract.
     pub(crate) fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
         self.timeout = IteratorTimeoutState::from_should_stop(should_stop);

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::borrow::Cow;
 use std::time::Instant;
 
 use crate::{iter::timeout::IteratorTimeoutState, trie_map::node::Node};
@@ -41,8 +42,11 @@ struct StackItem<'tm, Data> {
 
 impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     /// Creates a new contains iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'t [u8]) -> Self {
-        let finder = Finder::new(target);
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: impl Into<Cow<'t, [u8]>>) -> Self {
+        let finder = match target.into() {
+            Cow::Borrowed(target) => Finder::new(target),
+            Cow::Owned(target) => Finder::new(&target).into_owned(),
+        };
         Self {
             stack: root
                 .into_iter()

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -27,7 +27,7 @@ pub struct ContainsIter<'tm, 't, Data> {
     /// The target fragment we are looking for.
     finder: Finder<'t>,
     /// The timeout
-    timeout: IteratorTimeoutState,
+    timeout: IteratorTimeoutState<'tm>,
 }
 
 struct StackItem<'tm, Data> {
@@ -69,6 +69,12 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
 
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into()
+    }
+
+    /// See [`Iter::set_should_stop`](super::Iter::set_should_stop) for the
+    /// polling contract.
+    pub(crate) fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.timeout = IteratorTimeoutState::from_should_stop(should_stop);
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/driver.rs
@@ -128,7 +128,8 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
         self.timeout = timeout.into()
     }
 
-    /// See [`Iter::set_should_stop`](super::Iter::set_should_stop) for the
+    /// Stop the traversal when `should_stop` returns `true`, per the
+    /// [`TIMEOUT_CHECK_GRANULARITY`](super::TIMEOUT_CHECK_GRANULARITY)
     /// polling contract.
     pub(crate) fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
         self.timeout = IteratorTimeoutState::from_should_stop(should_stop);

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/driver.rs
@@ -37,7 +37,7 @@ pub struct AutomatonIter<'tm, Data, A: Automaton> {
     /// backtracks, instead of allocating a fresh `Vec` per yield.
     key: Vec<u8>,
     /// The timeout state
-    timeout: IteratorTimeoutState,
+    timeout: IteratorTimeoutState<'tm>,
 }
 
 /// One pending visit on the traversal stack.
@@ -126,6 +126,12 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
     /// Set timeout
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into()
+    }
+
+    /// See [`Iter::set_should_stop`](super::Iter::set_should_stop) for the
+    /// polling contract.
+    pub(crate) fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.timeout = IteratorTimeoutState::from_should_stop(should_stop);
     }
 
     /// Advance to the next matching entry, returning a reference to its data.

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
@@ -26,6 +26,8 @@ mod lending_range;
 mod prefixes;
 mod range;
 mod timeout;
+
+pub use timeout::TIMEOUT_CHECK_GRANULARITY;
 mod unfiltered;
 mod values;
 mod wildcard;

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -38,7 +38,14 @@ pub const TIMEOUT_CHECK_GRANULARITY: u32 = 100;
 /// [`from_should_stop`](Self::from_should_stop)), which keeps the clock —
 /// or whatever else signals cancellation — on the caller's side. Call
 /// [`check`](Self::check) once per traversal step.
-pub struct IteratorTimeoutState<'a>(Inner<'a>);
+pub struct IteratorTimeoutState<'a> {
+    /// Latched once the source reports a stop, so a stopped walk stays
+    /// stopped instead of resuming for another amortization window. Both
+    /// sources need it: an amortized clock checker clears its own counter
+    /// whenever it probes, expired deadline or not.
+    stopped: bool,
+    source: Inner<'a>,
+}
 
 enum Inner<'a> {
     /// Clock-based deadline (or the no-op checker when no deadline is set).
@@ -48,10 +55,6 @@ enum Inner<'a> {
     Callback {
         /// Traversal steps since `should_stop` was last polled.
         counter: u32,
-        /// Latched once `should_stop` returns `true`, so the iterator stays
-        /// exhausted instead of walking another amortization window —
-        /// matching an expired clock deadline, which stays expired.
-        stopped: bool,
         should_stop: Box<dyn FnMut() -> bool + 'a>,
     },
 }
@@ -59,44 +62,56 @@ enum Inner<'a> {
 impl IteratorTimeoutState<'_> {
     /// A state that never times out (used when no deadline is set).
     pub const fn no_timeout() -> Self {
-        Self(Inner::Clock(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker)))
+        Self {
+            stopped: false,
+            source: Inner::Clock(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker)),
+        }
     }
 
     /// Advance the amortized checker by one step and report whether the
     /// deadline has been reached.
     pub fn check(&mut self) -> TimeoutCheckResult {
-        match &mut self.0 {
+        if self.stopped {
+            return TimeoutCheckResult::TimedOut;
+        }
+
+        let outcome = match &mut self.source {
             Inner::Clock(checker) => checker.check_timeout(),
             Inner::Callback {
                 counter,
-                stopped,
                 should_stop,
             } => {
-                if *stopped {
-                    return TimeoutCheckResult::TimedOut;
-                }
                 *counter += 1;
                 if *counter >= TIMEOUT_CHECK_GRANULARITY {
                     *counter = 0;
                     if should_stop() {
-                        *stopped = true;
-                        return TimeoutCheckResult::TimedOut;
+                        TimeoutCheckResult::TimedOut
+                    } else {
+                        TimeoutCheckResult::Ok
                     }
+                } else {
+                    TimeoutCheckResult::Ok
                 }
-                TimeoutCheckResult::Ok
             }
+        };
+
+        if matches!(outcome, TimeoutCheckResult::TimedOut) {
+            self.stopped = true;
         }
+        outcome
     }
 }
 
 impl<'a> IteratorTimeoutState<'a> {
     /// A state driven by a caller-supplied stop signal instead of the clock.
     pub fn from_should_stop(should_stop: impl FnMut() -> bool + 'a) -> Self {
-        Self(Inner::Callback {
-            counter: 0,
+        Self {
             stopped: false,
-            should_stop: Box::new(should_stop),
-        })
+            source: Inner::Callback {
+                counter: 0,
+                should_stop: Box::new(should_stop),
+            },
+        }
     }
 }
 
@@ -106,9 +121,13 @@ impl From<Option<Instant>> for IteratorTimeoutState<'_> {
             None => Self::no_timeout(),
             Some(deadline) => {
                 let duration = deadline.saturating_duration_since(Instant::now());
-                Self(Inner::Clock(AnyTimeoutChecker::Deadline(
-                    DeadlineTimeoutChecker::new(duration, TIMEOUT_CHECK_GRANULARITY),
-                )))
+                Self {
+                    stopped: false,
+                    source: Inner::Clock(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(
+                        duration,
+                        TIMEOUT_CHECK_GRANULARITY,
+                    ))),
+                }
             }
         }
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -17,6 +17,16 @@ use timeout::{
 /// clock reads for a deadline set from an [`Instant`], calls to the
 /// predicate for one set via
 /// [`from_should_stop`](IteratorTimeoutState::from_should_stop).
+///
+/// This is the polling contract every deadline-carrying trie iterator
+/// obeys: the deadline source is probed once per this many *traversal
+/// steps*, not once per yielded entry, so it fires even on a sparse walk
+/// that visits many nodes without yielding any. Once it reports a stop,
+/// the iterator is exhausted and stays exhausted.
+///
+/// Mirrors `TIMEOUT_COUNTER_LIMIT` in `src/util/timeout.h`, which paces
+/// the equivalent C traversals. The value is duplicated rather than
+/// imported because this crate is pure Rust with no `ffi` dependency.
 pub const TIMEOUT_CHECK_GRANULARITY: u32 = 100;
 
 /// Deadline enforcement for a trie iterator.

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -13,39 +13,91 @@ use timeout::{
     AnyTimeoutChecker, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker,
 };
 
-/// Number of traversal steps between two consecutive clock probes.
-const TIMEOUT_CHECK_GRANULARITY: u32 = 100;
+/// Number of traversal steps between two consecutive deadline probes —
+/// clock reads for a deadline set from an [`Instant`], calls to the
+/// predicate for one set via
+/// [`from_should_stop`](IteratorTimeoutState::from_should_stop).
+pub const TIMEOUT_CHECK_GRANULARITY: u32 = 100;
 
 /// Deadline enforcement for a trie iterator.
 ///
-/// Wraps an [`AnyTimeoutChecker`] so each iterator can carry a timeout without
-/// naming the concrete checker type. Construct it from an optional deadline
-/// [`Instant`] via its [`From`] impl, then call [`check`](Self::check) once per
-/// traversal step.
-pub struct IteratorTimeoutState(AnyTimeoutChecker);
+/// Carries one of two amortized deadline sources, probed once per
+/// [`TIMEOUT_CHECK_GRANULARITY`] traversal steps: a clock deadline
+/// (constructed from an optional [`Instant`] via the [`From`] impl) or a
+/// caller-supplied `should_stop` predicate (via
+/// [`from_should_stop`](Self::from_should_stop)), which keeps the clock —
+/// or whatever else signals cancellation — on the caller's side. Call
+/// [`check`](Self::check) once per traversal step.
+pub struct IteratorTimeoutState<'a>(Inner<'a>);
 
-impl IteratorTimeoutState {
+enum Inner<'a> {
+    /// Clock-based deadline (or the no-op checker when no deadline is set).
+    Clock(AnyTimeoutChecker),
+    /// Caller-supplied stop signal, polled with the same amortization as
+    /// the clock checker.
+    Callback {
+        /// Traversal steps since `should_stop` was last polled.
+        counter: u32,
+        /// Latched once `should_stop` returns `true`, so the iterator stays
+        /// exhausted instead of walking another amortization window —
+        /// matching an expired clock deadline, which stays expired.
+        stopped: bool,
+        should_stop: Box<dyn FnMut() -> bool + 'a>,
+    },
+}
+
+impl IteratorTimeoutState<'_> {
     /// A state that never times out (used when no deadline is set).
     pub const fn no_timeout() -> Self {
-        Self(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker))
+        Self(Inner::Clock(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker)))
     }
 
     /// Advance the amortized checker by one step and report whether the
     /// deadline has been reached.
     pub fn check(&mut self) -> TimeoutCheckResult {
-        self.0.check_timeout()
+        match &mut self.0 {
+            Inner::Clock(checker) => checker.check_timeout(),
+            Inner::Callback {
+                counter,
+                stopped,
+                should_stop,
+            } => {
+                if *stopped {
+                    return TimeoutCheckResult::TimedOut;
+                }
+                *counter += 1;
+                if *counter >= TIMEOUT_CHECK_GRANULARITY {
+                    *counter = 0;
+                    if should_stop() {
+                        *stopped = true;
+                        return TimeoutCheckResult::TimedOut;
+                    }
+                }
+                TimeoutCheckResult::Ok
+            }
+        }
     }
 }
 
-impl From<Option<Instant>> for IteratorTimeoutState {
+impl<'a> IteratorTimeoutState<'a> {
+    /// A state driven by a caller-supplied stop signal instead of the clock.
+    pub fn from_should_stop(should_stop: impl FnMut() -> bool + 'a) -> Self {
+        Self(Inner::Callback {
+            counter: 0,
+            stopped: false,
+            should_stop: Box::new(should_stop),
+        })
+    }
+}
+
+impl From<Option<Instant>> for IteratorTimeoutState<'_> {
     fn from(value: Option<Instant>) -> Self {
         match value {
             None => Self::no_timeout(),
             Some(deadline) => {
                 let duration = deadline.saturating_duration_since(Instant::now());
-                Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(
-                    duration,
-                    TIMEOUT_CHECK_GRANULARITY,
+                Self(Inner::Clock(AnyTimeoutChecker::Deadline(
+                    DeadlineTimeoutChecker::new(duration, TIMEOUT_CHECK_GRANULARITY),
                 )))
             }
         }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
@@ -27,7 +27,7 @@ pub struct Iter<'tm, Data, F> {
     /// i.e. the key of the current node.
     key: Vec<u8>,
     /// Timeout for this iterator
-    timeout: IteratorTimeoutState,
+    timeout: IteratorTimeoutState<'tm>,
 }
 
 impl<'tm, Data, F> Iter<'tm, Data, F> {
@@ -48,6 +48,16 @@ impl<'tm, Data, F> Iter<'tm, Data, F> {
     /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into();
+    }
+
+    /// Stop the traversal when `should_stop` returns `true`. The predicate
+    /// is polled once per [`TIMEOUT_CHECK_GRANULARITY`](super::TIMEOUT_CHECK_GRANULARITY)
+    /// traversal steps — not per yielded entry — so it fires even on walks
+    /// that visit many nodes without yielding. Once it returns `true`, the
+    /// iterator is exhausted. Replaces any deadline set via
+    /// [`Self::set_timeout`].
+    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+        self.timeout = IteratorTimeoutState::from_should_stop(should_stop);
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
@@ -50,13 +50,10 @@ impl<'tm, Data, F> Iter<'tm, Data, F> {
         self.timeout = timeout.into();
     }
 
-    /// Stop the traversal when `should_stop` returns `true`. The predicate
-    /// is polled once per [`TIMEOUT_CHECK_GRANULARITY`](super::TIMEOUT_CHECK_GRANULARITY)
-    /// traversal steps — not per yielded entry — so it fires even on walks
-    /// that visit many nodes without yielding. Once it returns `true`, the
-    /// iterator is exhausted. Replaces any deadline set via
-    /// [`Self::set_timeout`].
-    pub fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
+    /// Stop the traversal when `should_stop` returns `true`, per the
+    /// [`TIMEOUT_CHECK_GRANULARITY`](super::TIMEOUT_CHECK_GRANULARITY)
+    /// polling contract. Replaces any deadline set via [`Self::set_timeout`].
+    pub(crate) fn set_should_stop(&mut self, should_stop: impl FnMut() -> bool + 'tm) {
         self.timeout = IteratorTimeoutState::from_should_stop(should_stop);
     }
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -23,6 +23,7 @@ use crate::trie_map::{
     utils::strip_prefix,
 };
 use rqe_wildcard::WildcardPattern;
+use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -286,7 +287,12 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over the entries that contain the target fragment, in lexicographical key order.
-    pub fn contains_iter<'tm, 't>(&'tm self, target: &'t [u8]) -> ContainsIter<'tm, 't, Data> {
+    /// An owned `target` is stored inside the iterator, so callers holding
+    /// only a temporary buffer still get a lazy iterator.
+    pub fn contains_iter<'tm, 't>(
+        &'tm self,
+        target: impl Into<Cow<'t, [u8]>>,
+    ) -> ContainsIter<'tm, 't, Data> {
         ContainsIter::new(self.root.as_ref(), target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -125,7 +125,10 @@ impl<Data> TrieMap<Data> {
     /// The value is obtained by calling the provided callback function.
     /// If the key already exists, the existing value is passed to the callback,
     /// otherwise `f(None)` is inserted.
-    pub fn insert_with<F>(&mut self, key: &[u8], f: F)
+    ///
+    /// Returns `true` if the key was newly inserted, `false` if it was
+    /// already present.
+    pub fn insert_with<F>(&mut self, key: &[u8], f: F) -> bool
     where
         F: FnOnce(Option<Data>) -> Data,
     {
@@ -149,6 +152,7 @@ impl<Data> TrieMap<Data> {
         if has_cardinality_increased {
             self.n_unique_keys += 1;
         }
+        has_cardinality_increased
     }
 
     #[cfg(feature = "test_utils")]

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
@@ -12,6 +12,7 @@ mod empty_input;
 mod fuzzy_iter;
 mod range_iter;
 mod return_value_contracts;
+mod should_stop;
 mod suffixed_iter;
 mod utf8_boundary;
 mod wildcard_iter;

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/return_value_contracts.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/return_value_contracts.rs
@@ -22,14 +22,17 @@ fn insert_returns_none_on_new_and_some_on_update() {
 fn insert_with_callback_receives_existing_value_on_reinsert() {
     let mut trie = StrTrieMap::<i32>::new();
 
-    trie.insert_with("k", |prev| {
+    let is_new = trie.insert_with("k", |prev| {
         assert!(prev.is_none());
         10
     });
-    trie.insert_with("k", |prev| {
+    assert!(is_new);
+
+    let is_new = trie.insert_with("k", |prev| {
         assert_eq!(prev, Some(10));
         prev.unwrap() + 5
     });
+    assert!(!is_new);
 
     assert_eq!(trie.get("k"), Some(&15));
     assert_eq!(trie.len(), 1);

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! `set_should_stop` contract: the predicate is polled per traversal step
+//! (amortized every [`TIMEOUT_CHECK_GRANULARITY`] steps), not per yielded
+//! entry, so it fires even on walks that visit many nodes without yielding
+//! anything.
+
+use std::cell::Cell;
+use trie_rs::iter::TIMEOUT_CHECK_GRANULARITY;
+use trie_rs::str_trie_map::StrTrieMap;
+
+/// Enough keys that any full walk takes well over
+/// [`TIMEOUT_CHECK_GRANULARITY`] traversal steps.
+const N_KEYS: usize = 300;
+
+fn seeded_trie() -> StrTrieMap<usize> {
+    let mut trie = StrTrieMap::new();
+    for i in 0..N_KEYS {
+        trie.insert(&format!("key{i:04}"), i);
+    }
+    trie
+}
+
+#[test]
+fn prefixed_iter_stops_mid_walk() {
+    let trie = seeded_trie();
+
+    let mut iter = trie.prefixed_iter("key");
+    iter.set_should_stop(|| true);
+    let yielded = iter.by_ref().count();
+
+    assert!(
+        yielded < N_KEYS,
+        "an always-true predicate must cut the walk short, got all {yielded} entries"
+    );
+    assert!(iter.next().is_none(), "a stopped iterator stays exhausted");
+}
+
+#[test]
+fn prefixed_iter_polls_predicate_amortized() {
+    let trie = seeded_trie();
+    let calls = Cell::new(0u32);
+
+    let mut iter = trie.prefixed_iter("key");
+    iter.set_should_stop(|| {
+        calls.set(calls.get() + 1);
+        false
+    });
+    let yielded = iter.count();
+
+    assert_eq!(yielded, N_KEYS, "a false predicate must not drop entries");
+    // Every node contributes at least one traversal step, so a full walk
+    // over N_KEYS keys polls the predicate at least N_KEYS / granularity
+    // times.
+    let min_polls = N_KEYS as u32 / TIMEOUT_CHECK_GRANULARITY;
+    assert!(
+        calls.get() >= min_polls,
+        "expected >= {min_polls} polls over a full walk, got {}",
+        calls.get()
+    );
+}
+
+#[test]
+fn suffixed_iter_polls_predicate_on_yieldless_walk() {
+    let trie = seeded_trie();
+    let calls = Cell::new(0u32);
+
+    // No key ends with "zzz": the walk visits the whole trie and yields
+    // nothing, so a per-yield poll would never fire.
+    let mut iter = trie.suffixed_iter("zzz");
+    iter.set_should_stop(|| {
+        calls.set(calls.get() + 1);
+        false
+    });
+    assert_eq!(iter.count(), 0);
+    assert!(
+        calls.get() > 0,
+        "the predicate must be polled per traversal step, not per yield"
+    );
+}
+
+#[test]
+fn suffixed_iter_stops_mid_walk() {
+    let trie = seeded_trie();
+    let calls = Cell::new(0u32);
+
+    let mut iter = trie.suffixed_iter("zzz");
+    iter.set_should_stop(|| {
+        calls.set(calls.get() + 1);
+        true
+    });
+    assert_eq!(iter.count(), 0);
+    assert_eq!(
+        calls.get(),
+        1,
+        "an always-true predicate must end the walk at its first poll"
+    );
+}
+
+#[test]
+fn contains_iter_polls_predicate_on_yieldless_walk() {
+    let trie = seeded_trie();
+    let calls = Cell::new(0u32);
+
+    let mut iter = trie.contains_iter("zzz");
+    iter.set_should_stop(|| {
+        calls.set(calls.get() + 1);
+        false
+    });
+    assert_eq!(iter.count(), 0);
+    assert!(
+        calls.get() > 0,
+        "the predicate must be polled per traversal step, not per yield"
+    );
+}
+
+#[test]
+fn contains_iter_stops_mid_walk() {
+    let trie = seeded_trie();
+
+    // Every key contains "key", so a full walk yields everything.
+    let mut iter = trie.contains_iter("key");
+    iter.set_should_stop(|| true);
+    assert!(
+        iter.count() < N_KEYS,
+        "an always-true predicate must cut the walk short"
+    );
+}
+
+#[test]
+fn wildcard_iter_nfa_backend_stops_mid_walk() {
+    let trie = seeded_trie();
+
+    // Few atoms: NFA backend.
+    let mut iter = trie.wildcard_iter("key*");
+    iter.set_should_stop(|| true);
+    assert!(
+        iter.count() < N_KEYS,
+        "an always-true predicate must cut the NFA walk short"
+    );
+}
+
+#[test]
+fn wildcard_iter_filter_backend_polls_predicate() {
+    let trie = seeded_trie();
+    let calls = Cell::new(0u32);
+
+    // >= 128 atoms forces the per-key filter backend; no stored key is 128
+    // codepoints long, so the walk yields nothing.
+    let pattern = "?".repeat(128);
+    let mut iter = trie.wildcard_iter(&pattern);
+    iter.set_should_stop(|| {
+        calls.set(calls.get() + 1);
+        false
+    });
+    assert_eq!(iter.count(), 0);
+    assert!(
+        calls.get() > 0,
+        "the filter backend must poll the predicate per traversal step"
+    );
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
@@ -13,6 +13,7 @@
 //! anything.
 
 use std::cell::Cell;
+use trie_rs::automaton::CodepointWildcard;
 use trie_rs::iter::TIMEOUT_CHECK_GRANULARITY;
 use trie_rs::str_trie_map::StrTrieMap;
 
@@ -171,5 +172,37 @@ fn wildcard_iter_filter_backend_polls_predicate() {
     assert!(
         calls.get() > 0,
         "the filter backend must poll the predicate per traversal step"
+    );
+}
+
+#[test]
+fn wildcard_iter_nfa128_backend_stops_mid_walk() {
+    // Long keys so a pattern that matches all of them still needs more
+    // NFA positions than a `u64` bitset holds.
+    let mut trie = StrTrieMap::new();
+    for i in 0..N_KEYS {
+        trie.insert(&format!("key{i:04}{}", "z".repeat(70)), i);
+    }
+
+    let pattern = format!("key????{}*", "z".repeat(70));
+    // The `u64` backend covers up to 64 positions and the accept position
+    // sits past the last atom, so this pattern selects the `u128` one.
+    let positions = CodepointWildcard::parse(&pattern).atom_count() + 1;
+    assert!(
+        (65..=128).contains(&positions),
+        "pattern must select the u128 NFA backend, got {positions} positions"
+    );
+
+    let full = trie
+        .wildcard_iter_with_should_stop(&pattern, || false)
+        .count();
+    assert_eq!(full, N_KEYS, "the pattern must match every key");
+
+    let stopped = trie
+        .wildcard_iter_with_should_stop(&pattern, || true)
+        .count();
+    assert!(
+        stopped < N_KEYS,
+        "an always-true predicate must cut the u128 NFA walk short"
     );
 }

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/should_stop.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! `set_should_stop` contract: the predicate is polled per traversal step
+//! `should_stop` contract: the predicate is polled per traversal step
 //! (amortized every [`TIMEOUT_CHECK_GRANULARITY`] steps), not per yielded
 //! entry, so it fires even on walks that visit many nodes without yielding
 //! anything.
@@ -32,8 +32,7 @@ fn seeded_trie() -> StrTrieMap<usize> {
 fn prefixed_iter_stops_mid_walk() {
     let trie = seeded_trie();
 
-    let mut iter = trie.prefixed_iter("key");
-    iter.set_should_stop(|| true);
+    let mut iter = trie.prefixed_iter_with_should_stop("key", || true);
     let yielded = iter.by_ref().count();
 
     assert!(
@@ -48,12 +47,12 @@ fn prefixed_iter_polls_predicate_amortized() {
     let trie = seeded_trie();
     let calls = Cell::new(0u32);
 
-    let mut iter = trie.prefixed_iter("key");
-    iter.set_should_stop(|| {
-        calls.set(calls.get() + 1);
-        false
-    });
-    let yielded = iter.count();
+    let yielded = trie
+        .prefixed_iter_with_should_stop("key", || {
+            calls.set(calls.get() + 1);
+            false
+        })
+        .count();
 
     assert_eq!(yielded, N_KEYS, "a false predicate must not drop entries");
     // Every node contributes at least one traversal step, so a full walk
@@ -74,12 +73,14 @@ fn suffixed_iter_polls_predicate_on_yieldless_walk() {
 
     // No key ends with "zzz": the walk visits the whole trie and yields
     // nothing, so a per-yield poll would never fire.
-    let mut iter = trie.suffixed_iter("zzz");
-    iter.set_should_stop(|| {
-        calls.set(calls.get() + 1);
-        false
-    });
-    assert_eq!(iter.count(), 0);
+    let count = trie
+        .suffixed_iter_with_should_stop("zzz", || {
+            calls.set(calls.get() + 1);
+            false
+        })
+        .count();
+
+    assert_eq!(count, 0);
     assert!(
         calls.get() > 0,
         "the predicate must be polled per traversal step, not per yield"
@@ -91,12 +92,14 @@ fn suffixed_iter_stops_mid_walk() {
     let trie = seeded_trie();
     let calls = Cell::new(0u32);
 
-    let mut iter = trie.suffixed_iter("zzz");
-    iter.set_should_stop(|| {
-        calls.set(calls.get() + 1);
-        true
-    });
-    assert_eq!(iter.count(), 0);
+    let count = trie
+        .suffixed_iter_with_should_stop("zzz", || {
+            calls.set(calls.get() + 1);
+            true
+        })
+        .count();
+
+    assert_eq!(count, 0);
     assert_eq!(
         calls.get(),
         1,
@@ -109,12 +112,14 @@ fn contains_iter_polls_predicate_on_yieldless_walk() {
     let trie = seeded_trie();
     let calls = Cell::new(0u32);
 
-    let mut iter = trie.contains_iter("zzz");
-    iter.set_should_stop(|| {
-        calls.set(calls.get() + 1);
-        false
-    });
-    assert_eq!(iter.count(), 0);
+    let count = trie
+        .contains_iter_with_should_stop("zzz", || {
+            calls.set(calls.get() + 1);
+            false
+        })
+        .count();
+
+    assert_eq!(count, 0);
     assert!(
         calls.get() > 0,
         "the predicate must be polled per traversal step, not per yield"
@@ -126,10 +131,10 @@ fn contains_iter_stops_mid_walk() {
     let trie = seeded_trie();
 
     // Every key contains "key", so a full walk yields everything.
-    let mut iter = trie.contains_iter("key");
-    iter.set_should_stop(|| true);
+    let count = trie.contains_iter_with_should_stop("key", || true).count();
+
     assert!(
-        iter.count() < N_KEYS,
+        count < N_KEYS,
         "an always-true predicate must cut the walk short"
     );
 }
@@ -139,10 +144,10 @@ fn wildcard_iter_nfa_backend_stops_mid_walk() {
     let trie = seeded_trie();
 
     // Few atoms: NFA backend.
-    let mut iter = trie.wildcard_iter("key*");
-    iter.set_should_stop(|| true);
+    let count = trie.wildcard_iter_with_should_stop("key*", || true).count();
+
     assert!(
-        iter.count() < N_KEYS,
+        count < N_KEYS,
         "an always-true predicate must cut the NFA walk short"
     );
 }
@@ -155,12 +160,14 @@ fn wildcard_iter_filter_backend_polls_predicate() {
     // >= 128 atoms forces the per-key filter backend; no stored key is 128
     // codepoints long, so the walk yields nothing.
     let pattern = "?".repeat(128);
-    let mut iter = trie.wildcard_iter(&pattern);
-    iter.set_should_stop(|| {
-        calls.set(calls.get() + 1);
-        false
-    });
-    assert_eq!(iter.count(), 0);
+    let count = trie
+        .wildcard_iter_with_should_stop(&pattern, || {
+            calls.set(calls.get() + 1);
+            false
+        })
+        .count();
+
+    assert_eq!(count, 0);
     assert!(
         calls.get() > 0,
         "the filter backend must poll the predicate per traversal step"

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
@@ -13,6 +13,7 @@ mod filter;
 mod prefixed;
 mod prefixes;
 mod range;
+mod timeout;
 mod unfiltered;
 mod values;
 mod wildcard_automaton;

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/timeout.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Clock-deadline half of the polling contract documented on
+//! [`TIMEOUT_CHECK_GRANULARITY`]: the amortized clock checker clears its
+//! own counter on every probe, so without a latch an expired iterator
+//! would resume for another window's worth of entries.
+
+use std::time::{Duration, Instant};
+use trie_rs::TrieMap;
+
+/// Enough keys that a full walk takes well over
+/// [`TIMEOUT_CHECK_GRANULARITY`](trie_rs::iter::TIMEOUT_CHECK_GRANULARITY)
+/// traversal steps.
+const N_KEYS: usize = 300;
+
+fn seeded_trie() -> TrieMap<usize> {
+    let mut trie = TrieMap::new();
+    for i in 0..N_KEYS {
+        trie.insert(format!("key{i:04}").as_bytes(), i);
+    }
+    trie
+}
+
+#[test]
+fn expired_deadline_stops_the_walk_for_good() {
+    let trie = seeded_trie();
+
+    let mut iter = trie.prefixed_iter(b"key");
+    iter.set_timeout(Some(Instant::now() - Duration::from_secs(1)));
+
+    let yielded = iter.by_ref().count();
+    assert!(
+        yielded < N_KEYS,
+        "an expired deadline must cut the walk short, got all {yielded} entries"
+    );
+    assert_eq!(
+        iter.by_ref().count(),
+        0,
+        "a timed-out iterator stays exhausted"
+    );
+}
+
+#[test]
+fn unexpired_deadline_yields_every_entry() {
+    let trie = seeded_trie();
+
+    let mut iter = trie.prefixed_iter(b"key");
+    iter.set_timeout(Some(Instant::now() + Duration::from_secs(3600)));
+
+    assert_eq!(iter.count(), N_KEYS);
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the trie's only interruption mechanism is a crate-internal clock-based
   timeout, unreachable from the `str_trie_map` layer, so a term walk over a sparse
   trie runs to completion however long the traversal takes.
2. Change: `prefixed`, `suffixed`, `contains` and `wildcard` iteration takes a
   caller-supplied `should_stop` predicate, checked as part of the existing
   amortized timeout check so it also fires on walks that yield nothing. On
   `TermDictionary` the predicate is a constructor argument rather than a setter,
   so a call site cannot omit it. Fuzzy iteration stays deadline-free, matching the
   C walk it replaces.
3. Outcome: internal-only — no user-visible change. It is the prerequisite for the
   term dictionary FFI to honor the query timeout the C term walks check today.

#### Which additional issues this PR fixes

1. MOD-16400

#### Main objects this PR modified

1. `trie_rs::trie_map::iter` — `should_stop` alongside the clock in the timeout
   check sites (`driver`, `contains`, `unfiltered`), `TIMEOUT_CHECK_GRANULARITY`
   now public as the polling contract.
2. `trie_rs::str_trie_map` — pattern iterators forward the predicate.
3. `term_dictionary::TermDictionary` — pattern walks take the predicate at
   construction; callers without a deadline pass `|| false`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
