### PR TITLE
[MOD-17659] Allow FT.SEARCH SORTBY on Flex indexes

### DIFF
--- a/docs/design/search_on_disk_mvp_feature_blocking.md
+++ b/docs/design/search_on_disk_mvp_feature_blocking.md
@@ -132,7 +132,7 @@ Once the MVP is complete, the following features should be unblocked:
 | `SUMMARIZE` | ✅ Yes | ✅ BLOCKED | `aggregate_request.c:627-630` |
 | `GEOFILTER` | ✅ Implicit | ✅ BLOCKED (implicit) | GEO field type is blocked, so no GEO index |
 | `FILTER` (numeric) | ✅ Implicit | ✅ BLOCKED (implicit) | NUMERIC field type is blocked |
-| `SORTBY` | No | ➖ Allowed | Sort keys load via the disk async loader at the arrange step |
+| `SORTBY` | No | ➖ Allowed | Sort keys load via the disk async loader at the arrange step; schema-field SORTBY is rejected where execution cannot block (MULTI/EXEC, Lua). Vector-distance sort keys need no loader and stay allowed there |
 
 ### Scorer Reference
 

--- a/docs/design/search_on_disk_mvp_feature_blocking.md
+++ b/docs/design/search_on_disk_mvp_feature_blocking.md
@@ -14,7 +14,7 @@ and compares them against the actual implementation status in the codebase.
 |---------|--------|-------|
 | `FT.CREATE` | ✅ Allowed | Requires `SKIPINITIALSCAN`; only HASH type; only TEXT/TAG/VECTOR fields |
 | `FT.DROPINDEX` | ✅ Allowed | `DD` option blocked |
-| `FT.SEARCH` | ✅ Allowed | Requires `NOCONTENT` or `RETURN 0`; no SLOP/INORDER/HIGHLIGHT/SUMMARIZE/SORTBY/LOAD |
+| `FT.SEARCH` | ✅ Allowed | Requires `NOCONTENT` or `RETURN 0`; no SLOP/INORDER/HIGHLIGHT/SUMMARIZE/LOAD |
 | `FT.PROFILE SEARCH` | ✅ Allowed | Only with `SEARCH` subcommand |
 | `FT.INFO` | ✅ Allowed | — |
 | `FT._LIST` | ✅ Allowed | — |
@@ -74,7 +74,6 @@ Once the MVP is complete, the following features should be unblocked:
 | `FT.HYBRID` | ❌ Blocked | ✅ Allow |
 | `FT.CURSOR` commands | ❌ Blocked | ✅ Allow |
 | `FT.ALTER` | ❌ Blocked | ✅ Allow |
-| `SORTBY` argument | ❌ Blocked | ✅ Allow |
 | `ON JSON` | ❌ Blocked | ✅ Allow |
 | Vector Range queries | ⚠️ Allowed | ✅ Keep allowed |
 | `FLAT` vector algorithm | ❌ Blocked | ⚠️ TBD |
@@ -133,7 +132,7 @@ Once the MVP is complete, the following features should be unblocked:
 | `SUMMARIZE` | ✅ Yes | ✅ BLOCKED | `aggregate_request.c:627-630` |
 | `GEOFILTER` | ✅ Implicit | ✅ BLOCKED (implicit) | GEO field type is blocked, so no GEO index |
 | `FILTER` (numeric) | ✅ Implicit | ✅ BLOCKED (implicit) | NUMERIC field type is blocked |
-| `SORTBY` | ✅ Yes | ✅ BLOCKED | `aggregate_request.c:310-312` |
+| `SORTBY` | No | ➖ Allowed | Sort keys load via the disk async loader at the arrange step |
 
 ### Scorer Reference
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1806,8 +1806,12 @@ static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv
 // flex has no SORTABLE fields to make one unnecessary. Vector-distance sort
 // keys are written into the lookup by the iterator instead, and metric names
 // colliding with schema fields are rejected, so a schema-field sort key is
