### PR TITLE
[MOD-18024] Redesign the GC resume path to preserve pointer provenance

### DIFF
--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -123,6 +123,60 @@ impl<Rf: Ref, E: Encoder> RawIndexReaderCore<Rf, E> {
     }
 }
 
+impl<E> RawIndexReaderCore<Suspended, E> {
+    /// Adopt `ii`'s provenance for this reader's index pointer.
+    ///
+    /// The pointer [`new`](RawIndexReaderCore::new) installs descends from the
+    /// `&InvertedIndex` it is handed. A garbage-collection pass mutating that index
+    /// through its owner invalidates the derivation while leaving the address
+    /// alone, so reading through it afterwards is undefined behaviour even though
+    /// [`points_to_ii`](RawIndexReaderCore::points_to_ii) still answers `true`.
+    /// Revalidation re-resolves the index anyway in order to *ask* that question;
+    /// this installs the answer's fresh derivation, so every later read goes
+    /// through a live one.
+    ///
+    /// Laundering, not a swap: `ii` must be the index the reader already reads.
+    /// [`swap_index`](RawIndexReaderCore::swap_index) is the latter.
+    ///
+    /// # Safety
+    ///
+    /// `ii` must be the index this reader already reads, and must stay
+    /// dereferenceable until the reader is resumed or dropped. Suspension itself
+    /// promises nothing about the referent, but the resume path reads through
+    /// whatever this installs.
+    pub unsafe fn reseat_index(&mut self, ii: NonNull<InvertedIndex<E>>) {
+        debug_assert!(
+            std::ptr::eq(self.ii.as_raw(), ii.as_ptr()),
+            "reseat must not move the reader to a different index"
+        );
+
+        self.ii = SharedPtr::from_non_null(ii);
+    }
+}
+
+impl<'index, E: 'index> RawIndexReaderCore<Active<'index>, E> {
+    /// The [`Active`] counterpart of
+    /// [`reseat_index`](RawIndexReaderCore::reseat_index) on the suspended reader,
+    /// which documents why the reseat is needed.
+    ///
+    /// # Safety
+    ///
+    /// Its contract, with the referent's validity pinned to `'index` rather than
+    /// to the resume.
+    pub unsafe fn reseat_index(&mut self, ii: NonNull<InvertedIndex<E>>) {
+        debug_assert!(
+            std::ptr::eq(self.ii.as_raw(), ii.as_ptr()),
+            "reseat must not move the reader to a different index"
+        );
+
+        // SAFETY: the caller guarantees `'index` validity. Deriving a reference here
+        // is harmless where `new` deriving one is not: `ii` was resolved after the
+        // mutation, so a reborrow of it is live rather than an heir of the pointer
+        // the mutation invalidated.
+        self.ii = SharedPtr::from_ref(unsafe { ii.as_ref() });
+    }
+}
+
 /// `IndexReaderCore<Active<'a>, E>` suspends to `IndexReaderCore<Suspended, E>`.
 ///
 /// SAFETY: the layout compatibility this trait requires is invariant 1 on

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -77,16 +77,19 @@ where
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     L: TagLookup<E>,
 {
-    /// Check if the iterator should abort revalidation.
+    /// The inverted index currently stored for this iterator's tag value,
+    /// freshly resolved, or `None` when the iterator must
+    /// [`abort`](RQEValidateStatus::Aborted) — the garbage collector removed all
+    /// the tag's documents, or replaced its inverted index with a new allocation.
     ///
-    /// The garbage collector may remove all documents from a tag value's
-    /// inverted index or replace it with a new allocation. In both cases the
-    /// reader's pointer is stale and the iterator must
-    /// [`abort`](RQEValidateStatus::Aborted).
+    /// Hands back the resolution rather than a verdict so the caller can
+    /// [reseat](inverted_index::RawIndexReaderCore::reseat_index) the reader on
+    /// it: the reader's own pointer does not survive the collection this check
+    /// exists to detect.
     ///
     /// Defined on the `Rf`-generic [`RawTag`] so the suspended form can run it
     /// from [`RQESuspendedIterator::resume`] before promoting to [`Active`].
-    fn should_abort(&self) -> bool {
+    fn resolve_live_index(&self) -> Option<NonNull<inverted_index::InvertedIndex<E>>> {
         let term = self
             .it
             .result
@@ -99,12 +102,15 @@ where
             .as_bytes()
             .expect("Tag iterator query term should have a non-null string");
 
-        match self.lookup.find(term_bytes) {
-            // The inverted index was collected entirely by GC, or the
-            // value is a null sentinel (disk mode).
-            None => true,
-            Some(ii) => !self.it.reader.points_to_ii(ii),
-        }
+        // `None`: the inverted index was collected entirely by GC, or the value is
+        // a null sentinel (disk mode).
+        let ii = self.lookup.find(term_bytes)?;
+
+        // Handing back a raw pointer ends the `&self` borrow at the return, leaving
+        // the caller free to take the `&mut` the reseat needs. It keeps `ii`'s
+        // provenance: a tag is invalidated by a conflicting retag, not by the
+        // reference it was minted for going out of scope.
+        self.it.reader.points_to_ii(ii).then(|| NonNull::from(ii))
     }
 }
 
@@ -231,9 +237,16 @@ where
         &mut self,
         spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        if self.should_abort() {
+        let Some(ii) = self.resolve_live_index() else {
             return Ok(RQEValidateStatus::Aborted);
-        }
+        };
+
+        // As in `resume`: the reader's own pointer did not survive the collection,
+        // and `revalidate` reads the index's GC marker through it.
+        // SAFETY: `ii` is the index this reader already reads — `points_to_ii`
+        // held — and `spec` witnesses the read lock keeping the spec's indexes
+        // alive for `'index`.
+        unsafe { self.it.reader.reseat_index(ii) };
 
         self.it.revalidate(spec)
     }
