### PR TITLE
[MOD-18025] Unflake the block-buffer-moved tests

### DIFF
--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -91,6 +91,9 @@ impl<'a> PartialEq for TermRecordCompare<'a> {
 /// two cannot share an address whatever the allocator does. The original is then freed, which is
 /// what makes a reader's cached pointer genuinely dangle.
 ///
+/// The guarantee is only against the address being replaced here, not against any address a
+/// caller sampled earlier: an address freed before this call can be handed back by the allocator.
+///
 /// Returns the buffer's new base address.
 ///
 /// # Panics
@@ -104,6 +107,7 @@ pub fn relocate_block_buffer<E: crate::Encoder + crate::DecodedBy>(
 
     // Hold the original allocation while the replacement is allocated, so they cannot overlap.
     let original = std::mem::take(&mut block.buffer);
+    let original_base = original.as_ptr();
     let mut relocated = Vec::with_capacity(original.len().max(1));
     relocated.extend_from_slice(&original);
 
@@ -111,7 +115,11 @@ pub fn relocate_block_buffer<E: crate::Encoder + crate::DecodedBy>(
     block.buffer = relocated;
     drop(original);
 
-    assert_ne!(base, std::ptr::null(), "relocated buffer must be allocated");
+    // Guaranteed by construction: `original` was still alive when `relocated` was allocated.
+    assert_ne!(
+        base, original_base,
+        "must not reuse the address it just replaced"
+    );
     base
 }
 

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -865,18 +865,10 @@ fn test_needs_revalidation_after_block_buffer_moved() {
         "an untouched index must not ask for revalidation"
     );
 
-    // Append a document the reader has not reached, then move the buffer. Appending alone would
-    // leave it to the allocator whether the address changes at all — see
-    // [`relocate_block_buffer`](crate::test_utils::relocate_block_buffer).
-    let base_before = ii.block_ref(0).unwrap().data().as_ptr();
     // SAFETY: see the `ii_ptr` construction above.
-    let base_after = unsafe {
-        (*ii_ptr)
-            .add_record(&RSIndexResult::build_virt().doc_id(12).build())
-            .unwrap();
-        crate::test_utils::relocate_block_buffer(&mut *ii_ptr, 0)
-    };
-    assert_ne!(base_before, base_after, "the buffer did not move");
+    unsafe {
+        crate::test_utils::relocate_block_buffer(&mut *ii_ptr, 0);
+    }
 
     assert_eq!(
         ii.gc_marker(),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -14,7 +14,7 @@ use ffi::{
 };
 use field::FieldMaskOrIndex;
 use index_result::{RSIndexResult, RSOffsetSlice};
-use inverted_index::{FilterMaskReader, full::Full};
+use inverted_index::{FilterMaskReader, full::Full, opaque::OpaqueEncoding};
 use query_term::RSQueryTerm;
 use rqe_core::{DocId, FieldMask};
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Term};
@@ -356,10 +356,7 @@ mod not_miri {
     fn term_revalidate_at_eof_after_gc() {
         let test = TermRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
-        let ii = {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
-            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-        };
+        let ii = { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
         test.test.revalidate_at_eof_after_gc(&mut it, ii);
     }
@@ -452,18 +449,16 @@ mod not_miri {
     #[test]
     fn term_revalidate_after_block_buffer_moved() {
         let test = TermRevalidateTest::new(10);
-        // Before the iterator exists, so the address it caches is the one the appends and the
-        // relocation act on. Reserving afterwards would reallocate out from under it.
+        // `reserve_block_buffer` reallocates, so it has to run before the iterator caches an
+        // address. Reserving afterwards could free that address, and the relocation below could
+        // then land back on it, leaving the test passing via the length check instead of the
+        // moved-address one.
         {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
             let ii = Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut();
             inverted_index::test_utils::reserve_block_buffer(ii, 0, 4096);
         }
         let mut it = ContractChecker::new(test.create_iterator());
-        let ii = {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
-            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-        };
+        let ii = { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
         test.test
             .revalidate_after_block_buffer_moved(&mut it, ii, appended_record);
@@ -476,18 +471,16 @@ mod not_miri {
     #[test]
     fn term_revalidate_after_block_buffer_moved_and_gc() {
         let test = TermRevalidateTest::new(10);
-        // Before the iterator exists, so the address it caches is the one the appends and the
-        // relocation act on. Reserving afterwards would reallocate out from under it.
+        // `reserve_block_buffer` reallocates, so it has to run before the iterator caches an
+        // address. Reserving afterwards could free that address, and the relocation below could
+        // then land back on it, leaving the test passing via the length check instead of the
+        // moved-address one.
         {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
             let ii = Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut();
             inverted_index::test_utils::reserve_block_buffer(ii, 0, 4096);
         }
         let mut it = test.create_iterator();
-        let ii = {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
-            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-        };
+        let ii = { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
         test.test
             .revalidate_after_block_buffer_moved_and_gc(&mut it, ii, appended_record);
@@ -507,10 +500,7 @@ mod not_miri {
     fn term_revalidate_after_document_deleted() {
         let test = TermRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
-        let ii = {
-            use inverted_index::{full::Full, opaque::OpaqueEncoding};
-            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-        };
+        let ii = { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
         test.test.revalidate_after_document_deleted(&mut it, ii);
     }
@@ -542,10 +532,8 @@ mod not_miri {
         fn term_revalidate_at_eof_after_gc() {
             let test = TermRevalidateTest::new(10);
             let it = test.create_iterator();
-            let ii = {
-                use inverted_index::{full::Full, opaque::OpaqueEncoding};
-                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-            };
+            let ii =
+                { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
             revalidate_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
@@ -634,10 +622,8 @@ mod not_miri {
         fn term_revalidate_after_document_deleted() {
             let test = TermRevalidateTest::new(10);
             let it = test.create_iterator();
-            let ii = {
-                use inverted_index::{full::Full, opaque::OpaqueEncoding};
-                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-            };
+            let ii =
+                { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
             revalidate_after_document_deleted(&test.test, Box::new(it), ii);
         }
@@ -655,10 +641,8 @@ mod not_miri {
         fn term_resume_before_first_read_keeps_first_doc() {
             let test = TermRevalidateTest::new(10);
             let it = Box::new(test.create_iterator());
-            let ii = {
-                use inverted_index::{full::Full, opaque::OpaqueEncoding};
-                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
-            };
+            let ii =
+                { Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut() };
 
             // Bump the GC marker *without reading the iterator first* by deleting
             // a document that sits after the first one. This forces resume down

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -452,6 +452,13 @@ mod not_miri {
     #[test]
     fn term_revalidate_after_block_buffer_moved() {
         let test = TermRevalidateTest::new(10);
+        // Before the iterator exists, so the address it caches is the one the appends and the
+        // relocation act on. Reserving afterwards would reallocate out from under it.
+        {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            let ii = Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut();
+            inverted_index::test_utils::reserve_block_buffer(ii, 0, 4096);
+        }
         let mut it = ContractChecker::new(test.create_iterator());
         let ii = {
             use inverted_index::{full::Full, opaque::OpaqueEncoding};
@@ -469,6 +476,13 @@ mod not_miri {
     #[test]
     fn term_revalidate_after_block_buffer_moved_and_gc() {
         let test = TermRevalidateTest::new(10);
+        // Before the iterator exists, so the address it caches is the one the appends and the
+        // relocation act on. Reserving afterwards would reallocate out from under it.
+        {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            let ii = Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut();
+            inverted_index::test_utils::reserve_block_buffer(ii, 0, 4096);
+        }
         let mut it = test.create_iterator();
         let ii = {
             use inverted_index::{full::Full, opaque::OpaqueEncoding};

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -616,9 +616,8 @@ impl RevalidateTest {
             assert_eq!(doc.doc_id, *expected);
         }
 
-        // Append documents the iterator has not reached, then move the buffer they live in.
-        // Appending alone would leave it to the allocator whether the address changes at all — see
-        // `inverted_index::test_utils::relocate_block_buffer`.
+        // The address the iterator cached. Callers reserve headroom before creating it, so nothing
+        // moves the buffer until the relocation below does.
         let base_before = ii.block_ref(0).unwrap().data().as_ptr();
         let appended: Vec<DocId> = (1..=3)
             .map(|i| self.doc_ids.last().unwrap() + 2 * i)
@@ -630,6 +629,12 @@ impl RevalidateTest {
             ii.number_of_blocks(),
             1,
             "the appends must stay in the block the iterator is parked in"
+        );
+
+        assert_eq!(
+            ii.block_ref(0).unwrap().data().as_ptr(),
+            base_before,
+            "the appends moved the buffer; reserve headroom before creating the iterator"
         );
 
         let base_after = inverted_index::test_utils::relocate_block_buffer(ii, 0);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: three `inverted_index`/`rqe_iterators` tests intermittently fail on macOS-aarch64 CI. Each samples a block buffer's address, appends, moves the buffer via `relocate_block_buffer`, and asserts the new address differs from the sampled one. On macOS libmalloc (not glibc/jemalloc on Linux), an intervening append can free the sampled address, and the allocator can legitimately hand that exact address back for the relocation, making the pre-append sample stale and the assertion fail with nothing wrong in the reader.
2. Change: test-only. `relocate_block_buffer` now asserts its own guarantee (new address differs from the address it *replaces*, since both allocations are alive simultaneously during the copy) instead of callers re-deriving a weaker, allocator-dependent version of it from an earlier sample. The `gc.rs` test drops its incidental append/comparison entirely; the `rqe_iterators` integration helper reserves buffer capacity before sampling so its load-bearing appends grow in place deterministically.
3. Outcome: the three tests no longer depend on allocator behavior and stop flaking on macOS CI. No product code changed — `needs_revalidation` and friends are untouched.

#### Which additional issues this PR fixes

1. MOD-18025

#### Main objects this PR modified

1. `inverted_index::test_utils::relocate_block_buffer` — added a self-check asserting its actual, previously-implicit guarantee (new address != the address it replaced), and a doc-comment clarification of that guarantee's scope.
2. `inverted_index::tests::gc::test_needs_revalidation_after_block_buffer_moved` — removed an incidental append and address comparison; the buffer-moved assertion is now covered by `relocate_block_buffer`'s own self-check.
3. `rqe_iterators` integration test helper `RevalidateTest` (`inverted_index/utils.rs`) — samples the base address after reserving headroom, so its appends deterministically grow the buffer in place before the subsequent relocation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Verification

- `./build.sh DEBUG=1` — success.
- `cargo nextest run` (inverted_index + rqe_iterators, 1182 tests) — all pass.
- `cargo fmt --check --all` and `cargo clippy --no-deps -p inverted_index -p rqe_iterators -- -D warnings` — clean.
- Negative check: temporarily reverted `needs_revalidation` to the pre-fix `gc_marker`-only comparison. Result: `test_needs_revalidation_after_block_buffer_moved`, `reader_needs_revalidation_when_block_buffer_grew_in_place`, and `term_revalidate_after_block_buffer_moved` FAILED as expected, while `term_revalidate_after_block_buffer_moved_and_gc` still PASSED — confirming the GC-marker path already covered that case and these tests still catch the original bug. Reverted `needs_revalidation` back afterward; `git status` is clean except for the three intended files.