-// exactly the case that loads.
+// exactly the case that loads. Count-only searches short-circuit the arrange
+// step with a counter before sort keys are examined, so they never load.
 static bool searchSortbyNeedsLoader(AREQ *r, const IndexSpec *spec) {
+  if (IsCount(r)) {
+    return false;
+  }
   PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(r));
   if (!arng) {
     return false;
@@ -1842,6 +1846,11 @@ static int rejectDiskLoaderInlineExecution(AREQ *r, const RedisSearchCtx *sctx,
   if (IsAggregate(r)) {
     error = "FT.AGGREGATE in a context that cannot block (MULTI/EXEC or Lua "
             "scripts) is not supported in Redis Flex";
+  } else if (IsSearch(r) && searchSortbyNeedsLoader(r, sctx->spec)) {
+    // Before the field-return check: when both apply, NOCONTENT/RETURN 0 is
+    // not a sufficient workaround — the sort key still has to load.
+    error = "FT.SEARCH with SORTBY on a schema field in a context that cannot "
+            "block (MULTI/EXEC or Lua scripts) is not supported in Redis Flex";
   } else if (IsSearch(r) &&
              (!(AREQ_RequestFlags(r) & QEXEC_F_SEND_NOFIELDS) ||
               AGPLN_FindStep(AREQ_AGGPlan(r), NULL, NULL, PLN_T_LOAD))) {
@@ -1850,9 +1859,6 @@ static int rejectDiskLoaderInlineExecution(AREQ *r, const RedisSearchCtx *sctx,
     error = "FT.SEARCH with field return in a context that cannot block "
             "(MULTI/EXEC or Lua scripts) is not supported in Redis Flex; "
             "use NOCONTENT or RETURN 0";
-  } else if (IsSearch(r) && searchSortbyNeedsLoader(r, sctx->spec)) {
-    error = "FT.SEARCH with SORTBY on a schema field in a context that cannot "
-            "block (MULTI/EXEC or Lua scripts) is not supported in Redis Flex";
   }
   if (error) {
     QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_UNSUPPORTED_ARGUMENT, error);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1372,68 +1372,6 @@ cleanup:
   blockedClientReqCtx_destroy(BCRctx);
 }
 
-/**
- * Validate SORTBY for disk indexes.
- * In disk/flex mode, FT.SEARCH SORTBY is only allowed on vector score
- * (distance) fields. FT.AGGREGATE SORTBY is unrestricted (sort keys load via
- * the disk async loader).
- * Must be called after QAST_Iterate so that metricRequests is populated.
- *
- * Current flex assumptions (asserted):
- * - FT.SEARCH allows only a single SORTBY field
- * - KNN is allowed only once per query, yielding a single vector score field
- *
- * @param req The AREQ to validate
- * @param status Error details set here
- * @return REDISMODULE_OK if valid, REDISMODULE_ERR otherwise
- */
-static int validateSortbyForDiskIndex(AREQ *req, QueryError *status) {
-  // Skip validation if disk is not enabled
-  if (!SearchDisk_IsEnabledForValidation()) {
-    return REDISMODULE_OK;
-  }
-
-  // SORTBY in aggregations is allowed on disk: the arrange step loads the sort
-  // keys through the disk async loader. The restriction (and the single-field
-  // asserts) below apply to FT.SEARCH only, so this early-return must precede
-  // them — a multi-field aggregate SORTBY would trip the asserts.
-  if (IsAggregate(req)) {
-    return REDISMODULE_OK;
-  }
-
-  // Skip if no SORTBY
-  if (!HasSortBy(req)) {
-    return REDISMODULE_OK;
-  }
-
-  // If HasSortBy is true, arrange step and sortKeys must exist
-  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(req));
-  RS_LOG_ASSERT(arng && arng->sortKeys && array_len(arng->sortKeys) == 1,
-                "Flex mode expects exactly one SORTBY field");
-
-  // Get the metric requests from the AST (vector score fields)
-  MetricRequest *metricRequests = req->ast.metricRequests;
-  size_t numMetrics = array_len(metricRequests);
-
-  // In flex mode, KNN is allowed only once, so at most one vector score field
-  RS_LOG_ASSERT(numMetrics <= 1, "Flex mode expects at most one vector score field");
-
-  // If there's no vector score field, or the sort key doesn't match it, block
-  const char *sortKey = arng->sortKeys[0];
-  bool isVectorScoreField = (numMetrics == 1) &&
-                            metricRequests[0].metric_name &&
-                            (strcasecmp(sortKey, metricRequests[0].metric_name) == 0);
-
-  if (!isVectorScoreField) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_FLEX_UNSUPPORTED_ARGUMENT,
-      "SORTBY in Redis Flex is restricted to sorting results by vector distance in vector queries. "
-      "Otherwise, results are always sorted by the default document score.");
-    return REDISMODULE_ERR;
-  }
-
-  return REDISMODULE_OK;
-}
-
 // Assumes the spec is guarded by its own lock (for read), such that races with
 // main-thread/GC updates are avoided.
 int prepareExecutionPlan(AREQ *req, QueryError *status) {
@@ -1474,12 +1412,6 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   }
 
   if (QueryError_HasError(status)) {
-    return REDISMODULE_ERR;
-  }
-
-  // Validate SORTBY for disk indexes - must be after QAST_Iterate so that
-  // vector score field names are populated in metricRequests
-  if (validateSortbyForDiskIndex(req, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
@@ -1869,14 +1801,34 @@ static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
+// FT.SEARCH SORTBY on a schema field puts the async loader in the pipeline:
+// the arrange step loads any sort key that is missing from the lookup, and
+// flex has no SORTABLE fields to make one unnecessary. Vector-distance sort
+// keys are written into the lookup by the iterator instead, and metric names
+// colliding with schema fields are rejected, so a schema-field sort key is
+// exactly the case that loads.
+static bool searchSortbyNeedsLoader(AREQ *r, const IndexSpec *spec) {
+  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(r));
+  if (!arng) {
+    return false;
+  }
+  for (size_t i = 0; i < array_len(arng->sortKeys); i++) {
+    const char *key = arng->sortKeys[i];
+    if (IndexSpec_GetFieldWithLength(spec, key, strlen(key))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Reject disk (flex) requests whose pipeline would carry the async loader when
  * execution is about to happen inline on the main thread: the loader blocks on
  * prefetch completions delivered by the main thread, so inline execution would
  * deadlock. Aggregations nearly always load fields, so all of them are
  * rejected (a predictable error beats a plan-shape-dependent one); searches
- * load fields unless NOCONTENT / RETURN 0 was given, so those stay usable in
- * MULTI/Lua.
+ * load fields unless NOCONTENT / RETURN 0 was given without a schema-field
+ * SORTBY, so those stay usable in MULTI/Lua.
  *
  * Returns REDISMODULE_ERR with `status` set (thread-local spec cleared) when
  * the request must be rejected, REDISMODULE_OK otherwise.
@@ -1898,6 +1850,9 @@ static int rejectDiskLoaderInlineExecution(AREQ *r, const RedisSearchCtx *sctx,
     error = "FT.SEARCH with field return in a context that cannot block "
             "(MULTI/EXEC or Lua scripts) is not supported in Redis Flex; "
             "use NOCONTENT or RETURN 0";
+  } else if (IsSearch(r) && searchSortbyNeedsLoader(r, sctx->spec)) {
+    error = "FT.SEARCH with SORTBY on a schema field in a context that cannot "
+            "block (MULTI/EXEC or Lua scripts) is not supported in Redis Flex";
   }
   if (error) {
     QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_UNSUPPORTED_ARGUMENT, error);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1802,12 +1802,10 @@ static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv
 }
 
 // FT.SEARCH SORTBY on a schema field puts the async loader in the pipeline:
-// the arrange step loads any sort key that is missing from the lookup, and
-// flex has no SORTABLE fields to make one unnecessary. Vector-distance sort
-// keys are written into the lookup by the iterator instead, and metric names
-// colliding with schema fields are rejected, so a schema-field sort key is
-// exactly the case that loads. Count-only searches short-circuit the arrange
-// step with a counter before sort keys are examined, so they never load.
+// the arrange step loads any sort key missing from the lookup, and flex has
+// no SORTABLE fields to make one unnecessary. Vector-distance keys are
+// written into the lookup by the iterator, and count-only searches
+// short-circuit the arrange step with a counter — neither loads.
 static bool searchSortbyNeedsLoader(AREQ *r, const IndexSpec *spec) {
   if (IsCount(r)) {
     return false;
@@ -1847,8 +1845,8 @@ static int rejectDiskLoaderInlineExecution(AREQ *r, const RedisSearchCtx *sctx,
     error = "FT.AGGREGATE in a context that cannot block (MULTI/EXEC or Lua "
             "scripts) is not supported in Redis Flex";
   } else if (IsSearch(r) && searchSortbyNeedsLoader(r, sctx->spec)) {
-    // Before the field-return check: when both apply, NOCONTENT/RETURN 0 is
-    // not a sufficient workaround — the sort key still has to load.
+    // Precedes the field-return check: NOCONTENT/RETURN 0 is not a sufficient
+    // workaround when a sort key still has to load.
     error = "FT.SEARCH with SORTBY on a schema field in a context that cannot "
             "block (MULTI/EXEC or Lua scripts) is not supported in Redis Flex";
   } else if (IsSearch(r) &&

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -325,9 +325,7 @@ def test_flex_search_allows_nocontent_withscores(env):
 @with_simulate_in_flex(True)
 def test_flex_aggregate_allows_sortby(env):
     """FT.AGGREGATE SORTBY is unrestricted on flex, including multi-field
-    SORTBY: sort keys load via the disk async loader at the arrange step.
-    FT.SEARCH SORTBY shares that loading path, so it works on schema fields
-    too."""
+    SORTBY: sort keys load via the disk async loader at the arrange step."""
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
                't', 'TEXT', 'u', 'TEXT').ok()
     env.expect('HSET', 'doc:1', 't', 'hello world', 'u', 'aaa').equal(2)
@@ -335,9 +333,6 @@ def test_flex_aggregate_allows_sortby(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'SORTBY', '2', '@t', 'ASC').noError()
     env.expect('FT.AGGREGATE', 'idx', '*', 'SORTBY', '4', '@t', 'ASC', '@u', 'DESC') \
         .noError()
-
-    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'SORTBY', 't') \
-        .equal([1, 'doc:1'])
 
 
 @skip(cluster=True)
@@ -940,23 +935,6 @@ def test_flex_blocks_configured_default_dialect_4(env):
 
 @skip(cluster=True)
 @with_simulate_in_flex(True)
-def test_flex_allows_sortby_on_non_vector_fields(env):
-    """SORTBY on a non-vector schema field works in Redis Flex:
-    the arrange step loads the sort key via the disk async loader."""
-    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
-               'n', 'NUMERIC').ok()
-    env.expect('HSET', 'doc:1', 'n', '3').equal(1)
-    env.expect('HSET', 'doc:2', 'n', '1').equal(1)
-    env.expect('HSET', 'doc:3', 'n', '2').equal(1)
-
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'SORTBY', 'n', 'ASC') \
-        .equal([3, 'doc:2', 'doc:3', 'doc:1'])
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'SORTBY', 'n', 'DESC') \
-        .equal([3, 'doc:1', 'doc:3', 'doc:2'])
-
-
-@skip(cluster=True)
-@with_simulate_in_flex(True)
 def test_flex_allows_sortby_on_vector_distance_fields(env):
     """Test that SORTBY on vector distance fields (from KNN queries) is allowed in Redis Flex"""
     # Create index with both text and vector fields
@@ -994,13 +972,6 @@ def test_flex_allows_sortby_on_vector_distance_fields(env):
                   'PARAMS', '2', 'b', query_blob,
                   'DIALECT', '2')
     env.assertEqual(res[0], 3)
-
-    # SORTBY on a non-vector schema field is allowed too
-    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 3 @v $b]', 'NOCONTENT',
-                  'SORTBY', 't', 'ASC',
-                  'PARAMS', '2', 'b', query_blob,
-                  'DIALECT', '2')
-    env.assertEqual(res, [3, 'doc:2', 'doc:3', 'doc:1'])
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -324,10 +324,10 @@ def test_flex_search_allows_nocontent_withscores(env):
 @skip(cluster=True)
 @with_simulate_in_flex(True)
 def test_flex_aggregate_allows_sortby(env):
-    """FT.AGGREGATE SORTBY is unrestricted on flex (sort keys load via the disk
-    async loader); the vector-distance-only restriction is FT.SEARCH only.
-    Multi-field SORTBY exercises the guard's early-return ordering (the
-    FT.SEARCH single-field asserts must not fire for aggregations)."""
+    """FT.AGGREGATE SORTBY is unrestricted on flex, including multi-field
+    SORTBY: sort keys load via the disk async loader at the arrange step.
+    FT.SEARCH SORTBY shares that loading path, so it works on schema fields
+    too (MOD-17659)."""
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
                't', 'TEXT', 'u', 'TEXT').ok()
     env.expect('HSET', 'doc:1', 't', 'hello world', 'u', 'aaa').equal(2)
@@ -336,9 +336,8 @@ def test_flex_aggregate_allows_sortby(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'SORTBY', '4', '@t', 'ASC', '@u', 'DESC') \
         .noError()
 
-    # The FT.SEARCH restriction is unchanged.
     env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'SORTBY', 't') \
-        .error().contains('SORTBY in Redis Flex is restricted to sorting results by vector distance')
+        .equal([1, 'doc:1'])
 
 
 @skip(cluster=True)
@@ -941,12 +940,19 @@ def test_flex_blocks_configured_default_dialect_4(env):
 
 @skip(cluster=True)
 @with_simulate_in_flex(True)
-def test_flex_blocks_sortby_on_non_vector_fields(env):
-    """Test that SORTBY on non-vector-score fields is blocked in Redis Flex"""
-    _create_flex_search(env)
+def test_flex_allows_sortby_on_non_vector_fields(env):
+    """SORTBY on a non-vector schema field works in Redis Flex (MOD-17659):
+    the arrange step loads the sort key via the disk async loader."""
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+               'n', 'NUMERIC').ok()
+    env.expect('HSET', 'doc:1', 'n', '3').equal(1)
+    env.expect('HSET', 'doc:2', 'n', '1').equal(1)
+    env.expect('HSET', 'doc:3', 'n', '2').equal(1)
 
-    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'SORTBY', 't') \
-        .error().contains('SORTBY in Redis Flex is restricted to sorting results by vector distance')
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'SORTBY', 'n', 'ASC') \
+        .equal([3, 'doc:2', 'doc:3', 'doc:1'])
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'SORTBY', 'n', 'DESC') \
+        .equal([3, 'doc:1', 'doc:3', 'doc:2'])
 
 
 @skip(cluster=True)
@@ -989,12 +995,12 @@ def test_flex_allows_sortby_on_vector_distance_fields(env):
                   'DIALECT', '2')
     env.assertEqual(res[0], 3)
 
-    # SORTBY on non-vector field should still be blocked
-    env.expect('FT.SEARCH', 'idx', '*=>[KNN 3 @v $b]', 'NOCONTENT',
-               'SORTBY', 't', 'ASC',
-               'PARAMS', '2', 'b', query_blob,
-               'DIALECT', '2') \
-        .error().contains('SORTBY in Redis Flex is restricted to sorting results by vector distance')
+    # SORTBY on a non-vector schema field is allowed too (MOD-17659)
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 3 @v $b]', 'NOCONTENT',
+                  'SORTBY', 't', 'ASC',
+                  'PARAMS', '2', 'b', query_blob,
+                  'DIALECT', '2')
+    env.assertEqual(res, [3, 'doc:2', 'doc:3', 'doc:1'])
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -327,7 +327,7 @@ def test_flex_aggregate_allows_sortby(env):
     """FT.AGGREGATE SORTBY is unrestricted on flex, including multi-field
     SORTBY: sort keys load via the disk async loader at the arrange step.
     FT.SEARCH SORTBY shares that loading path, so it works on schema fields
-    too (MOD-17659)."""
+    too."""
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
                't', 'TEXT', 'u', 'TEXT').ok()
     env.expect('HSET', 'doc:1', 't', 'hello world', 'u', 'aaa').equal(2)
@@ -941,7 +941,7 @@ def test_flex_blocks_configured_default_dialect_4(env):
 @skip(cluster=True)
 @with_simulate_in_flex(True)
 def test_flex_allows_sortby_on_non_vector_fields(env):
-    """SORTBY on a non-vector schema field works in Redis Flex (MOD-17659):
+    """SORTBY on a non-vector schema field works in Redis Flex:
     the arrange step loads the sort key via the disk async loader."""
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
                'n', 'NUMERIC').ok()
@@ -995,7 +995,7 @@ def test_flex_allows_sortby_on_vector_distance_fields(env):
                   'DIALECT', '2')
     env.assertEqual(res[0], 3)
 
-    # SORTBY on a non-vector schema field is allowed too (MOD-17659)
+    # SORTBY on a non-vector schema field is allowed too
     res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 3 @v $b]', 'NOCONTENT',
                   'SORTBY', 't', 'ASC',
                   'PARAMS', '2', 'b', query_blob,


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: on Flex (disk) indexes, `FT.SEARCH ... SORTBY <field>` is rejected with `SEARCH_FLEX_UNSUPPORTED_ARGUMENT` for everything except vector-distance keys, while `FT.AGGREGATE ... SORTBY` works — the restriction lives only in the FT.SEARCH code path ([MOD-17659](https://redislabs.atlassian.net/browse/MOD-17659)).
2. Change: the FT.SEARCH-only validation is removed, so SORTBY on disk behaves like RAM — schema fields are implicitly loaded through the disk async loader at the arrange step (the same mechanism FT.AGGREGATE already uses), and non-schema fields fail with ``Property `<field>` not loaded nor in schema``. FT.SEARCH with a schema-field SORTBY is now also rejected in contexts that cannot block (MULTI/EXEC, Lua), where the async loader would deadlock inline execution.
3. Outcome: `FT.SEARCH ... SORTBY` works on Flex indexes for any schema field (NUMERIC, TAG, ...), in both directions, with WITHSORTKEYS/LIMIT/NOCONTENT reply shapes as on RAM. Vector-distance KNN sorting is unchanged.

#### Which additional issues this PR fixes

1. MOD-17659

#### Main objects this PR modified

1. `FT.SEARCH` execution planning (`aggregate_exec.c`) — dropped the disk SORTBY gate; extended the inline-execution guard to schema-field sort keys.
2. Flex validation pytests (`test_flex_validation.py`) — deleted the obsolete SORTBY block assertions (they pinned the removed rejection); "works on disk" coverage lives in RediSearchEnterprise flow tests against a real Flex runtime, since simulate mode has no real disk backend.
3. Disk-MVP feature-blocking design doc — SORTBY rows updated to "allowed via the disk async loader".

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

API-change note: a class of previously rejected queries (`FT.SEARCH ... SORTBY` on Flex indexes) now succeeds — nothing that worked before changes shape or semantics, so there is no breakage and no migration; one new error case exists (schema-field SORTBY inside MULTI/EXEC or Lua on Flex, rejected to avoid a deadlock).

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

## Test plan

- [x] `tests/pytests/test_flex_validation.py`: 52/52 pass against a clean OSS redis (obsolete block assertions removed; no converted works-assertions — see above)
- [x] RediSearchEnterprise disk flow tests covering NUMERIC/TAG ordering over cold (disk-only) keys, selective-filter SORTBY, NOCONTENT/WITHSORTKEYS/LIMIT shapes, the RAM-parity error, and the MULTI/EXEC rejection pass with this commit pinned: [RediSearchEnterprise#874](https://github.com/redislabsdev/RediSearchEnterprise/pull/874) (4/4 new tests; regressions: disk-aggregate 23/23, disk-async-loader 18/18, vecsim-disk 85/85)
- [ ] RS CI green

[MOD-17659]: https://redislabs.atlassian.net/browse/MOD-17659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