@@ -310,9 +323,17 @@ where
         // Step 1: identity check on the suspended form. On abort we drop the
         // suspended iterator without promoting it to Active — nothing is
         // materialized.
-        if self.should_abort() {
+        let Some(ii) = self.resolve_live_index() else {
             return Ok(ResumeOutcome::Aborted);
-        }
+        };
+
+        // The resolution above is the only pointer to the index that a collection
+        // cannot have invalidated, so adopt it before `resume_in_place`, whose
+        // first act is to read the index's GC marker through it.
+        // SAFETY: `ii` is the index this reader already reads — `points_to_ii`
+        // held — and `guard` witnesses the read lock keeping it alive across the
+        // resume.
+        unsafe { self.it.reader.reseat_index(ii) };
 
         // Step 2: run the shared in-place resume transition on the inner
         // core iterator (refresh pointers, reset stale offsets, promote the

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -672,12 +672,17 @@ impl TrieLookup {
     ///    collector is handed to reach the same index, and **not** a pointer
     ///    derived from a `&TagIndex` or a `&mut TagIndex` to not break the
     ///    borrowing rules. Passing `idx` itself keeps the alternation
-    ///    raw → `&mut` → raw, which is permitted.
+    ///    raw → `&mut` → raw, which is permitted. That is what leaves the lookup
+    ///    the one route to a tag's postings a collection cannot invalidate, and
+    ///    so the route a parked reader recovers a usable pointer through — see
+    ///    [`RawIndexReaderCore::reseat_index`].
     ///
     /// 2. `idx` must stay valid for this lookup and any iterator holding it.
     ///
     /// 3. The index may only be mutated while the lookup is alive under the
     ///    standard revalidation protocol.
+    ///
+    /// [`RawIndexReaderCore::reseat_index`]: inverted_index::reader::RawIndexReaderCore::reseat_index
     pub const unsafe fn new(idx: NonNull<TagIndex<InMemoryMode>>) -> Self {
         Self(idx)
     }

--- a/src/redisearch_rs/tag_index/tests/integration/reader.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/reader.rs
@@ -330,17 +330,6 @@ fn resume_with_the_tag_untouched_reads_on() {
 /// only revalidation outcome in which a reader reads through the pointer it held
 /// across a mutation of the index.
 #[test]
-#[cfg_attr(
-    miri,
-    ignore = "the reader's stored pointer is derived from the `&self` reborrow taken in \
-              `open_reader` (a SharedReadOnly tag); the `&mut` the collector needs pops that tag \
-              under Stacked Borrows, so the re-seek reading through it is flagged as UB. The \
-              aliasing is the revalidation protocol working as designed (the same pattern the \
-              numeric iterator documents on `variant_resume` in \
-              rqe_iterators/tests/integration/inverted_index/numeric.rs) but Stacked Borrows \
-              cannot model it. The `Aborted` arm above stays in Miri's reach because it never \
-              reads through the pointer."
-)]
 fn resume_after_the_current_document_was_collected_reads_on() {
     const N: ffi::t_docId = 4;
     const COLLECTED: ffi::t_docId = 2;
@@ -394,6 +383,66 @@ fn resume_after_the_current_document_was_collected_reads_on() {
         COLLECTED + 1
     );
     assert_eq!(drain(*it), (COLLECTED + 2..=N).collect::<Vec<_>>());
+
+    // SAFETY: `allocate` allocated it; the iterator using it is gone.
+    drop(unsafe { Box::from_raw(tag_index) });
+}
+
+/// The active-side twin of
+/// [`resume_after_the_current_document_was_collected_reads_on`]: a reader that
+/// stayed live across an in-place collection revalidates to
+/// [`Moved`](RQEValidateStatus::Moved) rather than aborting, and reports the first
+/// document surviving past the collected one.
+///
+/// [`revalidate_aborts_after_gc`] covers the other arm, and is the only one that
+/// never reads through the pointer the reader held across the collection.
+#[test]
+fn revalidate_after_the_current_document_was_collected_reads_on() {
+    const N: ffi::t_docId = 4;
+    const COLLECTED: ffi::t_docId = 2;
+
+    let mock = MockContext::new(N, N as usize);
+    let (tag_index, lookup) = allocate(TagIndex::<InMemoryMode>::new(false));
+    for doc_id in 1..=N {
+        // SAFETY: `tag_index` was just allocated and is not yet aliased.
+        index_mem(unsafe { &mut *tag_index }, &[b"hello"], doc_id);
+    }
+
+    // SAFETY: `tag_index` and `mock` outlive the iterator, `tag_index` is mutated
+    // below only between revalidations, and `lookup` resolves `tag_index`.
+    let mut it = unsafe {
+        (*tag_index).open_reader(mock.sctx(), as_tag(b"hello"), 1.0, FIELD_INDEX, lookup)
+    }
+    .expect("the tag is indexed");
+    // Park the reader exactly on the document about to be collected, the position
+    // the revalidation has to recover from.
+    for _ in 1..=COLLECTED {
+        it.read().expect("read must not error");
+    }
+    assert_eq!(it.last_doc_id(), COLLECTED);
+
+    // SAFETY: the iterator is untouched during the mutation, per the revalidation
+    // protocol.
+    let info = gc_mem(unsafe { &mut *tag_index }, b"hello", |d| d != COLLECTED);
+    assert_eq!(
+        info.entries_removed, 1,
+        "only the document parked on must have been collected"
+    );
+
+    let status = it
+        .revalidate(&mock.spec_read())
+        .expect("revalidate must not error");
+    let RQEValidateStatus::Moved { current } = status else {
+        panic!("an in-place collection leaves the index the reader holds, so it cannot abort")
+    };
+    assert_eq!(
+        current
+            .expect("the collected document has a successor to land on")
+            .doc_id,
+        COLLECTED + 1
+    );
+
+    assert_eq!(drain(it), (COLLECTED + 2..=N).collect::<Vec<_>>());
 
     // SAFETY: `allocate` allocated it; the iterator using it is gone.
     drop(unsafe { Box::from_raw(tag_index) });


### PR DESCRIPTION
Based on this PR https://github.com/RediSearch/RediSearch/pull/11041 and this bot comment https://github.com/RediSearch/RediSearch/pull/11041#discussion_r3844744274, with CC, I developed this fix.
Anyway, during the review, @gdesmott put this comment https://github.com/RediSearch/RediSearch/pull/11041#discussion_r3853225134 . Because the fix goes beyond that PR, I put everything in a dedicated one, so we can discuss here.

Linked to https://redislabs.atlassian.net/browse/MOD-18024



The bot raised this problem here https://github.com/RediSearch/RediSearch/pull/11041#discussion_r3844744274, and it makes sense to me. The following text describes the problem better and why the proposed solution resolves it. Mainly, the problem is related to iterator suspension: the iterator next has an immutable reference to the inverted index, and GC wants to acquire a mutable reference. The GC lock prevents these two processes from running concurrently, but Rust's reference provenance is broken.

Query side, on every resume after the lock is re-taken (src/result_processor.c:294):
```
RPQueryIterator_Next
└─ handleSpecLockAndRevalidate            src/result_processor.c
   ├─ RedisSearchCtx_LockSpecRead
   └─ it->Revalidate(it, sctx->spec)      QueryIterator vtable
      └─ revalidate::<Tag>                rqe_iterators/src/interop.rs:309
         └─ Tag::revalidate               rqe_iterators/src/inverted_index/tag.rs
            ├─ should_abort
            │  ├─ TrieLookup::find(tag)   → &InvertedIndex, resolved just now
            │  └─ points_to_ii(ii)        → true, so no abort; the &InvertedIndex
            │                               is dropped here
            └─ RawInvIndIterator::revalidate
               └─ needs_revalidation → self.ii.get()   ← reads through the
                                                          pointer stored at open
```
GC side, in between two of those, while the query holds no lock (src/fork_gc/tags.c:182):
```
FGC_ApplyTagIndex
└─ Rust_TagIndex_GC                       tag_index_ffi/src/lib.rs
   └─ TagIndex::gc                        tag_index/src/lib.rs:562
      └─ values.find_mut(…)               → &mut InvertedIndex
```
Two different pointers to the same index meet in should_abort, and the wrong one wins.

The pointer needs_revalidation reads through is the one installed when the iterator was built: TagIndex::open_reader takes &self, resolves self.mode.values.find(…) (tag_index/src/lib.rs:506), and IndexReaderCore::new stores that &InvertedIndex (inverted_index/src/reader/core.rs:422). The &mut InvertedIndex the collector takes in between invalidates that derivation.

The pointer TrieLookup::find just produced is a fresh one, and it is fine. But points_to_ii does nothing with it except std::ptr::eq on the address and an equality check on the unique id (inverted_index/src/reader/core.rs:121) — and an in-place collection edits the posting list rather than replacing it, so both are unchanged. The check therefore answers true, should_abort returns false, the good reference goes out of scope, and needs_revalidation reads through the stale one. The reader is waved through at precisely the moment its pointer has lost its permission; Miri reports trying to retag from for SharedReadOnly permission waved through and then reads memory it no longer has permission to read. Miri reports it as trying to retag from for SharedReadOnly permission.

The resume path is the same defect one step ahead: it is not wired to C yet, but resume_in_place → refresh_pointers opens by reading the GC marker through that same pointer.

Why the reseat, and why it needs TrieLookup
TrieLookup is the one pointer in the picture a collection cannot invalidate. It holds the pointer C owns — tagOpts.tagIndex, the same one Rust_TagIndex_GC is called with — copied out before any reference to the index exists (Rust_TagIndex_OpenReader, tag_index_ffi/src/lib.rs). Copying a raw pointer is not an access, so the alternation stays raw → &mut → raw, and TrieLookup::find still resolves after the collector has run.

Revalidation was already calling find, purely to answer "is this still my index?", and then discarding the result and reading through the reader's own stale pointer. The change keeps it instead: resolve_live_index returns that NonNull rather than a bool, and reseat_index installs it into the reader before the first dereference — in revalidate and in resume alike. Everything downstream (the GC-marker read, the rewind, the re-seek, the block buffer) is then derived from a pointer minted after the mutation.

So the two pieces are complementary, and neither works alone: TrieLookup is what supplies a live pointer, and the reseat is what makes the reader actually use it instead of the one it has been holding since open_reader.









## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
