### PR TITLE
benchmarks: load numeric/geo fixtures with a single deterministic writer

### DIFF
--- a/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
@@ -17,13 +17,18 @@ dbconfig:
   - dataset_name: "1M-cardinality_numeric_and_tags_25x"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - requests: 1000000
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-cardinality_numeric_and_tags_25x/1M-cardinality_numeric_and_tags_25x.redisearch.commands.SETUP.csv"
   - init_commands:
       - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-filtering-tag-numeric.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric.yml
@@ -17,13 +17,18 @@ dbconfig:
   - dataset_name: "1M-cardinality_numeric_and_tags_25x"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - requests: 1000000
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-cardinality_numeric_and_tags_25x/1M-cardinality_numeric_and_tags_25x.redisearch.commands.SETUP.csv"
   - init_commands:
       - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-geo.yml
+++ b/tests/benchmarks/search-geo.yml
@@ -18,12 +18,17 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"
   - init_commands:
       - '"FT.CREATE" "nyc" "SCHEMA" "pickup_location_long_lat" "GEO" "dropoff_location_long_lat" "GEO"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-numeric-optimize.yml
+++ b/tests/benchmarks/search-numeric-optimize.yml
@@ -9,12 +9,17 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"
   - init_commands:
       - '"FT.CREATE" "nyc" "SCHEMA" "total_amount" "NUMERIC" "SORTABLE" "improvement_surcharge" "NUMERIC" "SORTABLE" "fare_amount" "NUMERIC" "SORTABLE" "trip_distance" "NUMERIC" "SORTABLE"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
@@ -9,12 +9,17 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"
   - init_commands:
       - '"FT.CREATE" "nyc" "SCHEMA" "total_amount" "NUMERIC" "SORTABLE" "improvement_surcharge" "NUMERIC" "SORTABLE" "fare_amount" "NUMERIC" "SORTABLE" "trip_distance" "NUMERIC" "SORTABLE"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-numeric-sortby-desc.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc.yml
@@ -16,7 +16,12 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - requests: 100000
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"

--- a/tests/benchmarks/search-numeric-sortby-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-optimized.yml
@@ -12,12 +12,17 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"
   - init_commands:
       - '"FT.CREATE" "nyc" "SCHEMA" "total_amount" "NUMERIC" "SORTABLE" "improvement_surcharge" "NUMERIC" "SORTABLE" "fare_amount" "NUMERIC" "SORTABLE" "trip_distance" "NUMERIC" "SORTABLE"'
-  - dataset_load_timeout_secs: 180
+  - dataset_load_timeout_secs: 900
   - check:
       keyspacelen: 1000000
 

--- a/tests/benchmarks/search-numeric-sortby.yml
+++ b/tests/benchmarks/search-numeric-sortby.yml
@@ -16,7 +16,12 @@ setups:
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    # Deterministic single-connection load: with concurrent loaders the numeric
+    # range tree splits leaves at the median of a racy sample, so every load lands
+    # different leaf boundaries and the query decodes a different record count.
+    # `pipeline` keeps the load fast without reordering (one connection, in order).
+    - workers: 1
+    - pipeline: 100
     - reporting-period: 1s
     - requests: 100000
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-nyc_taxis-hashes/1M-nyc_taxis-hashes.redisearch.commands.ALL.csv"


### PR DESCRIPTION
These read-only fixtures build their index during the load phase, so the measured window inherits whatever the load produced. The numeric range tree splits a leaf at the median of the entries that leaf holds when it crosses its cardinality threshold — 16 distinct values at depth 0, growing x4 per level — so the coarsest boundaries of the value domain are decided by the first few dozen documents to arrive. With `workers: 64` that arrival order is a fresh race on every load, and `find()` returns straddling leaves whole with a per-record filter, so a query whose window is narrower than one leaf pays for whichever leaf happens to contain it.

Simulating the real split rule over shuffled insertion orders of a fixed value multiset, `@trip_distance:[6,8]` decodes 1.78x more records in the worst order than the best (CV 22%), and flips between a bare reader and a 2-child union depending on how many leaves it lands in. A dense window in the same index varies by 3.6%, so this is specific to narrow tail windows.

Dropping to a single loader connection makes the tree reproducible across runs. `pipeline: 100` keeps the load fast: one connection stays strictly in file order whatever the pipeline depth, so determinism is unaffected. For the two `requests: 100000` specs it also pins *which* 100K of the 1M-row input get loaded, which 64 racing workers leave unspecified.

The 1M-document loads get `dataset_load_timeout_secs` 180 -> 900 as headroom, since single-connection load throughput on the benchmark hosts is unmeasured.

`search-geo` is included because GEO fields share the numeric range tree, and the geo reader never clears its per-record filter, so it is at least as exposed to leaf-boundary drift.

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
