### PR TITLE
[MOD-18065] Link "valid" to the pointer-validity rules in the FFI safety docs

### DIFF
--- a/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
@@ -17,10 +17,11 @@ use std::hash::Hasher;
 ///
 /// # Safety
 ///
-/// 1. `buf` must point to a valid region of memory of length `len`.
+/// 1. `buf` must point to a [valid] region of memory of length `len`.
 ///
 /// [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
 /// [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rs_fnv_32a_buf(buf: *const c_void, len: usize, hval: u32) -> u32 {
     // Safety: see safety point 1 above.
@@ -36,10 +37,11 @@ pub unsafe extern "C" fn rs_fnv_32a_buf(buf: *const c_void, len: usize, hval: u3
 ///
 /// # Safety
 ///
-/// 1. `buf` must point to a valid region of memory of length `len`.
+/// 1. `buf` must point to a [valid] region of memory of length `len`.
 ///
 /// [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
 /// [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fnv_64a_buf(buf: *const c_void, len: usize, hval: u64) -> u64 {
     // Safety: see safety point 1 above.

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -28,11 +28,13 @@ use crate::{FGCError, util::into_fgc_error};
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
-/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
 /// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     gc: *mut ffi::ForkGC,
@@ -62,8 +64,10 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -61,10 +61,12 @@ pub enum FGCError {
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
 ///    writable file descriptor.
 /// 2. `buff` must point to a readable region of at least `len` bytes.
 /// 3. `len` must be greater than zero.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_void, len: usize) {
     debug_assert!(len > 0, "buffer length cannot be 0");
@@ -85,11 +87,13 @@ pub unsafe extern "C" fn FGC_sendFixed(fgc: *mut ffi::ForkGC, buff: *const c_voi
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
 ///    writable file descriptor.
 /// 2. If `len > 0`, `buff` must point to a readable region of at least
 ///    `len` bytes. When `len == 0`, `buff` is unused and may be anything
 ///    (including NULL).
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_void, len: usize) {
     // SAFETY: caller guarantees (1).
@@ -115,8 +119,10 @@ pub unsafe extern "C" fn FGC_sendBuffer(fgc: *mut ffi::ForkGC, buff: *const c_vo
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
 ///    writable file descriptor.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_sendTerminator(fgc: *mut ffi::ForkGC) {
     // SAFETY: caller guarantees (1).
@@ -133,9 +139,11 @@ pub unsafe extern "C" fn FGC_sendTerminator(fgc: *mut ffi::ForkGC) {
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an open,
 ///    readable file descriptor.
 /// 2. `buf` must point to a writable region of at least `len` bytes.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_recvFixed(
     fgc: *mut ffi::ForkGC,
@@ -171,10 +179,12 @@ pub unsafe extern "C" fn FGC_recvFixed(
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an
 ///    open, readable file descriptor.
 /// 2. `buf` and `len` must point to writable `void*` and `size_t`
 ///    locations respectively.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn FGC_recvBuffer(
@@ -212,11 +222,13 @@ pub unsafe extern "C" fn FGC_recvBuffer(
 ///
 /// # Safety
 ///
-/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+/// 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an open,
 ///    readable file descriptor.
 /// 2. `field_name` and `field_name_len` must point to writable `char*` and
 ///    `size_t` locations respectively.
 /// 3. `id_ptr` must point to a writable `uint64_t` location.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn recvFieldHeader(

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -29,11 +29,13 @@ use crate::{FGCError, util::into_fgc_error};
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
-/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
 /// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectMissingDocs(
     gc: *mut ffi::ForkGC,
@@ -65,8 +67,10 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
@@ -29,11 +29,13 @@ use crate::{FGCError, util::into_fgc_error};
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
-/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
 /// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectNumeric(
     gc: *mut ffi::ForkGC,
@@ -65,8 +67,10 @@ pub unsafe extern "C" fn FGC_childCollectNumeric(
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleNumeric(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/terms.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/terms.rs
@@ -30,11 +30,13 @@ use crate::{FGCError, util::into_fgc_error};
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
-/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
 /// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectTerms(
     gc: *mut ffi::ForkGC,
@@ -66,8 +68,10 @@ pub unsafe extern "C" fn FGC_childCollectTerms(
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+/// 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
 ///    alive for the duration of this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleTerms(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/geo_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/geo_ffi/src/lib.rs
@@ -66,7 +66,9 @@ const INVALID_GEOHASH: f64 = -1.0;
 ///
 /// # Safety
 ///
-/// - `xy` must be a valid, non-null pointer to a writable `[f64; 2]`.
+/// - `xy` must be a [valid], non-null pointer to a writable `[f64; 2]`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn decodeGeo(bits: f64, xy: *mut f64) {
     let raw_bits = bits as u64;
@@ -118,7 +120,9 @@ pub extern "C" fn geohashGetDistance(lon1: f64, lat1: f64, lon2: f64, lat2: f64)
 ///
 /// # Safety
 ///
-/// - `distance` must be either null or a valid pointer to a writable `f64`.
+/// - `distance` must be either null or a [valid] pointer to a writable `f64`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn isWithinRadiusLonLat(
     lon1: f64,
@@ -148,8 +152,10 @@ pub unsafe extern "C" fn isWithinRadiusLonLat(
 ///
 /// # Safety
 ///
-/// - `status` must be a valid pointer to an [`OpaqueQueryError`] created by
+/// - `status` must be a [valid] pointer to an [`OpaqueQueryError`] created by
 ///   `QueryError_Default`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn set_parse_error(status: *mut OpaqueQueryError, err: ParseGeoError) {
     log_error!(err, level: tracing::Level::WARN, "parseGeo: failed to parse geo string");
     // SAFETY: caller guarantees `status` is valid.
@@ -166,10 +172,12 @@ unsafe fn set_parse_error(status: *mut OpaqueQueryError, err: ParseGeoError) {
 ///
 /// # Safety
 ///
-/// - `c` must be a valid pointer to at least `len` bytes.
-/// - `lon` and `lat` must be valid, non-null pointers to writable `f64` values.
-/// - `status` must be a valid, non-null pointer to an [`OpaqueQueryError`]
+/// - `c` must be a [valid] pointer to at least `len` bytes.
+/// - `lon` and `lat` must be [valid], non-null pointers to writable `f64` values.
+/// - `status` must be a [valid], non-null pointer to an [`OpaqueQueryError`]
 ///   created by `QueryError_Default`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn parseGeo(
     c: *const u8,

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -91,7 +91,7 @@ const NUMERIC_MASK: IndexFlags = IndexFlags_Index_StoreNumeric;
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `mem_size` must be a valid pointer to a `usize`.
+/// - `mem_size` must be a [valid] pointer to a `usize`.
 ///
 /// # Panics
 /// This function will panic if the provided flags does not set at least one of the following
@@ -101,6 +101,8 @@ const NUMERIC_MASK: IndexFlags = IndexFlags_Index_StoreNumeric;
 /// - `StoreTermOffsets`
 /// - `StoreNumeric`
 /// - `DocIdsOnly`
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub extern "C" fn NewInvertedIndex_Ex(
     flags: IndexFlags,
@@ -173,8 +175,10 @@ pub extern "C" fn NewInvertedIndex_Ex(
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance created using
+/// - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance created using
 ///   [`NewInvertedIndex_Ex`] or `NewInvertedIndex`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_Free(ii: *mut InvertedIndex) {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -187,7 +191,9 @@ pub unsafe extern "C" fn InvertedIndex_Free(ii: *mut InvertedIndex) {
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and must not be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and must not be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -202,7 +208,9 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
 /// growth and the number of new index blocks created.
 ///
 /// # Safety
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii: *mut InvertedIndex,
@@ -222,8 +230,10 @@ pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
 /// memory growth and the number of new index blocks created.
 ///
 /// # Safety
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
-/// - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `record` must be a [valid] pointer to an `RSIndexResult` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     ii: *mut InvertedIndex,
@@ -245,7 +255,9 @@ pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_NumBlocks(ii: *const InvertedIndex) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -259,7 +271,9 @@ pub unsafe extern "C" fn InvertedIndex_NumBlocks(ii: *const InvertedIndex) -> us
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_Flags(ii: *const InvertedIndex) -> IndexFlags {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -273,7 +287,9 @@ pub unsafe extern "C" fn InvertedIndex_Flags(ii: *const InvertedIndex) -> IndexF
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_NumDocs(ii: *const InvertedIndex) -> u32 {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -287,7 +303,9 @@ pub unsafe extern "C" fn InvertedIndex_NumDocs(ii: *const InvertedIndex) -> u32 
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_Summary(ii: *const InvertedIndex) -> Summary {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -303,8 +321,10 @@ pub unsafe extern "C" fn InvertedIndex_Summary(ii: *const InvertedIndex) -> Summ
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
-/// - `count` must be a valid pointer to a `usize` and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `count` must be a [valid] pointer to a `usize` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_BlocksSummary(
     ii: *const InvertedIndex,
@@ -330,10 +350,12 @@ pub unsafe extern "C" fn InvertedIndex_BlocksSummary(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `blocks` must be a valid pointer to an array of `BlockSummary` instances returned by
+/// - `blocks` must be a [valid] pointer to an array of `BlockSummary` instances returned by
 ///   [`InvertedIndex_BlocksSummary`].
 /// - `count` must have the same value as the `count` output parameter passed to
 ///   [`InvertedIndex_BlocksSummary`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_BlocksSummaryFree(blocks: *mut BlockSummary, count: usize) {
     debug_assert!(!blocks.is_null(), "blocks must not be null");
@@ -351,7 +373,9 @@ pub unsafe extern "C" fn InvertedIndex_BlocksSummaryFree(blocks: *mut BlockSumma
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_FieldMask(ii: *const InvertedIndex) -> FieldMask {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -383,7 +407,9 @@ pub unsafe extern "C" fn InvertedIndex_FieldMask(ii: *const InvertedIndex) -> Fi
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_NumEntries(ii: *const InvertedIndex) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -415,7 +441,9 @@ pub unsafe extern "C" fn InvertedIndex_NumEntries(ii: *const InvertedIndex) -> u
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_BlockRef<'index>(
     ii: *const InvertedIndex,
@@ -433,7 +461,9 @@ pub unsafe extern "C" fn InvertedIndex_BlockRef<'index>(
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> DocId {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -448,7 +478,9 @@ pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> DocId
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+/// - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_GcMarker(ii: *const InvertedIndex) -> u32 {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -464,7 +496,9 @@ pub unsafe extern "C" fn InvertedIndex_GcMarker(ii: *const InvertedIndex) -> u32
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+/// - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_GcMarkerInc(ii: *mut InvertedIndex) {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -481,12 +515,14 @@ pub unsafe extern "C" fn InvertedIndex_GcMarkerInc(ii: *mut InvertedIndex) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `wr` must be a valid, non NULL, pointer to an `InvertedIndexGCWriter` instance.
-/// - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
-/// - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
-/// - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
-/// - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
+/// - `wr` must be a [valid], non NULL, pointer to an `InvertedIndexGCWriter` instance.
+/// - `sctx` must be a [valid], non NULL, pointer to a `RedisSearchCtx` instance.
+/// - `idx` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+/// - `cb` must be a [valid], non NULL, pointer to an `InvertedIndexGCCallback` instance.
+/// - The `spec` field of the `RedisSearchCtx` must be a [valid], non NULL, pointer to an
 ///   `IndexSpec` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
     wr: *mut InvertedIndexGCWriter,
@@ -542,7 +578,9 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `rd` must be a valid, non NULL, pointer to an `InvertedIndexGCReader` instance.
+/// - `rd` must be a [valid], non NULL, pointer to an `InvertedIndexGCReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_GcDelta_Read(
     rd: *mut InvertedIndexGCReader,
@@ -566,8 +604,10 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Read(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `deltas` must be a valid pointer to a `GcScanDelta` instance created using
+/// - `deltas` must be a [valid] pointer to a `GcScanDelta` instance created using
 ///   [`InvertedIndex_GcDelta_Read`], or NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
     if !deltas.is_null() {
@@ -587,10 +627,12 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
-/// - `deltas` must be a valid, non NULL, pointer to a `GcScanDelta` instance created using
+/// - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+/// - `deltas` must be a [valid], non NULL, pointer to a `GcScanDelta` instance created using
 ///   [`InvertedIndex_GcDelta_Read`].
-/// - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
+/// - `apply_info` must be a [valid], non NULL, pointer to a `GcApplyInfo` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_ApplyGCDelta(
     ii: *mut InvertedIndex,
@@ -619,7 +661,9 @@ pub unsafe extern "C" fn InvertedIndex_ApplyGCDelta(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `gc_scan_delta` must be a valid, non NULL, pointer to a `GcScanDelta` instance.
+/// - `gc_scan_delta` must be a [valid], non NULL, pointer to a `GcScanDelta` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn GcScanDelta_LastBlockIdx(gc_scan_delta: *const GcScanDelta) -> usize {
     debug_assert!(!gc_scan_delta.is_null(), "gc_scan_delta must not be null");
@@ -635,7 +679,9 @@ pub unsafe extern "C" fn GcScanDelta_LastBlockIdx(gc_scan_delta: *const GcScanDe
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+/// - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexBlock_FirstId(ib: *const IndexBlock) -> DocId {
     debug_assert!(!ib.is_null(), "ib must not be null");
@@ -651,7 +697,9 @@ pub unsafe extern "C" fn IndexBlock_FirstId(ib: *const IndexBlock) -> DocId {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+/// - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexBlock_LastId(ib: *const IndexBlock) -> DocId {
     debug_assert!(!ib.is_null(), "ib must not be null");
@@ -667,7 +715,9 @@ pub unsafe extern "C" fn IndexBlock_LastId(ib: *const IndexBlock) -> DocId {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+/// - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexBlock_NumEntries(ib: *const IndexBlock) -> u16 {
     debug_assert!(!ib.is_null(), "ib must not be null");
@@ -683,7 +733,9 @@ pub unsafe extern "C" fn IndexBlock_NumEntries(ib: *const IndexBlock) -> u16 {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+/// - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexBlock_Data(ib: *const IndexBlock) -> *const c_char {
     debug_assert!(!ib.is_null(), "ib must not be null");
@@ -835,10 +887,12 @@ impl<'index> IndexReader<'index> {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+/// - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
 ///
 /// # Panics
 /// This function will panic if the provided filter is not compatible with the `InvertedIndex` type.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewIndexReader(
     ii: *const InvertedIndex,
@@ -919,8 +973,10 @@ pub unsafe extern "C" fn NewIndexReader(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance created using
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance created using
 ///   [`NewIndexReader`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Free(ir: *mut IndexReader) {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -934,7 +990,9 @@ pub unsafe extern "C" fn IndexReader_Free(ir: *mut IndexReader) {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Reset(ir: *mut IndexReader) {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -950,7 +1008,9 @@ pub unsafe extern "C" fn IndexReader_Reset(ir: *mut IndexReader) {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_NumEstimated(ir: *const IndexReader) -> u64 {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -966,8 +1026,10 @@ pub unsafe extern "C" fn IndexReader_NumEstimated(ir: *const IndexReader) -> u64
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
-/// - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+/// - `ii` must be either NULL or a [valid] pointer to an `InvertedIndex` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_IsIndex(
     ir: *const IndexReader,
@@ -1034,8 +1096,10 @@ pub unsafe extern "C" fn IndexReader_IsIndex(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
-/// - `res` must be a valid pointer to an `RSIndexResult` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+/// - `res` must be a [valid] pointer to an `RSIndexResult` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Next<'index>(
     ir: *mut IndexReader<'index>,
@@ -1061,7 +1125,9 @@ pub unsafe extern "C" fn IndexReader_Next<'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: DocId) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -1080,8 +1146,10 @@ pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: DocId)
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
-/// - `res` must be a valid pointer to an `RSIndexResult` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+/// - `res` must be a [valid] pointer to an `RSIndexResult` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Seek<'index>(
     ir: *mut IndexReader<'index>,
@@ -1105,7 +1173,9 @@ pub unsafe extern "C" fn IndexReader_Seek<'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_HasMulti(ir: *const IndexReader) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -1121,7 +1191,9 @@ pub unsafe extern "C" fn IndexReader_HasMulti(ir: *const IndexReader) -> bool {
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Flags(ir: *const IndexReader) -> IndexFlags {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -1138,7 +1210,9 @@ pub unsafe extern "C" fn IndexReader_Flags(ir: *const IndexReader) -> IndexFlags
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_NumericFilter(ir: *const IndexReader) -> *const NumericFilter {
     debug_assert!(!ir.is_null(), "ir must not be null");
@@ -1176,7 +1250,9 @@ pub unsafe extern "C" fn IndexReader_NumericFilter(ir: *const IndexReader) -> *c
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_NeedsRevalidation(ir: *mut IndexReader) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
@@ -124,10 +124,12 @@ unsafe fn c_producer(
 ///
 /// # Safety
 ///
-/// 1. `produce` must run the query against `ctx` and return a valid [`VectorRangeResults`]
+/// 1. `produce` must run the query against `ctx` and return a [valid] [`VectorRangeResults`]
 ///    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
 /// 2. `free_ctx` must free `ctx` and be safe to call exactly once.
 /// 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewLazyVectorRangeIterator(
     produce: ProduceResultsFn,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
@@ -127,7 +127,7 @@ unsafe fn c_producer(
 /// 1. `produce` must run the query against `ctx` and return a [valid] [`VectorRangeResults`]
 ///    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
 /// 2. `free_ctx` must free `ctx` and be safe to call exactly once.
-/// 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
+/// 3. `ctx` must remain [valid] until the iterator is freed; ownership transfers to the iterator.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/deferred.rs
@@ -124,7 +124,7 @@ unsafe fn c_producer(
 ///
 /// # Safety
 ///
-/// 1. `produce` must run the query against `ctx` and return a [valid] [`VectorRangeResults`]
+/// 1. `produce` must run the query against `ctx` and return a valid [`VectorRangeResults`]
 ///    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
 /// 2. `free_ctx` must free `ctx` and be safe to call exactly once.
 /// 3. `ctx` must remain [valid] until the iterator is freed; ownership transfers to the iterator.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -37,11 +37,13 @@ impl ExternalCounter {
     /// # Safety
     ///
     /// The pointed-to `usize` must:
-    /// 1. be valid and initialized;
+    /// 1. be [valid] and initialized;
     /// 2. remain valid for the entire lifetime of the [`GeoShape`] iterator this
     ///    tracker is given to; and
     /// 3. only be accessed single-threaded (it is mutated without
     ///    synchronization, which holds under the index/spec lock).
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     #[inline(always)]
     const unsafe fn new(counter: NonNull<usize>) -> Self {
         Self { counter }
@@ -78,19 +80,21 @@ impl MemTracker for ExternalCounter {
 ///
 /// # Safety
 ///
-/// 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
-///    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
+/// 1. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
+///    `spec` is a [valid] [`IndexSpec`](ffi::IndexSpec); both must outlive the
 ///    returned iterator, and `sctx` must stay at a stable address for that
 ///    whole window: the iterator reads the request-owned deadline back on every
 ///    timeout probe. No write to that deadline may overlap a probe.
-/// 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
+/// 2. `filter_ctx` must be a non-null pointer to a [valid] [`FieldFilterContext`].
 /// 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
 ///    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`
 ///    is null, `num` must be zero.
-/// 4. `allocated`, when non-null, must point to a valid, initialized `usize`
+/// 4. `allocated`, when non-null, must point to a [valid], initialized `usize`
 ///    (it is read-modify-written) that outlives the iterator and is only
 ///    accessed single-threaded (it is mutated without synchronization, which
 ///    holds under the spec lock).
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewGeometryQueryIterator(
     sctx: *const RedisSearchCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -38,7 +38,7 @@ impl ExternalCounter {
     ///
     /// The pointed-to `usize` must:
     /// 1. be [valid] and initialized;
-    /// 2. remain valid for the entire lifetime of the [`GeoShape`] iterator this
+    /// 2. remain [valid] for the entire lifetime of the [`GeoShape`] iterator this
     ///    tracker is given to; and
     /// 3. only be accessed single-threaded (it is mutated without
     ///    synchronization, which holds under the index/spec lock).

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -18,11 +18,13 @@ use rqe_iterators::{id_list::IdList, utils::OwnedSlice};
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
 ///    The array must be sorted in ascending order.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn NewSortedIdListIterator(
     ids: *mut DocId,
     num: u64,
@@ -37,10 +39,12 @@ pub unsafe extern "C" fn NewSortedIdListIterator(
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn NewUnsortedIdListIterator(
     ids: *mut DocId,
     num: u64,
@@ -52,10 +56,12 @@ pub unsafe extern "C" fn NewUnsortedIdListIterator(
 
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn new_id_list_iterator<const SORTED: bool>(
     ids: *mut DocId,
     num: u64,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -46,10 +46,12 @@ unsafe fn free_iterators_array(its: *mut *mut QueryIterator) {
 ///
 /// # Safety
 ///
-/// 1. `its` must be a valid non-null pointer to an array of `num` `QueryIterator*` values,
+/// 1. `its` must be a [valid] non-null pointer to an array of `num` `QueryIterator*` values,
 ///    allocated with the Redis allocator (`rm_malloc`). Ownership is transferred to this function.
-/// 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose callbacks are set.
+/// 2. Every non-null pointer in `its` must be a [valid] `QueryIterator` whose callbacks are set.
 /// 3. Null entries in `its` are treated as empty iterators.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewIntersectionIterator(
     its: *mut *mut QueryIterator,
@@ -126,8 +128,10 @@ pub unsafe extern "C" fn NewIntersectionIterator(
 ///
 /// # Safety
 ///
-/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
-/// 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
+/// 1. `header` must be a [valid] non-null pointer created via [`NewIntersectionIterator()`].
+/// 2. `child` must be a [valid] non-null pointer to a `QueryIterator`, not aliased.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AddIntersectionIteratorChild(
     header: *mut QueryIterator,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -21,14 +21,16 @@ use rqe_iterators::{IteratorsConfig, build_geo_range_iterator, free_geo_numeric_
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a valid non-NULL pointer to a `RedisSearchCtx`, remaining valid for the
+/// 1. `ctx` must be a [valid] non-NULL pointer to a `RedisSearchCtx`, remaining valid for the
 ///    lifetime of all returned iterators.
-/// 2. `ctx.spec` must be a valid non-NULL pointer to an `IndexSpec`.
-/// 3. `gf` must be a valid non-NULL pointer to a `GeoFilter`.
-///    - `gf.fieldSpec` must be a valid non-NULL pointer to a `FieldSpec`.
+/// 2. `ctx.spec` must be a [valid] non-NULL pointer to an `IndexSpec`.
+/// 3. `gf` must be a [valid] non-NULL pointer to a `GeoFilter`.
+///    - `gf.fieldSpec` must be a [valid] non-NULL pointer to a `FieldSpec`.
 ///    - `gf.numericFilters` must be NULL on entry; it is populated by this function and
 ///      freed by `GeoFilter_Free`.
-/// 4. `config` must be a valid non-NULL pointer to an `IteratorsConfig`.
+/// 4. `config` must be a [valid] non-NULL pointer to an `IteratorsConfig`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewGeoRangeIterator(
     ctx: *const ffi::RedisSearchCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -21,7 +21,7 @@ use rqe_iterators::{IteratorsConfig, build_geo_range_iterator, free_geo_numeric_
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a [valid] non-NULL pointer to a `RedisSearchCtx`, remaining valid for the
+/// 1. `ctx` must be a [valid] non-NULL pointer to a `RedisSearchCtx`, remaining [valid] for the
 ///    lifetime of all returned iterators.
 /// 2. `ctx.spec` must be a [valid] non-NULL pointer to an `IndexSpec`.
 /// 3. `gf` must be a [valid] non-NULL pointer to a `GeoFilter`.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -28,14 +28,16 @@ use rqe_iterators::{interop::RQEIteratorWrapper, inverted_index::new_missing_ite
 ///
 /// The following invariants must be upheld when calling this function:
 ///
-/// 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+/// 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
 /// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `spec.missingFieldDict`
 ///    lookup.
-/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+/// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
 /// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
 /// 5. `field_index` must be a valid index into `sctx.spec.fields`.
-/// 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+/// 6. `sctx.spec.missingFieldDict` must be a non-null, [valid] dict pointer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewInvIndIterator_MissingQuery(
     idx: *const ffi::InvertedIndex,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -29,11 +29,11 @@ use rqe_iterators::{interop::RQEIteratorWrapper, inverted_index::new_missing_ite
 /// The following invariants must be upheld when calling this function:
 ///
 /// 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
-/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+/// 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `spec.missingFieldDict`
 ///    lookup.
 /// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
-/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+/// 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
 /// 5. `field_index` must be a valid index into `sctx.spec.fields`.
 /// 6. `sctx.spec.missingFieldDict` must be a non-null, [valid] dict pointer.
 ///

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -17,8 +17,10 @@ use rqe_iterators::{IteratorsConfig, open_numeric_or_geo_index};
 ///
 /// # Safety
 ///
-/// 1. `spec` must be a valid non-null pointer to an [`ffi::IndexSpec`].
-/// 2. `fs` must be a valid non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+/// 1. `spec` must be a [valid] non-null pointer to an [`ffi::IndexSpec`].
+/// 2. `fs` must be a [valid] non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn openNumericOrGeoIndex(
     spec: *mut ffi::IndexSpec,
@@ -52,15 +54,17 @@ pub unsafe extern "C" fn openNumericOrGeoIndex(
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a valid non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
+/// 1. `ctx` must be a [valid] non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
 ///    for the lifetime of the returned iterator.
-/// 2. `ctx.spec` must be a valid non-NULL pointer to an [`ffi::IndexSpec`].
-/// 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
-///    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
+/// 2. `ctx.spec` must be a [valid] non-NULL pointer to an [`ffi::IndexSpec`].
+/// 3. `flt` must be a [valid] non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
+///    is a [valid] non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
 ///    returned iterator.
-/// 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
-/// 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
+/// 4. `config` must be a [valid] non-NULL pointer to an [`IteratorsConfig`].
+/// 5. `filter_ctx` must be a [valid] non-NULL pointer to a [`FieldFilterContext`] with a field
 ///    index (not a field mask).
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewNumericFilterIterator(
     ctx: *const ffi::RedisSearchCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -54,11 +54,11 @@ pub unsafe extern "C" fn openNumericOrGeoIndex(
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a [valid] non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
+/// 1. `ctx` must be a [valid] non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining [valid]
 ///    for the lifetime of the returned iterator.
 /// 2. `ctx.spec` must be a [valid] non-NULL pointer to an [`ffi::IndexSpec`].
 /// 3. `flt` must be a [valid] non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
-///    is a [valid] non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
+///    is a [valid] non-NULL pointer to a [`FieldSpec`], remaining [valid] for the lifetime of the
 ///    returned iterator.
 /// 4. `config` must be a [valid] non-NULL pointer to an [`IteratorsConfig`].
 /// 5. `filter_ctx` must be a [valid] non-NULL pointer to a [`FieldFilterContext`] with a field

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -120,13 +120,15 @@ impl CTagIndexLookup {
     ///
     /// # Safety
     ///
-    /// 1. `tag_index` must point to a valid TagIndex and remain valid for
+    /// 1. `tag_index` must point to a [valid] TagIndex and remain valid for
     ///    the lifetime of this lookup (and of any iterator holding it).
-    /// 2. `tag_index.values`, when non-null, must be a valid
+    /// 2. `tag_index.values`, when non-null, must be a [valid]
     ///    [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
     /// 3. The entries in `tag_index.values` must point to opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex)es whose
     ///    encoding variant matches the `E` this lookup is used with.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn new(tag_index: NonNull<ffi::TagIndex>) -> Self {
         Self(tag_index)
     }
@@ -177,17 +179,19 @@ where
 ///
 /// The following invariants must be upheld when calling this function:
 ///
-/// 1. `idx` must be a valid pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
+/// 1. `idx` must be a [valid] pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
 ///    [`InvertedIndex`](ffi::InvertedIndex) and cannot be NULL.
 /// 2. `idx` must remain valid between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
 ///    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) `TrieMap` lookup.
-/// 3. `tag_idx` must be a valid pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
+/// 3. `tag_idx` must be a [valid] pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
 /// 4. `tag_idx` and `tag_idx.values` must remain valid for the lifetime of the returned
 ///    iterator.
-/// 5. `sctx` must be a valid pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) and cannot be NULL.
+/// 5. `sctx` must be a [valid] pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) and cannot be NULL.
 /// 6. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
-/// 7. `term` must be a valid pointer to a heap-allocated [`RSQueryTerm`] (e.g. created by
+/// 7. `term` must be a [valid] pointer to a heap-allocated [`RSQueryTerm`] (e.g. created by
 ///    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewInvIndIterator_TagQuery(
     idx: *const ffi::InvertedIndex,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -120,7 +120,7 @@ impl CTagIndexLookup {
     ///
     /// # Safety
     ///
-    /// 1. `tag_index` must point to a [valid] TagIndex and remain valid for
+    /// 1. `tag_index` must point to a [valid] TagIndex and remain [valid] for
     ///    the lifetime of this lookup (and of any iterator holding it).
     /// 2. `tag_index.values`, when non-null, must be a [valid]
     ///    [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
@@ -181,13 +181,13 @@ where
 ///
 /// 1. `idx` must be a [valid] pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
 ///    [`InvertedIndex`](ffi::InvertedIndex) and cannot be NULL.
-/// 2. `idx` must remain valid between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
+/// 2. `idx` must remain [valid] between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
 ///    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) `TrieMap` lookup.
 /// 3. `tag_idx` must be a [valid] pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
-/// 4. `tag_idx` and `tag_idx.values` must remain valid for the lifetime of the returned
+/// 4. `tag_idx` and `tag_idx.values` must remain [valid] for the lifetime of the returned
 ///    iterator.
 /// 5. `sctx` must be a [valid] pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) and cannot be NULL.
-/// 6. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+/// 6. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
 /// 7. `term` must be a [valid] pointer to a heap-allocated [`RSQueryTerm`] (e.g. created by
 ///    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
 ///

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -33,11 +33,11 @@ use rqe_iterators::inverted_index::build_term_iterator;
 /// The following invariants must be upheld when calling this function:
 ///
 /// 1. `idx` must be a [valid] pointer to a term `InvertedIndex` and cannot be NULL.
-/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+/// 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
 ///    pointer comparison.
 /// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
-/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+/// 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
 /// 5. `term` must be a [valid] pointer to a heap-allocated `RSQueryTerm` (e.g. created by
 ///    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
 ///

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -32,14 +32,16 @@ use rqe_iterators::inverted_index::build_term_iterator;
 ///
 /// The following invariants must be upheld when calling this function:
 ///
-/// 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
+/// 1. `idx` must be a [valid] pointer to a term `InvertedIndex` and cannot be NULL.
 /// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
 ///    pointer comparison.
-/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+/// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
 /// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
-/// 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
+/// 5. `term` must be a [valid] pointer to a heap-allocated `RSQueryTerm` (e.g. created by
 ///    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     idx: *const ffi::InvertedIndex,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -147,12 +147,14 @@ impl profile_print::ProfilePrint for WildcardIterator<'_> {
 ///
 /// The following invariants must be upheld when calling this function:
 ///
-/// 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+/// 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
 /// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
 ///    comparison.
-/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+/// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
 /// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery(
     idx: *const ffi::InvertedIndex,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -148,11 +148,11 @@ impl profile_print::ProfilePrint for WildcardIterator<'_> {
 /// The following invariants must be upheld when calling this function:
 ///
 /// 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
-/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+/// 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
 ///    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
 ///    comparison.
 /// 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
-/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+/// 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -20,12 +20,14 @@ use rqe_iterators::{
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
 ///    The array must be sorted in ascending order.
-/// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+/// 2. `metric_list` must be a [valid] pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn NewMetricIteratorSortedById(
     ids: *mut DocId,
     metric_list: *mut f64,
@@ -41,11 +43,13 @@ pub unsafe extern "C" fn NewMetricIteratorSortedById(
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
-/// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
+/// 2. `metric_list` must be a [valid] pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn NewMetricIteratorSortedByScore(
     ids: *mut DocId,
     metric_list: *mut f64,
@@ -58,11 +62,13 @@ pub unsafe extern "C" fn NewMetricIteratorSortedByScore(
 
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
-/// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+/// 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
+/// 2. `metric_list` must be a [valid] pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     ids: *mut DocId,
     metrics: *mut f64,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -175,21 +175,23 @@ unsafe fn build_timeout_context(q: NonNull<ffi::QueryEvalCtx>) -> AnyTimeoutCont
 ///
 /// # Safety
 ///
-/// 1. `child` must be null or a valid pointer to a [`QueryIterator`].
+/// 1. `child` must be null or a [valid] pointer to a [`QueryIterator`].
 ///    A null `child` is treated as empty.
 /// 2. When non-null, `child` must not be aliased.
-/// 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
-/// 4. `q.sctx` must be a non-null pointer to a valid
+/// 3. `q` must be a [valid] non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
+/// 4. `q.sctx` must be a non-null pointer to a [valid]
 ///    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay valid and at a stable
 ///    address for the lifetime of the returned iterator: on the Clock Based Timeout path
 ///    the iterator reads the request-owned deadline back on every probe. No write to that
 ///    deadline may overlap a probe.
-/// 5. `q.sctx.spec` must be a non-null pointer to a valid
+/// 5. `q.sctx.spec` must be a non-null pointer to a [valid]
 ///    [`IndexSpec`](ffi::IndexSpec).
-/// 6. `q.sctx.spec.rule`, when non-null, must point to a valid
+/// 6. `q.sctx.spec.rule`, when non-null, must point to a [valid]
 ///    [`SchemaRule`](ffi::SchemaRule).
 /// 7. When the optimized path is taken, the preconditions of
 ///    [`crate::wildcard::NewWildcardIterator`] must hold.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewNotIterator(
     child: *mut QueryIterator,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -180,7 +180,7 @@ unsafe fn build_timeout_context(q: NonNull<ffi::QueryEvalCtx>) -> AnyTimeoutCont
 /// 2. When non-null, `child` must not be aliased.
 /// 3. `q` must be a [valid] non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
 /// 4. `q.sctx` must be a non-null pointer to a [valid]
-///    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay valid and at a stable
+///    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay [valid] and at a stable
 ///    address for the lifetime of the returned iterator: on the Clock Based Timeout path
 ///    the iterator reads the request-owned deadline back on every probe. No write to that
 ///    deadline may overlap a probe.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
@@ -27,9 +27,11 @@ use rqe_iterators::optional_reducer::{
 ///
 /// # Safety
 ///
-/// 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
-/// 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
+/// 1. `child`, when non-null, must be a [valid] owning pointer to a C query iterator that is not aliased.
+/// 2. `q` must be a [valid] non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
 ///    [`new_optional_iterator`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn NewOptionalIterator(
     child: *mut QueryIterator,
     q: *mut QueryEvalCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile.rs
@@ -20,8 +20,10 @@ use std::ptr::NonNull;
 ///
 /// # Safety
 ///
-/// 1. `iter` must be a valid non-null pointer to an implementation of the C query iterator API.
+/// 1. `iter` must be a [valid] non-null pointer to an implementation of the C query iterator API.
 /// 2. `iter` must not be aliased.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IntoProfiled(iter: *mut QueryIterator) -> *mut QueryIterator {
     debug_assert!(!iter.is_null(), "iter must not be null");
@@ -41,8 +43,10 @@ pub unsafe extern "C" fn IntoProfiled(iter: *mut QueryIterator) -> *mut QueryIte
 ///
 /// # Safety
 ///
-/// 1. `root` must be a valid non-null pointer to a `*mut QueryIterator`.
-/// 2. `*root` must be null or a valid non-null, non-aliased pointer to a `QueryIterator`.
+/// 1. `root` must be a [valid] non-null pointer to a `*mut QueryIterator`.
+/// 2. `*root` must be null or a [valid] non-null, non-aliased pointer to a `QueryIterator`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Profile_AddIters(root: *mut *mut QueryIterator) {
     debug_assert!(!root.is_null());

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/profile_print.rs
@@ -28,9 +28,11 @@ use rqe_iterators::{c2rust::call_print_profile, profile_print::ProfilePrintCtx};
 ///
 /// # Safety
 ///
-/// 1. `self_` must be a valid pointer to a Hybrid iterator.
-/// 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
-/// 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+/// 1. `self_` must be a [valid] pointer to a Hybrid iterator.
+/// 2. `map` must be a [valid] pointer to a [`redis_reply::MapBuilder`].
+/// 3. `ctx` must be a [valid] pointer to a [`ProfilePrintCtx`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Hybrid_PrintProfile(
     self_: *const QueryIterator,
@@ -80,9 +82,11 @@ pub unsafe extern "C" fn Hybrid_PrintProfile(
 ///
 /// # Safety
 ///
-/// 1. `self_` must be a valid pointer to an Optimus iterator.
-/// 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
-/// 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+/// 1. `self_` must be a [valid] pointer to an Optimus iterator.
+/// 2. `map` must be a [valid] pointer to a [`redis_reply::MapBuilder`].
+/// 3. `ctx` must be a [valid] pointer to a [`ProfilePrintCtx`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Optimus_PrintProfile(
     self_: *const QueryIterator,
@@ -136,9 +140,11 @@ pub unsafe extern "C" fn Optimus_PrintProfile(
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a valid [`RedisModuleCtx`] pointer.
-/// 2. `root` must be null or a valid pointer to a [`QueryIterator`] tree
+/// 1. `ctx` must be a [valid] [`RedisModuleCtx`] pointer.
+/// 2. `root` must be null or a [valid] pointer to a [`QueryIterator`] tree
 ///    that has been profile-wrapped via `Profile_AddIters`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Profile_PrintIterators(
     ctx: *mut RedisModuleCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -58,15 +58,17 @@ unsafe fn free_iterators_array(its: *mut *mut QueryIterator) {
 ///
 /// # Safety
 ///
-/// 1. `its` must be a valid non-null pointer to an array of `num`
+/// 1. `its` must be a [valid] non-null pointer to an array of `num`
 ///    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
 ///    Ownership is transferred to this function.
-/// 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
+/// 2. Every non-null pointer in `its` must be a [valid] `QueryIterator` whose
 ///    callbacks are set.
 /// 3. Null entries in `its` are treated as empty iterators.
-/// 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
-/// 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
+/// 4. `config` must be a [valid] non-null pointer to an [`IteratorsConfig`].
+/// 5. `q_str` must be null or a [valid], NUL-terminated C string that outlives
 ///    the returned iterator — the requirement of [`build_union`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewUnionIterator(
     its: *mut *mut QueryIterator,
@@ -135,8 +137,10 @@ pub unsafe extern "C" fn NewUnionIterator(
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid non-null pointer to a non-reduced union iterator
+/// 1. `it` must be a [valid] non-null pointer to a non-reduced union iterator
 ///    created via [`NewUnionIterator`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrimUnionIterator(it: *mut QueryIterator, limit: usize, asc: bool) {
     debug_assert!(!it.is_null());

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -32,7 +32,7 @@ use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
 /// [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
 /// accessors below must not be called on such a handle.
 ///
-/// Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
+/// Pass `child = NULL` for a pure KNN query; pass a [valid] owning child iterator
 /// for a hybrid (filtered) query.
 ///
 /// The `query_params` pointer is read once to copy the parameters into the
@@ -199,7 +199,9 @@ pub unsafe extern "C" fn VectorTopK_GetOwnKeyRef(it: *mut QueryIterator) -> *mut
 ///
 /// 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
 ///    not reduce to `Empty`, whose `index` and `sctx` are still alive.
-/// 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
+/// 2. `handle` is either null or a [valid] pointer to a [`RLookupKeyHandle`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
     it: *mut QueryIterator,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -28,7 +28,9 @@ pub extern "C" fn NewWildcardIterator_NonOptimized(
 ///
 /// # Safety
 ///
-/// `it`, when non-null, must point to a valid [`QueryIterator`].
+/// `it`, when non-null, must point to a [valid] [`QueryIterator`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn IsWildcardIterator(it: *const QueryIterator) -> bool {
     // SAFETY: Caller guarantees `it`, when non-null, points to a valid `QueryIterator`.
@@ -55,24 +57,26 @@ pub const unsafe extern "C" fn IsWildcardIterator(it: *const QueryIterator) -> b
 ///
 /// # Safety
 ///
-/// 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`](ffi::QueryEvalCtx)
+/// 1. `q` must be a non-null pointer to a [valid] [`QueryEvalCtx`](ffi::QueryEvalCtx)
 ///    that remains valid for the lifetime of the returned iterator.
-/// 2. `q.sctx` must be a non-null pointer to a valid
+/// 2. `q.sctx` must be a non-null pointer to a [valid]
 ///    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains valid for the lifetime
 ///    of the returned iterator.
-/// 3. `q.sctx.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) that
+/// 3. `q.sctx.spec` must be a non-null pointer to a [valid] [`IndexSpec`](ffi::IndexSpec) that
 ///    remains valid for the lifetime of the returned iterator.
-/// 4. `q.sctx.spec.rule`, when non-null, must point to a valid [`SchemaRule`](ffi::SchemaRule).
+/// 4. `q.sctx.spec.rule`, when non-null, must point to a [valid] [`SchemaRule`](ffi::SchemaRule).
 /// 5. When [`SchemaRule`](ffi::SchemaRule)`.index_all` is true, the preconditions of
 ///    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`] must also hold.
-/// 6. `q.docTable` must be a non-null pointer to a valid [`DocTable`](ffi::DocTable).
-/// 7. `q.sctx.spec.diskSpec`, when non-null, must point to a valid
+/// 6. `q.docTable` must be a non-null pointer to a [valid] [`DocTable`](ffi::DocTable).
+/// 7. `q.sctx.spec.diskSpec`, when non-null, must point to a [valid]
 ///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains valid for the
 ///    lifetime of the returned iterator, and the disk iterator backend must be initialized.
 /// 8. When `q.sctx.spec.diskSpec` is non-null, `q.sctx.diskSnapshot` must be a **non-null**
 ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for `q.sctx.spec.diskSpec`
 ///    that remains valid for the lifetime of the returned iterator. The disk path requires a
 ///    point-in-time view: a null snapshot alongside a non-null `diskSpec` makes the call panic.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewWildcardIterator(
     q: *const ffi::QueryEvalCtx,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -58,22 +58,22 @@ pub const unsafe extern "C" fn IsWildcardIterator(it: *const QueryIterator) -> b
 /// # Safety
 ///
 /// 1. `q` must be a non-null pointer to a [valid] [`QueryEvalCtx`](ffi::QueryEvalCtx)
-///    that remains valid for the lifetime of the returned iterator.
+///    that remains [valid] for the lifetime of the returned iterator.
 /// 2. `q.sctx` must be a non-null pointer to a [valid]
-///    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains valid for the lifetime
+///    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains [valid] for the lifetime
 ///    of the returned iterator.
 /// 3. `q.sctx.spec` must be a non-null pointer to a [valid] [`IndexSpec`](ffi::IndexSpec) that
-///    remains valid for the lifetime of the returned iterator.
+///    remains [valid] for the lifetime of the returned iterator.
 /// 4. `q.sctx.spec.rule`, when non-null, must point to a [valid] [`SchemaRule`](ffi::SchemaRule).
 /// 5. When [`SchemaRule`](ffi::SchemaRule)`.index_all` is true, the preconditions of
 ///    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`] must also hold.
 /// 6. `q.docTable` must be a non-null pointer to a [valid] [`DocTable`](ffi::DocTable).
 /// 7. `q.sctx.spec.diskSpec`, when non-null, must point to a [valid]
-///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains valid for the
+///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains [valid] for the
 ///    lifetime of the returned iterator, and the disk iterator backend must be initialized.
 /// 8. When `q.sctx.spec.diskSpec` is non-null, `q.sctx.diskSnapshot` must be a **non-null**
 ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for `q.sctx.spec.diskSpec`
-///    that remains valid for the lifetime of the returned iterator. The disk path requires a
+///    that remains [valid] for the lifetime of the returned iterator. The disk path requires a
 ///    point-in-time view: a null snapshot alongside a non-null `diskSpec` makes the call panic.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -32,8 +32,10 @@ pub const extern "C" fn MetricsVec_New() -> MetricsVec<'static> {
 ///
 /// # Safety
 ///
-/// 1. `parent` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
-/// 2. `child` must point to a valid `MetricsVec`, or be null (no-op).
+/// 1. `parent` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
+/// 2. `child` must point to a [valid] `MetricsVec`, or be null (no-op).
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSYieldableMetric_Concat<'a>(
     parent: *mut MetricsVec<'a>,
@@ -57,9 +59,11 @@ pub unsafe extern "C" fn RSYieldableMetric_Concat<'a>(
 ///
 /// # Safety
 ///
-/// 1. `r` must point to a valid `RSIndexResult` and cannot be null.
-/// 2. `key` must be a valid `*const RLookupKey` that outlives the result
+/// 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+/// 2. `key` must be a [valid] `*const RLookupKey` that outlives the result
 ///    (or null).
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ResultMetrics_Add(
     r: *mut RSIndexResult,
@@ -83,7 +87,9 @@ pub unsafe extern "C" fn ResultMetrics_Add(
 ///
 /// # Safety
 ///
-/// 1. `r` must point to a valid `RSIndexResult` and cannot be null.
+/// 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ResultMetrics_Reset(r: *mut RSIndexResult) {
     debug_assert!(!r.is_null(), "result must not be null");
@@ -98,7 +104,9 @@ pub unsafe extern "C" fn ResultMetrics_Reset(r: *mut RSIndexResult) {
 ///
 /// # Safety
 ///
-/// 1. `r` must point to a valid `RSIndexResult` and cannot be null.
+/// 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_ResetAggregate(r: *mut RSIndexResult) {
     debug_assert!(!r.is_null(), "result must not be null");
@@ -113,9 +121,11 @@ pub unsafe extern "C" fn IndexResult_ResetAggregate(r: *mut RSIndexResult) {
 ///
 /// # Safety
 ///
-/// 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
+/// 1. `metrics` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
 /// 2. The returned slice borrows from the `MetricsVec`; the caller must
 ///    not mutate or free the `MetricsVec` while the slice is in use.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn MetricsVec_AsSlice(metrics: *const MetricsVec) -> MetricsSlice {
     debug_assert!(!metrics.is_null(), "metrics must not be null");
@@ -130,8 +140,10 @@ pub unsafe extern "C" fn MetricsVec_AsSlice(metrics: *const MetricsVec) -> Metri
 ///
 /// # Safety
 ///
-/// 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
-/// 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
+/// 1. `metrics` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
+/// 2. `key` must point to a [valid] `RLookupKey`. Compared by pointer identity.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn MetricsVec_UpdateValue(
     metrics: *mut MetricsVec,

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -22,7 +22,9 @@ use tracing::level_filters::LevelFilter;
 ///
 /// # Safety
 ///
-/// `level` must point to a valid, null-terminated C string.
+/// `level` must point to a [valid], null-terminated C string.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn parse_level(level: *const c_char) -> LevelFilter {
     // Safety: the caller guarantees a valid, null-terminated C string.
     let level = unsafe { CStr::from_ptr(level) };
@@ -47,8 +49,10 @@ unsafe fn parse_level(level: *const c_char) -> LevelFilter {
 ///
 /// # Safety
 ///
-/// `level` must point to a valid, null-terminated C string. `ctx` must either
-/// be null or point to a valid `RedisModuleCtx`.
+/// `level` must point to a [valid], null-terminated C string. `ctx` must either
+/// be null or point to a [valid] `RedisModuleCtx`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TracingRedisModule_Init(
     ctx: *mut redis_module::RedisModuleCtx,
@@ -64,7 +68,9 @@ pub unsafe extern "C" fn TracingRedisModule_Init(
 ///
 /// # Safety
 ///
-/// `level` must point to a valid, null-terminated C string.
+/// `level` must point to a [valid], null-terminated C string.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TracingRedisModule_SetLogLevel(level: *const c_char) {
     // Safety: forwarded to the caller's contract on `level`.
@@ -176,7 +182,9 @@ fn info_cstring(value: impl Into<Vec<u8>>) -> CString {
 ///
 /// # Safety
 ///
-/// `ctx` must either be null or point to a valid `RedisModuleInfoCtx`.
+/// `ctx` must either be null or point to a [valid] `RedisModuleInfoCtx`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AddToInfo_RustBacktrace(ctx: *mut redis_module::RedisModuleInfoCtx) {
     if ctx.is_null() {

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -24,8 +24,10 @@ use redis_module::RedisModuleCtx;
 ///
 /// # Safety
 ///
-/// - `ctx` must be a valid Redis module context.
-/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+/// - `ctx` must be a [valid] Redis module context.
+/// - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
@@ -48,8 +50,10 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
 ///
 /// # Safety
 ///
-/// - `ctx` must be a valid Redis module context.
-/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+/// - `ctx` must be a [valid] Redis module context.
+/// - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     ctx: *mut RedisModuleCtx,
@@ -73,8 +77,10 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
 ///
 /// # Safety
 ///
-/// - `ctx` must be a valid Redis module context.
-/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+/// - `ctx` must be a [valid] Redis module context.
+/// - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     ctx: *mut RedisModuleCtx,

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/iterator.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/iterator.rs
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn NumericRangeTreeIterator_New<'a>(
 /// Returns a pointer to the next [`NumericRangeNode`] in the traversal,
 /// or NULL if the iteration is complete.
 ///
-/// The returned pointer is valid until the tree is modified or freed.
+/// The returned pointer is [valid] until the tree is modified or freed.
 /// Do NOT free the returned pointer - it points to memory owned by the tree.
 ///
 /// # Safety
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn NumericRangeTreeIterator_New<'a>(
 /// The following invariants must be upheld when calling this function:
 /// - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
 ///   [`NumericRangeTreeIterator_New`] and cannot be NULL.
-/// - The tree from which this iterator was created must still be valid.
+/// - The tree from which this iterator was created must still be [valid].
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/iterator.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/iterator.rs
@@ -21,10 +21,12 @@ use crate::NumericRangeTreeIterator;
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`crate::NewNumericRangeTree`] and cannot be NULL.
 /// - `t` must not be freed while the iterator lives.
 /// - The tree must not be mutated while the iterator lives.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTreeIterator_New<'a>(
     t: *const NumericRangeTree,
@@ -49,9 +51,11 @@ pub unsafe extern "C" fn NumericRangeTreeIterator_New<'a>(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
+/// - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
 ///   [`NumericRangeTreeIterator_New`] and cannot be NULL.
 /// - The tree from which this iterator was created must still be valid.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTreeIterator_Next(
     it: *mut NumericRangeTreeIterator,
@@ -73,9 +77,11 @@ pub unsafe extern "C" fn NumericRangeTreeIterator_Next(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
+/// - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
 ///   [`NumericRangeTreeIterator_New`], or be NULL (in which case this is a no-op).
 /// - After calling this function, `it` must not be used again.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTreeIterator_Free(it: *mut NumericRangeTreeIterator) {
     if it.is_null() {

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
@@ -101,8 +101,10 @@ pub extern "C" fn NewNumericRangeTree(compress_floats: bool) -> *mut NumericRang
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`NewNumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _NumericRangeTree_Add(
     t: *mut NumericRangeTree,
@@ -132,10 +134,12 @@ pub unsafe extern "C" fn _NumericRangeTree_Add(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`NewNumericRangeTree`], or be NULL (in which case this is a no-op).
 /// - After calling this function, `t` must not be used again.
 /// - Any iterators obtained from this tree must be freed before calling this.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_Free(t: *mut NumericRangeTree) {
     if t.is_null() {
@@ -155,8 +159,10 @@ pub unsafe extern "C" fn NumericRangeTree_Free(t: *mut NumericRangeTree) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`NewNumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_MemUsage(t: *const NumericRangeTree) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -176,9 +182,11 @@ pub unsafe extern "C" fn NumericRangeTree_MemUsage(t: *const NumericRangeTree) -
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`NewNumericRangeTree`] and cannot be NULL.
-/// - `nf` must point to a valid [`NumericFilter`] and cannot be NULL.
+/// - `nf` must point to a [valid] [`NumericFilter`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_Find(
     t: *const NumericRangeTree,
@@ -239,9 +247,11 @@ pub unsafe extern "C" fn NumericRangeTreeFindResult_Free(result: NumericRangeTre
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid [`NumericRangeTree`] obtained from
+/// - `t` must point to a [valid] [`NumericRangeTree`] obtained from
 ///   [`NewNumericRangeTree`] and cannot be NULL.
 /// - No iterators should be active on this tree while calling this function.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_TrimEmptyLeaves(
     t: *mut NumericRangeTree,

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/node.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/node.rs
@@ -22,9 +22,11 @@ use numeric_range_tree::{NumericRange, NumericRangeNode};
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `node` must point to a valid [`NumericRangeNode`] obtained from
+/// - `node` must point to a [valid] [`NumericRangeNode`] obtained from
 ///   [`crate::iterator::NumericRangeTreeIterator_Next`] and cannot be NULL.
 /// - The tree from which this node came must still be valid.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeNode_GetRange(
     node: *const NumericRangeNode,

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/node.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/node.rs
@@ -16,7 +16,7 @@ use numeric_range_tree::{NumericRange, NumericRangeNode};
 /// Returns a pointer to the range, or NULL if the node has no range
 /// (e.g., an internal node whose range has been trimmed).
 ///
-/// The returned pointer is valid until the tree is modified or freed.
+/// The returned pointer is [valid] until the tree is modified or freed.
 /// Do NOT free the returned pointer - it points to memory owned by the tree.
 ///
 /// # Safety
@@ -24,7 +24,7 @@ use numeric_range_tree::{NumericRange, NumericRangeNode};
 /// The following invariants must be upheld when calling this function:
 /// - `node` must point to a [valid] [`NumericRangeNode`] obtained from
 ///   [`crate::iterator::NumericRangeTreeIterator_Next`] and cannot be NULL.
-/// - The tree from which this node came must still be valid.
+/// - The tree from which this node came must still be [valid].
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
@@ -27,7 +27,7 @@ use crate::{IndexReader, InvertedIndexNumeric};
 /// The following invariants must be upheld when calling this function:
 /// - `range` must point to a [valid] [`NumericRange`] obtained from
 ///   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
-/// - The tree from which this range came must still be valid.
+/// - The tree from which this range came must still be [valid].
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn NumericRange_InvertedIndexSize(range: *const NumericRan
 /// Get the inverted index entries from a range.
 ///
 /// Returns a pointer to the [`InvertedIndexNumeric`] (which is a `NumericIndex` enum)
-/// stored inside the range. The returned pointer is valid until the tree is modified or freed.
+/// stored inside the range. The returned pointer is [valid] until the tree is modified or freed.
 ///
 /// # Safety
 ///
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn NumericRange_GetEntries(
 /// - `filter` may be NULL for no filtering, or must point to a [valid] [`NumericFilter`].
 /// - The returned reader holds a reference to the range's inverted index. The range
 ///   must not be freed or modified while the reader exists.
-/// - The filter (if non-NULL) must remain valid for the lifetime of the reader.
+/// - The filter (if non-NULL) must remain [valid] for the lifetime of the reader.
 /// - Free the returned reader with `IndexReader_Free()` when done.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
@@ -25,9 +25,11 @@ use crate::{IndexReader, InvertedIndexNumeric};
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `range` must point to a valid [`NumericRange`] obtained from
+/// - `range` must point to a [valid] [`NumericRange`] obtained from
 ///   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
 /// - The tree from which this range came must still be valid.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_GetCardinality(range: *const NumericRange) -> usize {
     debug_assert!(!range.is_null(), "range cannot be NULL");
@@ -42,7 +44,9 @@ pub unsafe extern "C" fn NumericRange_GetCardinality(range: *const NumericRange)
 ///
 /// # Safety
 ///
-/// - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+/// - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_MinVal(range: *const NumericRange) -> f64 {
     debug_assert!(!range.is_null(), "range cannot be NULL");
@@ -55,7 +59,9 @@ pub unsafe extern "C" fn NumericRange_MinVal(range: *const NumericRange) -> f64 
 ///
 /// # Safety
 ///
-/// - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+/// - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_MaxVal(range: *const NumericRange) -> f64 {
     debug_assert!(!range.is_null(), "range cannot be NULL");
@@ -68,7 +74,9 @@ pub unsafe extern "C" fn NumericRange_MaxVal(range: *const NumericRange) -> f64 
 ///
 /// # Safety
 ///
-/// - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+/// - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_InvertedIndexSize(range: *const NumericRange) -> usize {
     debug_assert!(!range.is_null(), "range cannot be NULL");
@@ -84,8 +92,10 @@ pub unsafe extern "C" fn NumericRange_InvertedIndexSize(range: *const NumericRan
 ///
 /// # Safety
 ///
-/// - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+/// - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
 /// - The returned pointer points to memory owned by the range; do not free it.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_GetEntries(
     range: *const NumericRange,
@@ -107,12 +117,14 @@ pub unsafe extern "C" fn NumericRange_GetEntries(
 ///
 /// # Safety
 ///
-/// - `range` must point to a valid [`NumericRange`] and cannot be NULL.
-/// - `filter` may be NULL for no filtering, or must point to a valid [`NumericFilter`].
+/// - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+/// - `filter` may be NULL for no filtering, or must point to a [valid] [`NumericFilter`].
 /// - The returned reader holds a reference to the range's inverted index. The range
 ///   must not be freed or modified while the reader exists.
 /// - The filter (if non-NULL) must remain valid for the lifetime of the reader.
 /// - Free the returned reader with `IndexReader_Free()` when done.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRange_NewIndexReader<'a>(
     range: *const NumericRange,

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/tree.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/tree.rs
@@ -22,7 +22,9 @@ use numeric_range_tree::{NumericRangeNode, NumericRangeTree};
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetRevisionId(t: *const NumericRangeTree) -> u32 {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -41,8 +43,10 @@ pub unsafe extern "C" fn NumericRangeTree_GetRevisionId(t: *const NumericRangeTr
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
 /// - The caller must have unique access to `t`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_IncrementRevisionId(t: *mut NumericRangeTree) -> u32 {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -55,7 +59,9 @@ pub unsafe extern "C" fn NumericRangeTree_IncrementRevisionId(t: *mut NumericRan
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetUniqueId(t: *const NumericRangeTree) -> u32 {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -68,7 +74,9 @@ pub unsafe extern "C" fn NumericRangeTree_GetUniqueId(t: *const NumericRangeTree
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetNumEntries(t: *const NumericRangeTree) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -81,7 +89,9 @@ pub unsafe extern "C" fn NumericRangeTree_GetNumEntries(t: *const NumericRangeTr
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetNumRanges(t: *const NumericRangeTree) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -94,7 +104,9 @@ pub unsafe extern "C" fn NumericRangeTree_GetNumRanges(t: *const NumericRangeTre
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetInvertedIndexesSize(
     t: *const NumericRangeTree,
@@ -109,8 +121,10 @@ pub unsafe extern "C" fn NumericRangeTree_GetInvertedIndexesSize(
 ///
 /// # Safety
 ///
-/// - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+/// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
 /// - The returned pointer is valid until the tree is modified or freed.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_GetRoot(
     t: *const NumericRangeTree,

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/tree.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/tree.rs
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn NumericRangeTree_GetInvertedIndexesSize(
 /// # Safety
 ///
 /// - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
-/// - The returned pointer is valid until the tree is modified or freed.
+/// - The returned pointer is [valid] until the tree is modified or freed.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
@@ -119,7 +119,9 @@ pub const extern "C" fn QueryError_CodeMaxValue() -> u8 {
 ///
 /// # Safety
 ///
-/// - `message` must be a valid C string or a NULL pointer.
+/// - `message` must be a [valid] C string or a NULL pointer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryError_GetCodeFromMessage(message: *const c_char) -> QueryErrorCode {
     if message.is_null() {
@@ -161,7 +163,9 @@ pub unsafe extern "C" fn QueryError_GetCodeFromMessage(message: *const c_char) -
 /// # Safety
 ///
 /// - `query_error` must have been created by [`QueryError_Default`].
-/// - `message` must be a valid C string or a NULL pointer.
+/// - `message` must be a [valid] C string or a NULL pointer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryError_SetError(
     query_error: *mut OpaqueQueryError,
@@ -209,7 +213,9 @@ pub unsafe extern "C" fn QueryError_SetCode(query_error: *mut OpaqueQueryError, 
 /// # Safety
 ///
 /// - `query_error` must have been created by [`QueryError_Default`].
-/// - `detail` must be a valid C string or a NULL pointer.
+/// - `detail` must be a [valid] C string or a NULL pointer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryError_SetDetail(
     query_error: *mut OpaqueQueryError,
@@ -449,7 +455,9 @@ pub unsafe extern "C" fn QueryError_SetQueryOOMWarning(query_error: *mut OpaqueQ
 ///
 /// # Safety
 ///
-/// - `message` must be a valid C string or a NULL pointer.
+/// - `message` must be a [valid] C string or a NULL pointer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryWarningCode_GetCodeFromMessage(
     message: *const c_char,

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -66,7 +66,9 @@ fn eval_config(iterators: &IteratorsConfig) -> Config {
 ///
 /// # Safety
 ///
-/// `scorer_name` must be null or a valid NUL-terminated C string.
+/// `scorer_name` must be null or a [valid] NUL-terminated C string.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn resolve_scorer(scorer_name: *const c_char) -> Option<BuiltInScorer> {
     // A null scorer name means "use the configured default scorer".
     let name = if scorer_name.is_null() {
@@ -92,7 +94,9 @@ unsafe fn resolve_scorer(scorer_name: *const c_char) -> Option<BuiltInScorer> {
 ///
 /// # Safety
 ///
-/// `scorer_name` must be null or a valid NUL-terminated C string.
+/// `scorer_name` must be null or a [valid] NUL-terminated C string.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn scorerNeedsOffsets(scorer_name: *const c_char) -> bool {
     // SAFETY: `scorer_name` upholds this function's contract (null or a valid
@@ -105,8 +109,10 @@ pub unsafe extern "C" fn scorerNeedsOffsets(scorer_name: *const c_char) -> bool 
 ///
 /// # Safety
 ///
-/// `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
-/// null or point to a valid [`QueryNodeOptions`].
+/// `scorer_name` must be null or a [valid] NUL-terminated C string; `opts` must be
+/// null or point to a [valid] [`QueryNodeOptions`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn queryNeedsOffsets(
     scorer_name: *const c_char,
@@ -136,19 +142,21 @@ pub unsafe extern "C" fn queryNeedsOffsets(
 ///
 /// # Safety
 ///
-/// 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
+/// 1. `q` must be a non-null pointer to a [valid] [`QueryEvalCtx`] that satisfies
 ///    all the invariants documented on [`QueryEvalContext::new`] and remains
-///    valid for the lifetime of the returned iterator.
-/// 2. `n` must be a non-null pointer to a valid [`RSQueryNode`]. Evaluation
+///    [valid] for the lifetime of the returned iterator.
+/// 2. `n` must be a non-null pointer to a [valid] [`RSQueryNode`]. Evaluation
 ///    rewrites some tokens in place, so every node in the subtree that carries a
 ///    rewritable one — see [`QueryNodeMut::token_mut`] — must additionally satisfy
 ///    invariant (4) of [`QueryNodeMut::new`]. A parser-produced AST does; one
 ///    assembled by hand, with a token borrowing a read-only or length-delimited
 ///    string, does not.
 /// 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
-///    pointing to a valid [`Config`] that stays valid for the duration of the
+///    pointing to a [valid] [`Config`] that stays valid for the duration of the
 ///    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
 ///    dispatcher.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 // TODO: remove the '_Rs' suffix once fully ported.
 pub unsafe extern "C" fn Query_EvalNode_Rs(
@@ -196,19 +204,21 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
 ///
 /// # Safety
 ///
-/// 1. `qast` must be a non-null pointer to a valid [`QueryAST`] whose `root` is
-///    a valid [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
+/// 1. `qast` must be a non-null pointer to a [valid] [`QueryAST`] whose `root` is
+///    a [valid] [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
 ///    must stay valid and exclusively borrowed for the duration of the call. The
 ///    root's subtree must meet the token-buffer requirement of
 ///    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
-/// 2. `opts` must be a non-null pointer to a valid [`RSSearchOptions`].
-/// 3. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
-///    `spec` is a valid, non-null [`IndexSpec`](ffi::IndexSpec).
-/// 4. `status` must be a non-null pointer to a valid [`QueryError`].
+/// 2. `opts` must be a non-null pointer to a [valid] [`RSSearchOptions`].
+/// 3. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
+///    `spec` is a [valid], non-null [`IndexSpec`](ffi::IndexSpec).
+/// 4. `status` must be a non-null pointer to a [valid] [`QueryError`].
 ///
 /// Together these are exactly the invariants documented on
 /// [`QueryEvalContext::new`] for the assembled context, which remains valid for
 /// the lifetime of the returned iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QAST_Iterate(
     qast: *mut QueryAST,

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn queryNeedsOffsets(
 ///    assembled by hand, with a token borrowing a read-only or length-delimited
 ///    string, does not.
 /// 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
-///    pointing to a [valid] [`Config`] that stays valid for the duration of the
+///    pointing to a [valid] [`Config`] that stays [valid] for the duration of the
 ///    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
 ///    dispatcher.
 ///
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
 ///
 /// 1. `qast` must be a non-null pointer to a [valid] [`QueryAST`] whose `root` is
 ///    a [valid] [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
-///    must stay valid and exclusively borrowed for the duration of the call. The
+///    must stay [valid] and exclusively borrowed for the duration of the call. The
 ///    root's subtree must meet the token-buffer requirement of
 ///    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
 /// 2. `opts` must be a non-null pointer to a [valid] [`RSSearchOptions`].
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
 /// 4. `status` must be a non-null pointer to a [valid] [`QueryError`].
 ///
 /// Together these are exactly the invariants documented on
-/// [`QueryEvalContext::new`] for the assembled context, which remains valid for
+/// [`QueryEvalContext::new`] for the assembled context, which remains [valid] for
 /// the lifetime of the returned iterator.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
@@ -24,12 +24,14 @@ use query_term::RSQueryTerm;
 ///
 /// # Safety
 ///
-/// - `tok` must point to a valid `RSToken` and cannot be NULL.
+/// - `tok` must point to a [valid] `RSToken` and cannot be NULL.
 /// - `tok->str` may be NULL, in which case the resulting term will have a
 ///   NULL `str` field.
-/// - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
+/// - If not NULL, `tok->str` must be a [valid] byte slice of `tok->len` bytes.
 /// - The returned pointer is heap-allocated and must be freed with
 ///   [`Term_Free`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewQueryTerm(tok: *const ffi::RSToken, id: c_int) -> *mut RSQueryTerm {
     debug_assert!(!tok.is_null(), "tok cannot be NULL");
@@ -73,8 +75,10 @@ pub unsafe extern "C" fn Term_Free(t: *mut RSQueryTerm) {
 ///
 /// # Safety
 ///
-/// `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+/// `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
 /// allocated by [`NewQueryTerm`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_GetIDF(term: *const RSQueryTerm) -> f64 {
     debug_assert!(!term.is_null(), "term cannot be NULL");
@@ -86,8 +90,10 @@ pub unsafe extern "C" fn QueryTerm_GetIDF(term: *const RSQueryTerm) -> f64 {
 ///
 /// # Safety
 ///
-/// `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+/// `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
 /// allocated by [`NewQueryTerm`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_GetBM25_IDF(term: *const RSQueryTerm) -> f64 {
     debug_assert!(!term.is_null(), "term cannot be NULL");
@@ -101,8 +107,10 @@ pub unsafe extern "C" fn QueryTerm_GetBM25_IDF(term: *const RSQueryTerm) -> f64 
 ///
 /// # Safety
 ///
-/// `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+/// `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
 /// allocated by [`NewQueryTerm`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_SetIDFs(term: *mut RSQueryTerm, idf: f64, bm25_idf: f64) {
     debug_assert!(!term.is_null(), "term cannot be NULL");
@@ -118,8 +126,10 @@ pub unsafe extern "C" fn QueryTerm_SetIDFs(term: *mut RSQueryTerm, idf: f64, bm2
 ///
 /// # Safety
 ///
-/// `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+/// `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
 /// allocated by [`NewQueryTerm`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_GetID(term: *const RSQueryTerm) -> c_int {
     debug_assert!(!term.is_null(), "term cannot be NULL");
@@ -131,8 +141,10 @@ pub unsafe extern "C" fn QueryTerm_GetID(term: *const RSQueryTerm) -> c_int {
 ///
 /// # Safety
 ///
-/// `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+/// `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
 /// allocated by [`NewQueryTerm`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_GetLen(term: *const RSQueryTerm) -> usize {
     debug_assert!(!term.is_null(), "term cannot be NULL");
@@ -146,8 +158,10 @@ pub unsafe extern "C" fn QueryTerm_GetLen(term: *const RSQueryTerm) -> usize {
 ///
 /// # Safety
 ///
-/// - `term` must be valid and non-null
-/// - `out_len` must be a valid pointer to write the length to
+/// - `term` must be [valid] and non-null
+/// - `out_len` must be a [valid] pointer to write the length to
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryTerm_GetStrAndLen(
     term: *const RSQueryTerm,

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
@@ -21,7 +21,7 @@ use std::{
 /// # Safety
 ///
 /// If `len > 0`, `names` must point to an array of at least `len` [valid],
-/// NUL-terminated C strings. Each pointer's pointee must remain valid for
+/// NUL-terminated C strings. Each pointer's pointee must remain [valid] for
 /// the duration of this call.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
@@ -20,9 +20,11 @@ use std::{
 ///
 /// # Safety
 ///
-/// If `len > 0`, `names` must point to an array of at least `len` valid,
+/// If `len > 0`, `names` must point to an array of at least `len` [valid],
 /// NUL-terminated C strings. Each pointer's pointee must remain valid for
 /// the duration of this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn copy_c_names(names: *const *const c_char, len: usize) -> Box<[CString]> {
     if names.is_null() || len == 0 {
         return Box::new([]);
@@ -46,10 +48,10 @@ unsafe fn copy_c_names(names: *const *const c_char, len: usize) -> Box<[CString]
 /// 1. `input_key` must be a [valid] pointer to an [`RLookupKey`] that remains
 ///    alive for the lifetime of the returned reducer.
 /// 2. If `field_names_len > 0`, `field_names` must point to an array of at
-///    least `field_names_len` valid, NUL-terminated C strings. Ignored when
+///    least `field_names_len` [valid], NUL-terminated C strings. Ignored when
 ///    `load_all` is `true`.
 /// 3. If `sort_names_len > 0`, `sort_names` must point to an array of at
-///    least `sort_names_len` valid, NUL-terminated C strings.
+///    least `sort_names_len` [valid], NUL-terminated C strings.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
@@ -98,8 +100,10 @@ pub unsafe extern "C" fn CollectReducer_CreateLocal(
 
 /// # Safety
 ///
-/// 1. `r` must point to a valid [`LocalCollectReducer`] originally created by
+/// 1. `r` must point to a [valid] [`LocalCollectReducer`] originally created by
 ///    [`CollectReducer_CreateLocal`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_IsLocalLoadAll(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller (1.)

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -195,8 +195,10 @@ pub unsafe extern "C" fn collectRemoteFree(r: *mut ffi::Reducer) {
 //
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_GetFieldKeysLen(r: *const ffi::Reducer) -> usize {
     // SAFETY: ensured by caller.
@@ -206,8 +208,10 @@ pub const unsafe extern "C" fn CollectReducer_GetFieldKeysLen(r: *const ffi::Red
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_IsLoadAll(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller.
@@ -217,8 +221,10 @@ pub const unsafe extern "C" fn CollectReducer_IsLoadAll(r: *const ffi::Reducer) 
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_GetSortKeysLen(r: *const ffi::Reducer) -> usize {
     // SAFETY: ensured by caller.
@@ -228,8 +234,10 @@ pub const unsafe extern "C" fn CollectReducer_GetSortKeysLen(r: *const ffi::Redu
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_GetSortAscMap(r: *const ffi::Reducer) -> u64 {
     // SAFETY: ensured by caller.
@@ -239,8 +247,10 @@ pub const unsafe extern "C" fn CollectReducer_GetSortAscMap(r: *const ffi::Reduc
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_HasLimit(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller.
@@ -250,8 +260,10 @@ pub const unsafe extern "C" fn CollectReducer_HasLimit(r: *const ffi::Reducer) -
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_GetLimitOffset(r: *const ffi::Reducer) -> u64 {
     // SAFETY: ensured by caller.
@@ -261,8 +273,10 @@ pub const unsafe extern "C" fn CollectReducer_GetLimitOffset(r: *const ffi::Redu
 
 /// # Safety
 ///
-/// `r` must point to a valid [`RemoteCollectReducer`] originally created by
+/// `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn CollectReducer_GetLimitCount(r: *const ffi::Reducer) -> u64 {
     // SAFETY: ensured by caller.

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -28,7 +28,7 @@ use std::{
 ///    `field_keys_len` [valid] `*const RLookupKey` pointers.
 /// 2. If `sort_keys_len > 0`, `sort_keys` must point to an array of at least
 ///    `sort_keys_len` [valid] `*const RLookupKey` pointers.
-/// 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
+/// 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain [valid] for the
 ///    lifetime of the returned reducer.
 /// 4. `srclookup` is either null or a [valid] pointer to a
 ///    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -575,7 +575,7 @@ pub unsafe extern "C" fn RLookup_HasIndexSpecCache(lookup: *const OpaqueRLookup)
 
 /// Releases any resources created by this lookup object. Note that if there are
 /// lookup keys created with RLOOKUP_F_NOINCREF, those keys will no longer be
-/// valid after this call!
+/// [valid] after this call!
 ///
 /// # Safety
 ///
@@ -948,7 +948,7 @@ pub unsafe extern "C" fn RLookup_LoadDocumentIndividual(
 /// # Safety
 ///
 /// 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
-/// 2. The returned iterator must only be used as long as the `lookup` remains valid.
+/// 2. The returned iterator must only be used as long as the `lookup` remains [valid].
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
@@ -974,7 +974,7 @@ pub struct RLookupIterator<'a> {
 /// # Safety
 ///
 /// 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
-/// 2. The returned iterator must only be used as long as the `lookup` remains valid.
+/// 2. The returned iterator must only be used as long as the `lookup` remains [valid].
 /// 3. The caller must treat the returned `current` pointer as pinned. Specifically
 ///    a. Not move (memcpy/memmove) out of the pointer.
 ///    b. The pointed-to value must remain at its original address in memory and never be relocated.

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -611,7 +611,7 @@ pub unsafe extern "C" fn RLookup_Cleanup(lookup: *mut OpaqueRLookup) {
 ///     1. The entire memory range of this `CStr` must be contained within a single allocation!
 ///     2. `key` must be non-null even for a zero-length cstr.
 /// 7. The nul terminator must be within `isize::MAX` from `key`
-/// 8. `open_key`, if non-null, must be a valid, already-open `redis_module::RedisModuleKey` handle for
+/// 8. `open_key`, if non-null, must be a [valid], already-open `redis_module::RedisModuleKey` handle for
 ///    `key` that outlives this call. It is borrowed, not closed here. Pass null to open by name.
 /// 9. `status` must be a [valid], non-null pointer to an `ffi::QueryError` that is properly initialized.
 ///

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -456,9 +456,11 @@ pub unsafe extern "C" fn RLookupRow_SetSortingVector(
 ///
 /// # Safety
 ///
-/// 1. `keys` must point to an array of at least `nkeys` valid, non-null `RLookupKey` pointers.
-/// 2. `h1` and `h2` must be valid, non-null pointers to a `SearchResult`.
-/// 3. `qerr`, when non-null, must be a valid, writable pointer to a `QueryError`.
+/// 1. `keys` must point to an array of at least `nkeys` [valid], non-null `RLookupKey` pointers.
+/// 2. `h1` and `h2` must be [valid], non-null pointers to a `SearchResult`.
+/// 3. `qerr`, when non-null, must be a [valid], writable pointer to a `QueryError`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SearchResult_CmpByFields(
     keys: *const *const RLookupKey,

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn RLookupRow_GetSortingVector(
 ///
 /// 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
 /// 2. `sv` must be either null or a [valid] pointer to an [`sorting_vector::RSSortingVector`].
-///    The pointed-to vector must remain valid for the lifetime of the row.
+///    The pointed-to vector must remain [valid] for the lifetime of the row.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
@@ -132,8 +132,10 @@ where
 ///
 /// # Safety
 ///
-/// The caller must ensure the pointer is valid and points to a properly initialized
+/// The caller must ensure the pointer is [valid] and points to a properly initialized
 /// SlotRangeArray with at least `num_ranges` elements in the flexible array.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn parse_slot_ranges<'a>(ranges: *const SlotRangeArray) -> &'a [SlotRange] {
     debug_assert!(!ranges.is_null(), "SlotRangeArray pointer is null");
 
@@ -169,9 +171,11 @@ unsafe fn parse_slot_ranges<'a>(ranges: *const SlotRangeArray) -> &'a [SlotRange
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_set_local_slots(ranges: *const SlotRangeArray) -> u32 {
     // SAFETY: Caller guarantees valid pointer
@@ -200,9 +204,11 @@ pub unsafe extern "C" fn slots_tracker_set_local_slots(ranges: *const SlotRangeA
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_mark_partially_available_slots(
     ranges: *const SlotRangeArray,
@@ -231,9 +237,11 @@ pub unsafe extern "C" fn slots_tracker_mark_partially_available_slots(
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_promote_to_local_slots(ranges: *const SlotRangeArray) {
     // SAFETY: Caller guarantees valid pointer
@@ -258,9 +266,11 @@ pub unsafe extern "C" fn slots_tracker_promote_to_local_slots(ranges: *const Slo
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_mark_fully_available_slots(ranges: *const SlotRangeArray) {
     // SAFETY: Caller guarantees valid pointer
@@ -282,9 +292,11 @@ pub unsafe extern "C" fn slots_tracker_mark_fully_available_slots(ranges: *const
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_remove_deleted_slots(ranges: *const SlotRangeArray) {
     // SAFETY: Caller guarantees valid pointer
@@ -306,9 +318,11 @@ pub unsafe extern "C" fn slots_tracker_remove_deleted_slots(ranges: *const SlotR
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_has_fully_available_overlap(
     ranges: *const SlotRangeArray,
@@ -377,9 +391,11 @@ fn local_slots_array_layout(num_ranges: usize) -> std::alloc::Layout {
 /// # Safety
 ///
 /// This function must be called from the main thread only.
-/// The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
-/// The ranges array must contain `num_ranges` valid elements.
+/// The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+/// The ranges array must contain `num_ranges` [valid] elements.
 /// All ranges must be sorted and have start <= end, with values in [0, 16383].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slots_tracker_check_availability(
     ranges: *const SlotRangeArray,

--- a/src/redisearch_rs/c_entrypoint/spellcheck_dictionary_ffi/src/iter_cursor.rs
+++ b/src/redisearch_rs/c_entrypoint/spellcheck_dictionary_ffi/src/iter_cursor.rs
@@ -188,6 +188,8 @@ pub struct SpellCheckDictionaryIterator<'scd> {
     /// `# Safety` obligations.
     iter: Box<dyn Iterator<Item = String> + 'scd>,
     /// Keeps the most recently yielded string alive so the pointer
-    /// stays valid until the next advance (or free).
+    /// stays [valid] until the next advance (or free).
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     current: Option<String>,
 }

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_cursor.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_cursor.rs
@@ -131,6 +131,8 @@ pub unsafe extern "C" fn TermSuffixIndexIterator_Free(it: *mut TermSuffixIndexIt
 pub struct TermSuffixIndexIterator<'si> {
     iter: Box<dyn Iterator<Item = String> + 'si>,
     /// Keeps the most recently yielded string alive so the pointer
-    /// stays valid until the next advance (or free).
+    /// stays [valid] until the next advance (or free).
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     current: Option<String>,
 }

--- a/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn LexTrieRs_Free(t: *mut LexTrieRs) {
 /// # Safety
 ///
 /// - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
-///   Redis module command and remain valid for the duration of the call.
+///   Redis module command and remain [valid] for the duration of the call.
 /// - `map` must be a [valid] pointer to a [`LexTrieRs`] (typically obtained
 ///   from [`LexTrieRs_New`] / [`LexTrieRs_RdbLoad`]). It is borrowed
 ///   immutably for the duration of the call; no aliasing mutable
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn LexTrieRs_RdbSave(
 /// # Safety
 ///
 /// - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
-///   Redis module type loader and remain valid for the duration of the
+///   Redis module type loader and remain [valid] for the duration of the
 ///   call.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/trie_rdb_ffi/src/lib.rs
@@ -64,12 +64,14 @@ pub unsafe extern "C" fn LexTrieRs_Free(t: *mut LexTrieRs) {
 ///
 /// # Safety
 ///
-/// - `io` must be a valid `*mut RedisModuleIO` supplied by the calling
+/// - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
 ///   Redis module command and remain valid for the duration of the call.
-/// - `map` must be a valid pointer to a [`LexTrieRs`] (typically obtained
+/// - `map` must be a [valid] pointer to a [`LexTrieRs`] (typically obtained
 ///   from [`LexTrieRs_New`] / [`LexTrieRs_RdbLoad`]). It is borrowed
 ///   immutably for the duration of the call; no aliasing mutable
 ///   references must exist.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn LexTrieRs_RdbSave(
     io: *mut RedisModuleIO,
@@ -101,9 +103,11 @@ pub unsafe extern "C" fn LexTrieRs_RdbSave(
 ///
 /// # Safety
 ///
-/// - `io` must be a valid `*mut RedisModuleIO` supplied by the calling
+/// - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
 ///   Redis module type loader and remain valid for the duration of the
 ///   call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn LexTrieRs_RdbLoad(
     io: *mut RedisModuleIO,

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
@@ -19,11 +19,12 @@ use thin_vec::SmallThinVec;
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
 ///
 /// [`NewTrieMap`]: crate::NewTrieMap
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_FindPrefixes(
     t: *const TrieMap,
@@ -70,7 +71,9 @@ pub extern "C" fn TrieMapResultBuf_Free(buf: TrieMapResultBuf) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+/// - `buf` must point to a [valid] TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapResultBuf_GetByIndex(
     buf: *mut TrieMapResultBuf,
@@ -94,7 +97,9 @@ pub unsafe extern "C" fn TrieMapResultBuf_GetByIndex(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+/// - `buf` must point to a [valid] TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapResultBuf_Len(buf: *mut TrieMapResultBuf) -> usize {
     debug_assert!(!buf.is_null(), "buf cannot be NULL");

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -40,8 +40,10 @@ pub struct TrieMapIterator<'tm> {
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `t` must not be freed while the iterator lives.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Iterate<'tm>(t: *mut TrieMap) -> *mut TrieMapIterator<'tm> {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -71,10 +73,12 @@ pub unsafe extern "C" fn TrieMap_Iterate<'tm>(t: *mut TrieMap) -> *mut TrieMapIt
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `t` must not be freed while the iterator lives.
-/// - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
+/// - `prefix` must point to a [valid] pointer to a byte sequence of length `prefix_len`,
 ///   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateWithFilter<'tm>(
     t: *mut TrieMap,
@@ -127,8 +131,10 @@ pub unsafe extern "C" fn TrieMap_IterateWithFilter<'tm>(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+/// - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
 ///   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, timeout: timespec) {
     debug_assert!(!it.is_null(), "it cannot be NULL");
@@ -156,8 +162,10 @@ pub unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, ti
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+/// - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
 ///   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapIterator_Free(it: *mut TrieMapIterator) {
     debug_assert!(!it.is_null(), "it cannot be NULL");
@@ -174,12 +182,14 @@ pub unsafe extern "C" fn TrieMapIterator_Free(it: *mut TrieMapIterator) {
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+/// - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
 ///   [`TrieMap_IterateWithFilter`] and cannot be NULL.
-/// - `ptr` must point to a valid pointer to a byte sequence, which will be set to the current key. This
+/// - `ptr` must point to a [valid] pointer to a byte sequence, which will be set to the current key. This
 ///   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
-/// - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
-/// - `value` must point to a valid pointer, which will be set to the value of the current key.
+/// - `len` must point to a [valid] `tm_len_t` which will be set to the length of the current key.
+/// - `value` must point to a [valid] pointer, which will be set to the value of the current key.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapIterator_Next(
     it: *mut TrieMapIterator,

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
@@ -58,13 +58,15 @@ pub type TrieMapReplaceFunc =
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-///  - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///  - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 ///  - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 ///  - `len` can be 0. If so, `str` is regarded as an empty string.
 ///  - `value` holds a pointer to the value of the record, which can be NULL
 ///  - `cb` must not free the value it returns
 ///  - The Redis allocator must be initialized before calling this function,
 ///    and `RedisModule_Free` must not get mutated while running this function.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Add(
     t: *mut TrieMap,
@@ -133,13 +135,15 @@ pub unsafe extern "C" fn TrieMap_Add(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
 /// - The value behind the returned pointer must not be destroyed by the caller.
 ///   Use [`TrieMap_Delete`] to remove it instead.
 /// - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
 ///   and the pointer must not be dereferenced.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Find(
     t: *const TrieMap,
@@ -191,10 +195,12 @@ pub type freeCB = Option<unsafe extern "C" fn(*mut c_void)>;
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
-/// - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
+/// - if `func` is not NULL, it must be a [valid] function pointer of the type [`freeCB`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Delete(
     t: *mut TrieMap,
@@ -253,9 +259,11 @@ pub unsafe extern "C" fn TrieMap_Delete(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `func` must either be NULL or a valid pointer to a function of type [`freeCB`].
+/// - `func` must either be NULL or a [valid] pointer to a function of type [`freeCB`].
 /// - The Redis allocator must be initialized before calling this function,
 ///   and `RedisModule_Free` must not get mutated while running this function.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
     if t.is_null() {
@@ -303,7 +311,9 @@ pub unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
@@ -322,7 +332,9 @@ pub unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn TrieMap_NUniqueKeys(t: *const TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
 
@@ -342,7 +354,9 @@ pub unsafe extern "C" fn TrieMap_NUniqueKeys(t: *const TrieMap) -> usize {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn TrieMap_NNodes(t: *const TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
 

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
@@ -198,8 +198,10 @@ pub type freeCB = Option<unsafe extern "C" fn(*mut c_void)>;
 /// - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
-/// - if `func` is not NULL, it must be a [valid] function pointer of the type [`freeCB`].
+/// - if `func` is not NULL, it must be an [ABI-compatible] function pointer of the type
+///   [`freeCB`].
 ///
+/// [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Delete(
@@ -259,11 +261,12 @@ pub unsafe extern "C" fn TrieMap_Delete(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `func` must either be NULL or a [valid] pointer to a function of type [`freeCB`].
+/// - `func` must either be NULL or an [ABI-compatible] pointer to a function of type
+///   [`freeCB`].
 /// - The Redis allocator must be initialized before calling this function,
 ///   and `RedisModule_Free` must not get mutated while running this function.
 ///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+/// [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
     if t.is_null() {

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
@@ -36,8 +36,10 @@ pub type TrieMapRangeCallback =
 /// - `minlen` can be 0. If so, `min` is regarded as an empty string.
 /// - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
 /// - `maxlen` can be 0. If so, `max` is regarded as an empty string.
-/// - `callback` must be a [valid] pointer to a function of type [`TrieMapRangeCallback`]
+/// - `callback` must be an [ABI-compatible] pointer to a function of type
+///   [`TrieMapRangeCallback`]
 ///
+/// [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
 /// [`NewTrieMap`]: crate::NewTrieMap
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
@@ -31,14 +31,15 @@ pub type TrieMapRangeCallback =
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `trie` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `trie` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `min` can be NULL only if `minlen == 0` or `minlen == -1`. It is not necessarily NULL-terminated.
 /// - `minlen` can be 0. If so, `min` is regarded as an empty string.
 /// - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
 /// - `maxlen` can be 0. If so, `max` is regarded as an empty string.
-/// - `callback` must be a valid pointer to a function of type [`TrieMapRangeCallback`]
+/// - `callback` must be a [valid] pointer to a function of type [`TrieMapRangeCallback`]
 ///
 /// [`NewTrieMap`]: crate::NewTrieMap
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateRange(
     trie: *const TrieMap,

--- a/src/redisearch_rs/c_entrypoint/ttl_table_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/ttl_table_ffi/src/lib.rs
@@ -56,7 +56,9 @@ impl<'a> FieldExpirationSlice<'a> {
 /// `max_size` must be ≥ 1, otherwise the function panics
 ///
 /// # Safety
-///  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+///  - `table` must be a [valid], writable `*mut *mut TimeToLiveTable`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_VerifyInit(
     table: *mut *mut TimeToLiveTable,
@@ -76,9 +78,11 @@ pub unsafe extern "C" fn TimeToLiveTable_VerifyInit(
 /// No-op if `*table` is already null.
 ///
 /// # Safety
-///  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+///  - `table` must be a [valid], writable `*mut *mut TimeToLiveTable`.
 ///  - If `*table` is non-null, it must point to a value previously returned
 ///    by [`TimeToLiveTable_VerifyInit`] and not yet destroyed.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_Destroy(table: *mut *mut TimeToLiveTable) {
     debug_assert!(!table.is_null(), "table cannot be NULL");
@@ -98,12 +102,14 @@ pub unsafe extern "C" fn TimeToLiveTable_Destroy(table: *mut *mut TimeToLiveTabl
 /// afterwards.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`] (no
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`] (no
 ///    other reference to it must exist for the duration of the call).
 ///  - `field_expirations` must have been produced by [`FieldExpirations_Empty`]
 ///    or [`FieldExpirations_WithCapacity`] and must be non-empty.
 ///    Sortedness and uniqueness-by-`index` are carried by the type itself.
 ///  - `doc_id` must not already be present in the table.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_Add(
     table: *mut TimeToLiveTable,
@@ -120,8 +126,10 @@ pub unsafe extern "C" fn TimeToLiveTable_Add(
 /// Remove the entry for `doc_id`, if any. No-op if absent.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`] with
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`] with
 ///    no other live references.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_Remove(table: *mut TimeToLiveTable, doc_id: DocId) {
     debug_assert!(!table.is_null(), "table cannot be NULL");
@@ -133,7 +141,9 @@ pub unsafe extern "C" fn TimeToLiveTable_Remove(table: *mut TimeToLiveTable, doc
 /// Returns whether the table holds no entries.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_IsEmpty(table: *const TimeToLiveTable) -> bool {
     debug_assert!(!table.is_null(), "table cannot be NULL");
@@ -149,7 +159,9 @@ pub unsafe extern "C" fn TimeToLiveTable_IsEmpty(table: *const TimeToLiveTable) 
 /// not be freed by the caller.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_GetFieldExpirations<'a>(
     table: *const TimeToLiveTable,
@@ -172,7 +184,9 @@ pub unsafe extern "C" fn TimeToLiveTable_GetFieldExpirations<'a>(
 /// the caller.
 ///
 /// # Safety
-///  - `fields`, when non-null, must point to a valid [`FieldExpirations`].
+///  - `fields`, when non-null, must point to a [valid] [`FieldExpirations`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FieldExpirations_AsSlice<'a>(
     fields: *const FieldExpirations,
@@ -198,8 +212,10 @@ pub unsafe extern "C" fn FieldExpirations_AsSlice<'a>(
 /// Documents with no entry trivially satisfy any predicate and return `true`.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`].
-///  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+///  - `expiration_point` must be a [valid] `*const t_expirationTimePoint`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_FieldSatisfiesPredicate(
     table: *const TimeToLiveTable,
@@ -228,7 +244,7 @@ pub unsafe extern "C" fn TimeToLiveTable_FieldSatisfiesPredicate(
 /// the full [`FieldMask`] width is walked.
 ///
 /// `ft_id_to_field_index` must point to at least
-/// `highest_set_bit(field_mask) + 1` valid `u16` entries.
+/// `highest_set_bit(field_mask) + 1` [valid] `u16` entries.
 /// May be `NULL` when `field_mask == 0`.
 ///
 /// # Returns
@@ -242,9 +258,11 @@ pub unsafe extern "C" fn TimeToLiveTable_FieldSatisfiesPredicate(
 /// Documents with no entry trivially return `true` under either predicate.
 ///
 /// # Safety
-///  - `table` must point to a valid, initialized [`TimeToLiveTable`].
-///  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
+///  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+///  - `expiration_point` must be a [valid] `*const t_expirationTimePoint`.
 ///  - `ft_id_to_field_index` must satisfy the bound above.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TimeToLiveTable_FieldMaskSatisfiesPredicate(
     table: *const TimeToLiveTable,
@@ -285,8 +303,10 @@ pub unsafe extern "C" fn TimeToLiveTable_FieldMaskSatisfiesPredicate(
 /// The current bucket-array length, or `0` if `table` is `NULL`.
 ///
 /// # Safety
-///  - If non-null, `table` must point to a valid, initialized
+///  - If non-null, `table` must point to a [valid], initialized
 ///    [`TimeToLiveTable`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn TimeToLiveTable_NAllocatedBuckets(
     table: *const TimeToLiveTable,
@@ -415,8 +435,10 @@ const fn highest_bit_plus_one_wide(mask: FieldMask) -> usize {
 ///
 /// # Safety
 ///
-/// The caller guarantees `ptr` covers at least `len` valid `u16`
+/// The caller guarantees `ptr` covers at least `len` [valid] `u16`
 /// entries.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[inline]
 unsafe fn build_ft_slice<'a>(ptr: *const u16, len: usize) -> &'a [u16] {
     if len == 0 {

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -28,7 +28,9 @@ pub use inverted_index::{
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+/// - `filter` must point to a [valid] `NumericFilter` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericFilter_Match(filter: *const NumericFilter, value: f64) -> bool {
     debug_assert!(!filter.is_null(), "filter must not be null");
@@ -126,7 +128,7 @@ pub unsafe extern "C" fn NewTokenRecord<'result>(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
 /// - `result` must have been created using one of these:
 ///   - [`NewIntersectResult`]
 ///   - [`NewUnionResult`]
@@ -136,6 +138,8 @@ pub unsafe extern "C" fn NewTokenRecord<'result>(
 ///   - [`NewHybridResult`]
 ///   - [`NewTokenRecord`]
 ///   - [`IndexResult_DeepCopy`]
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_Free(result: *mut RSIndexResult) {
     debug_assert!(!result.is_null(), "result cannot be NULL");
@@ -152,7 +156,9 @@ pub unsafe extern "C" fn IndexResult_Free(result: *mut RSIndexResult) {
 ///
 /// # Safety
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_DeepCopy(source: *const RSIndexResult) -> *mut RSIndexResult {
     // SAFETY: caller is to ensure `source` points to a valid RSIndexResult
@@ -169,7 +175,9 @@ pub unsafe extern "C" fn IndexResult_DeepCopy(source: *const RSIndexResult) -> *
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_IsAggregate(result: *const RSIndexResult) -> bool {
     debug_assert!(!result.is_null(), "result must not be null");
@@ -187,7 +195,9 @@ pub unsafe extern "C" fn IndexResult_IsAggregate(result: *const RSIndexResult) -
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_NumValue(result: *const RSIndexResult) -> f64 {
     debug_assert!(!result.is_null(), "result must not be null");
@@ -205,7 +215,9 @@ pub unsafe extern "C" fn IndexResult_NumValue(result: *const RSIndexResult) -> f
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_SetNumValue(result: *mut RSIndexResult, value: f64) {
     debug_assert!(!result.is_null(), "result must not be null");
@@ -225,7 +237,9 @@ pub unsafe extern "C" fn IndexResult_SetNumValue(result: *mut RSIndexResult, val
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_QueryTermRef<'index>(
     result: *const RSIndexResult<'index>,
@@ -248,7 +262,9 @@ pub unsafe extern "C" fn IndexResult_QueryTermRef<'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_TermOffsetsRef<'result, 'index>(
     result: *const RSIndexResult<'index>,
@@ -276,7 +292,9 @@ pub unsafe extern "C" fn IndexResult_TermOffsetsRef<'result, 'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_AggregateRef<'result, 'index>(
     result: *const RSIndexResult<'index>,
@@ -300,8 +318,10 @@ pub unsafe extern "C" fn IndexResult_AggregateRef<'result, 'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// 1. `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
 /// 2. `result`'s data payload must be of the aggregate kind
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_AggregateRefUnchecked<'result, 'index>(
     result: *const RSIndexResult<'index>,
@@ -327,8 +347,10 @@ pub unsafe extern "C" fn IndexResult_AggregateRefUnchecked<'result, 'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// 1. `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
 /// 2. `result`'s data payload must be of the aggregate kind
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_AggregateRefMutUnchecked<'result, 'index>(
     result: *mut RSIndexResult<'index>,
@@ -350,7 +372,9 @@ pub unsafe extern "C" fn IndexResult_AggregateRefMutUnchecked<'result, 'index>(
 /// # Safety
 ///
 /// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_AggregateReset(result: *mut RSIndexResult) {
     debug_assert!(!result.is_null(), "result must not be null");
@@ -370,7 +394,9 @@ pub unsafe extern "C" fn IndexResult_AggregateReset(result: *mut RSIndexResult) 
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_Get<'result, 'index>(
     agg: *const RSAggregateResult<'index>,
@@ -390,8 +416,10 @@ pub unsafe extern "C" fn AggregateResult_Get<'result, 'index>(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// 1. `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
 /// 2. `index` must be lower than the length of the aggregate result children vector.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_GetUnchecked<'result, 'index>(
     agg: *const RSAggregateResult<'index>,
@@ -413,9 +441,11 @@ pub unsafe extern "C" fn AggregateResult_GetUnchecked<'result, 'index>(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// 1. `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
 /// 2. `index` must be lower than the length of the aggregate result children vector.
 /// 3. `agg` must be of the `Owned` variant.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_GetMutUnchecked<'result, 'index>(
     agg: *mut RSAggregateResult<'index>,
@@ -445,7 +475,9 @@ pub unsafe extern "C" fn AggregateResult_GetMutUnchecked<'result, 'index>(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
     debug_assert!(!agg.is_null(), "agg must not be null");
@@ -462,7 +494,9 @@ pub unsafe extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResu
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
     debug_assert!(!agg.is_null(), "agg must not be null");
@@ -479,7 +513,9 @@ pub unsafe extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult)
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_KindMask(agg: *const RSAggregateResult) -> u8 {
     debug_assert!(!agg.is_null(), "agg must not be null");
@@ -533,8 +569,10 @@ pub extern "C" fn AggregateResult_Free(agg: RSAggregateResult) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `parent` must point to a valid `RSIndexResult` and cannot be NULL.
-/// - `child` must point to a valid `RSIndexResult` and cannot be NULL.
+/// - `parent` must point to a [valid] `RSIndexResult` and cannot be NULL.
+/// - `child` must point to a [valid] `RSIndexResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_AddChild(
     parent: *mut RSIndexResult<'static>,
@@ -562,7 +600,9 @@ pub unsafe extern "C" fn AggregateResult_AddChild(
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_GetRecordsSlice(
     agg: *const RSAggregateResult<'static>,
@@ -603,9 +643,11 @@ pub struct AggregateRecordsSlice {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+/// - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
 ///   and cannot be NULL.
 /// - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_GetData(
     offsets: *const RSOffsetSlice,
@@ -633,10 +675,12 @@ pub unsafe extern "C" fn RSOffsetVector_GetData(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+/// - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
 ///   and cannot be NULL.
 /// - `data` must point to an array of `len` offsets.
 /// - if `data` is NULL then `len` should be 0.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_SetData(
     offsets: *mut RSOffsetSlice,
@@ -667,9 +711,11 @@ pub unsafe extern "C" fn RSOffsetVector_SetData(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+/// - `offsets` must point to a [valid] [`RSOffsetVector`] and cannot be NULL.
 /// - The data pointer of `offsets` had been allocated via the global allocator
 ///   and points to an array matching the length of `offsets`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_FreeData(offsets: *mut RSOffsetVector) {
     debug_assert!(!offsets.is_null(), "offsets must not be null");
@@ -690,10 +736,12 @@ pub unsafe extern "C" fn RSOffsetVector_FreeData(offsets: *mut RSOffsetVector) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `dest` must point to a valid [`RSOffsetVector`] and cannot be NULL.
-/// - `src` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+/// - `dest` must point to a [valid] [`RSOffsetVector`] and cannot be NULL.
+/// - `src` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
 ///   and cannot be NULL.
-/// - `src` data should point to a valid array of `src.len` offsets.
+/// - `src` data should point to a [valid] array of `src.len` offsets.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_CopyData(
     dest: *mut RSOffsetVector,
@@ -716,8 +764,10 @@ pub unsafe extern "C" fn RSOffsetVector_CopyData(
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+/// - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
 ///   and cannot be NULL.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_Len(offsets: *const RSOffsetSlice) -> u32 {
     debug_assert!(!offsets.is_null(), "offsets must not be null");

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -564,7 +564,7 @@ pub extern "C" fn AggregateResult_Free(agg: RSAggregateResult) {
 ///
 /// **Borrowed aggregates:** When `parent.is_copy()` is false, the parent
 /// stores a borrowed reference to `child`. The caller retains ownership
-/// and must ensure `child` remains valid for the lifetime of `parent`.
+/// and must ensure `child` remains [valid] for the lifetime of `parent`.
 ///
 /// # Safety
 ///

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/array.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/array.rs
@@ -41,7 +41,9 @@ pub unsafe extern "C" fn RSValue_NewArrayBuilder(len: u32) -> *mut *mut RSValue 
 ///
 /// 1. `values` must have been allocated via [`RSValue_NewArrayBuilder`] with
 ///    a capacity equal to `len`.
-/// 2. All `len` entries in `values` must have been filled with valid [`RSValue`] pointers.
+/// 2. All `len` entries in `values` must have been filled with [valid] [`RSValue`] pointers.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_NewArrayFromBuilder(
     values: *mut *mut RSValue,

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn RSValue_NewString(str: *mut c_char, len: u32) -> *mut R
 /// 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
 /// 2. A nul-terminator is expected in memory at `str+len`.
 /// 3. The size determined by `len` excludes the nul-terminator.
-/// 4. The memory pointed to by `str` must remain valid and not be mutated for the entire
+/// 4. The memory pointed to by `str` must remain [valid] and not be mutated for the entire
 ///    lifetime of the returned [`RSValue`] and any clones of it.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
@@ -245,7 +245,9 @@ pub extern "C" fn RSValue_NewNumberFromInt64(number: i64) -> *mut RSValue {
 ///
 /// # Safety
 ///
-/// 1. `src` must point to a valid [`RSValue`].
+/// 1. `src` must point to a [valid] [`RSValue`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_NewReference(src: *const RSValue) -> *mut RSValue {
     // SAFETY: ensured by caller (1.)

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/map.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/map.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn RSValue_NewMapBuilder(len: u32) -> *mut RSValueMapBuild
 ///
 /// # Safety
 ///
-/// 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
+/// 1. `map` must be a [valid] pointer to an [`RSValueMapBuilder`] created by
 ///    [`RSValue_NewMapBuilder`].
 /// 2. `key` and `value` must be [valid], non-null pointers to [`RSValue`]s.
 ///
@@ -74,9 +74,11 @@ pub unsafe extern "C" fn RSValue_MapBuilderSetEntry(
 ///
 /// # Safety
 ///
-/// 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
+/// 1. `map` must be a [valid] pointer to an [`RSValueMapBuilder`] created by
 ///    [`RSValue_NewMapBuilder`].
 /// 2. All entries in the map must have been initialized via [`RSValue_MapBuilderSetEntry`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_NewMapFromBuilder(map: *mut RSValueMapBuilder) -> *mut RSValue {
     // Safety: ensured by caller (1.)
@@ -133,7 +135,7 @@ pub unsafe extern "C" fn RSValue_Map_Len(map: *const RSValue) -> u32 {
 /// # Safety
 ///
 /// 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
-/// 2. `key` and `value` must be valid, non-null pointers to writable
+/// 2. `key` and `value` must be [valid], non-null pointers to writable
 ///    `*mut RSValue` locations.
 ///
 /// # Panics

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/setters.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/setters.rs
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn RSValue_SetString(value: *mut RSValue, str: *mut c_char
 /// 3. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
 /// 4. A nul-terminator is expected in memory at `str+len`.
 /// 5. The size determined by `len` excludes the nul-terminator.
-/// 6. The memory pointed to by `str` must remain valid and not be mutated for the entire
+/// 6. The memory pointed to by `str` must remain [valid] and not be mutated for the entire
 ///    lifetime of the returned [`RSValue`] and any clones of it.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/util.rs
@@ -26,7 +26,9 @@ use value::{SharedValue, Value};
 ///
 /// # Safety
 ///
-/// 1. If non-null, `value` must point to a valid [`Value`].
+/// 1. If non-null, `value` must point to a [valid] [`Value`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub const unsafe fn try_value<'a>(value: *const RSValue) -> Option<&'a Value> {
     // SAFETY: ensured by caller (1.)
     unsafe { value.cast::<Value>().as_ref() }
@@ -40,7 +42,9 @@ pub const unsafe fn try_value<'a>(value: *const RSValue) -> Option<&'a Value> {
 ///
 /// # Safety
 ///
-/// 1. `value` must point to a valid [`RSValue`].
+/// 1. `value` must point to a [valid] [`RSValue`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub(crate) const unsafe fn expect_value<'a>(value: *const RSValue) -> &'a Value {
     // SAFETY: ensured by caller (1.)
     let value = unsafe { try_value(value) };
@@ -63,7 +67,9 @@ pub(crate) const unsafe fn expect_value<'a>(value: *const RSValue) -> &'a Value 
 ///
 /// # Safety
 ///
-/// 1. `value` must point to a valid [`RSValue`].
+/// 1. `value` must point to a [valid] [`RSValue`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub(crate) unsafe fn expect_shared_value(value: *const RSValue) -> ManuallyDrop<SharedValue> {
     if cfg!(debug_assertions) && value.is_null() {
         panic!("value must not be null");
@@ -82,8 +88,10 @@ pub(crate) unsafe fn expect_shared_value(value: *const RSValue) -> ManuallyDrop<
 ///
 /// # Safety
 ///
-/// 1. `value` must be a valid pointer obtained from [`into_rs_value`] and must
+/// 1. `value` must be a [valid] pointer obtained from [`into_rs_value`] and must
 ///    not be used again after this call.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub const unsafe fn into_shared_value(value: *mut RSValue) -> SharedValue {
     // SAFETY: ensured by caller (1.)
     unsafe { SharedValue::from_raw(value.cast_const().cast()) }
@@ -97,8 +105,10 @@ pub const unsafe fn into_shared_value(value: *mut RSValue) -> SharedValue {
 ///
 /// # Safety
 ///
-/// 1. `value` must point to a valid [`RSValue`] and must remain live for as
+/// 1. `value` must point to a [valid] [`RSValue`] and must remain live for as
 ///    long as the returned borrow is used.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub const unsafe fn as_shared_value(value: *const RSValue) -> ManuallyDrop<SharedValue> {
     // SAFETY: ensured by caller (1.)
     let shared_value = unsafe { SharedValue::from_raw(value.cast()) };

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/string.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/string.rs
@@ -42,7 +42,9 @@ fn rm_alloc_cstring(s: &str) -> (*mut c_char, u32) {
 ///
 /// # Safety
 ///
-/// `ptr` must be a valid owned pointer obtained from an `RSValue_*` constructor.
+/// `ptr` must be a [valid] owned pointer obtained from an `RSValue_*` constructor.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 unsafe fn drop_value(ptr: *mut RSValue) {
     drop(unsafe { into_shared_value(ptr) });
 }

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
@@ -19,8 +19,10 @@ use varint::VarintEncode;
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
+/// 1. `b` must point to a [valid] `BufferReader` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer reader.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ReadVarintFieldMask(b: *mut BufferReader) -> FieldMask {
     // Safety: Safe thanks to invariants 1. and 2.
@@ -39,8 +41,10 @@ pub unsafe extern "C" fn ReadVarintFieldMask(b: *mut BufferReader) -> FieldMask 
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+/// 1. `writer` must point to a [valid] `BufferWriter` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer writer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn WriteVarintFieldMask(
     value: FieldMask,

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/value.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/value.rs
@@ -19,8 +19,10 @@ use varint::VarintEncode;
 ///
 /// # Safety
 /// The following invariants must be upheld when calling this function:
-/// 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
+/// 1. `b` must point to a [valid] `BufferReader` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer reader.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn ReadVarint(b: *mut BufferReader) -> u32 {
     // Safety: Safe thanks to invariants 1. and 2.
     let buffer_reader = unsafe { b.as_mut() }.expect("b must not be NULL");
@@ -38,8 +40,10 @@ pub unsafe extern "C" fn ReadVarint(b: *mut BufferReader) -> u32 {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+/// 1. `writer` must point to a [valid] `BufferWriter` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer writer.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn WriteVarint(value: u32, writer: *mut BufferWriter) -> usize {
     // Safety: Safe thanks to invariants 1. and 2.

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
@@ -26,8 +26,10 @@ pub extern "C" fn NewVarintVectorWriter(cap: usize) -> *mut VectorWriter {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VVW_Write(writer: *mut VectorWriter, value: u32) -> usize {
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
@@ -41,7 +43,9 @@ pub unsafe extern "C" fn VVW_Write(writer: *mut VectorWriter, value: u32) -> usi
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VVW_GetByteData(writer: *const VectorWriter) -> *const u8 {
     if writer.is_null() {
@@ -58,7 +62,9 @@ pub unsafe extern "C" fn VVW_GetByteData(writer: *const VectorWriter) -> *const 
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn VVW_GetByteLength(writer: *const VectorWriter) -> usize {
     if writer.is_null() {
@@ -75,7 +81,9 @@ pub const unsafe extern "C" fn VVW_GetByteLength(writer: *const VectorWriter) ->
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub const unsafe extern "C" fn VVW_GetCount(writer: *const VectorWriter) -> usize {
     if writer.is_null() {
@@ -93,8 +101,10 @@ pub const unsafe extern "C" fn VVW_GetCount(writer: *const VectorWriter) -> usiz
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VVW_Reset(writer: *mut VectorWriter) {
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
@@ -110,8 +120,10 @@ pub unsafe extern "C" fn VVW_Reset(writer: *mut VectorWriter) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn VVW_Free(writer: *mut VectorWriter) {
     assert!(!writer.is_null(), "writer must not be NULL");
     // Safety: The pointer is leaked in `NewVectorWriter`, so we can safely drop it here.
@@ -124,8 +136,10 @@ pub unsafe extern "C" fn VVW_Free(writer: *mut VectorWriter) {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn VVW_Truncate(writer: *mut VectorWriter) -> usize {
     // Safety: The preconditions are met, thanks to safety invariants 1. and 2.
     let writer = unsafe { writer.as_mut() }.expect("writer must not be NULL");
@@ -140,9 +154,11 @@ pub unsafe extern "C" fn VVW_Truncate(writer: *mut VectorWriter) -> usize {
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+/// 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
 /// 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
 /// 3. `len` cannot be NULL and the caller must have exclusive access to it.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 pub unsafe extern "C" fn VVW_TakeByteData(writer: *mut VectorWriter, len: *mut usize) -> *mut u8 {
     if writer.is_null() {
         return std::ptr::null_mut();

--- a/src/redisearch_rs/headers/fnv_ffi.h
+++ b/src/redisearch_rs/headers/fnv_ffi.h
@@ -17,10 +17,11 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `buf` must point to a valid region of memory of length `len`.
+ * 1. `buf` must point to a [valid] region of memory of length `len`.
  *
  * [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
  * [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint64_t fnv_64a_buf(const void *buf, size_t len, uint64_t hval);
 
@@ -29,10 +30,11 @@ uint64_t fnv_64a_buf(const void *buf, size_t len, uint64_t hval);
  *
  * # Safety
  *
- * 1. `buf` must point to a valid region of memory of length `len`.
+ * 1. `buf` must point to a [valid] region of memory of length `len`.
  *
  * [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
  * [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t rs_fnv_32a_buf(const void *buf, size_t len, uint32_t hval);
 

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -53,7 +53,8 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
  * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
  * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
@@ -76,7 +77,8 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
  *
  * # Safety
  *
- * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
  * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
  * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
@@ -99,7 +101,8 @@ void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
  *
  * # Safety
  *
- * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
  * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
  * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
@@ -107,6 +110,31 @@ void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
+
+/**
+ * Collect GC delta data for every term in the spec's terms trie and send it
+ * to the parent process over the pipe.
+ *
+ * Walks the terms trie, and for each term with a non-null `InvertedIndex`
+ * attempts a GC scan. When a scan produces a delta the term header (its raw
+ * bytes) followed by the serialised GC delta is sent. Terms that produce no
+ * delta or fail the scan are skipped. A terminator is sent once every term
+ * has been processed.
+ *
+ * Any write failure, such as a closed fd or a broken pipe, terminates the
+ * child process via `RedisModule_ExitFromChild`.
+ *
+ * # Safety
+ *
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
+ * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
+ * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx);
 
 /**
  * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
@@ -174,6 +202,25 @@ enum FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum FGCError FGC_parentHandleNumeric(ForkGC *gc);
+
+/**
+ * Receive and apply the GC delta for one term in the spec's terms trie.
+ *
+ * Reads one protocol frame from the pipe. Returns [`FGCError::Collected`] after
+ * successfully applying a delta, [`FGCError::Done`] when the child sent a
+ * terminator (all terms processed), or an error variant on pipe or spec failure.
+ *
+ * Called in a loop (via `COLLECT_FROM_CHILD`) until it returns something other
+ * than [`FGCError::Collected`].
+ *
+ * # Safety
+ *
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum FGCError FGC_parentHandleTerms(ForkGC *gc);
 
 /**
  * Read a length-prefixed buffer frame from the FGC pipe.

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -53,11 +53,12 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
- *    alive for the duration of this call.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
@@ -75,11 +76,12 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
- *    alive for the duration of this call.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
@@ -97,36 +99,14 @@ void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
- *    alive for the duration of this call.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`].
+ * 2. `sctx` must point to a [valid] [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a [valid] [`ffi::IndexSpec`].
  * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
-
-/**
- * Collect GC delta data for every term in the spec's terms trie and send it
- * to the parent process over the pipe.
- *
- * Walks the terms trie, and for each term with a non-null `InvertedIndex`
- * attempts a GC scan. When a scan produces a delta the term header (its raw
- * bytes) followed by the serialised GC delta is sent. Terms that produce no
- * delta or fail the scan are skipped. A terminator is sent once every term
- * has been processed.
- *
- * Any write failure, such as a closed fd or a broken pipe, terminates the
- * child process via `RedisModule_ExitFromChild`.
- *
- * # Safety
- *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
- *    alive for the duration of this call.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
- * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
- */
-void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx);
 
 /**
  * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
@@ -150,8 +130,10 @@ void FGC_freeBuffer(void *buf, size_t len);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
  *    alive for the duration of this call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
 
@@ -167,8 +149,10 @@ enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
  *    alive for the duration of this call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
 
@@ -184,27 +168,12 @@ enum FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+ * 1. `gc` must point to a [valid] [`ffi::ForkGC`], with no other reference to it
  *    alive for the duration of this call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum FGCError FGC_parentHandleNumeric(ForkGC *gc);
-
-/**
- * Receive and apply the GC delta for one term in the spec's terms trie.
- *
- * Reads one protocol frame from the pipe. Returns [`FGCError::Collected`] after
- * successfully applying a delta, [`FGCError::Done`] when the child sent a
- * terminator (all terms processed), or an error variant on pipe or spec failure.
- *
- * Called in a loop (via `COLLECT_FROM_CHILD`) until it returns something other
- * than [`FGCError::Collected`].
- *
- * # Safety
- *
- * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
- *    alive for the duration of this call.
- */
-enum FGCError FGC_parentHandleTerms(ForkGC *gc);
 
 /**
  * Read a length-prefixed buffer frame from the FGC pipe.
@@ -222,10 +191,12 @@ enum FGCError FGC_parentHandleTerms(ForkGC *gc);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an
  *    open, readable file descriptor.
  * 2. `buf` and `len` must point to writable `void*` and `size_t`
  *    locations respectively.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
 
@@ -238,9 +209,11 @@ int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an open,
  *    readable file descriptor.
  * 2. `buf` must point to a writable region of at least `len` bytes.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
 
@@ -253,11 +226,13 @@ int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
  *    writable file descriptor.
  * 2. If `len > 0`, `buff` must point to a readable region of at least
  *    `len` bytes. When `len == 0`, `buff` is unused and may be anything
  *    (including NULL).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len);
 
@@ -269,10 +244,12 @@ void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
  *    writable file descriptor.
  * 2. `buff` must point to a readable region of at least `len` bytes.
  * 3. `len` must be greater than zero.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
 
@@ -285,8 +262,10 @@ void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_write_fd` is an open,
  *    writable file descriptor.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void FGC_sendTerminator(ForkGC *fgc);
 
@@ -300,11 +279,13 @@ void FGC_sendTerminator(ForkGC *fgc);
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+ * 1. `fgc` must point to a [valid] `ForkGC` whose `pipe_read_fd` is an open,
  *    readable file descriptor.
  * 2. `field_name` and `field_name_len` must point to writable `char*` and
  *    `size_t` locations respectively.
  * 3. `id_ptr` must point to a writable `uint64_t` location.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id_ptr);
 

--- a/src/redisearch_rs/headers/geo_ffi.h
+++ b/src/redisearch_rs/headers/geo_ffi.h
@@ -53,7 +53,9 @@ extern "C" {
  *
  * # Safety
  *
- * - `xy` must be a valid, non-null pointer to a writable `[f64; 2]`.
+ * - `xy` must be a [valid], non-null pointer to a writable `[f64; 2]`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void decodeGeo(double bits, double *xy);
 
@@ -89,7 +91,9 @@ double geohashGetDistance(double lon1, double lat1, double lon2, double lat2);
  *
  * # Safety
  *
- * - `distance` must be either null or a valid pointer to a writable `f64`.
+ * - `distance` must be either null or a [valid] pointer to a writable `f64`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool isWithinRadiusLonLat(double lon1, double lat1, double lon2, double lat2, double radius, double *distance);
 
@@ -103,10 +107,12 @@ bool isWithinRadiusLonLat(double lon1, double lat1, double lon2, double lat2, do
  *
  * # Safety
  *
- * - `c` must be a valid pointer to at least `len` bytes.
- * - `lon` and `lat` must be valid, non-null pointers to writable `f64` values.
- * - `status` must be a valid, non-null pointer to an [`OpaqueQueryError`]
+ * - `c` must be a [valid] pointer to at least `len` bytes.
+ * - `lon` and `lat` must be [valid], non-null pointers to writable `f64` values.
+ * - `status` must be a [valid], non-null pointer to an [`OpaqueQueryError`]
  *   created by `QueryError_Default`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int parseGeo(const uint8_t *c, size_t len, double *lon, double *lat, struct QueryError *status);
 

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -87,7 +87,9 @@ extern "C" {
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `gc_scan_delta` must be a valid, non NULL, pointer to a `GcScanDelta` instance.
+ * - `gc_scan_delta` must be a [valid], non NULL, pointer to a `GcScanDelta` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t GcScanDelta_LastBlockIdx(const struct InvertedIndexGcDelta *gc_scan_delta);
 
@@ -97,7 +99,9 @@ size_t GcScanDelta_LastBlockIdx(const struct InvertedIndexGcDelta *gc_scan_delta
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const char *IndexBlock_Data(const struct IndexBlock *ib);
 
@@ -107,7 +111,9 @@ const char *IndexBlock_Data(const struct IndexBlock *ib);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 t_docId IndexBlock_FirstId(const struct IndexBlock *ib);
 
@@ -117,7 +123,9 @@ t_docId IndexBlock_FirstId(const struct IndexBlock *ib);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 t_docId IndexBlock_LastId(const struct IndexBlock *ib);
 
@@ -127,7 +135,9 @@ t_docId IndexBlock_LastId(const struct IndexBlock *ib);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ib` must be a [valid] pointer to an `IndexBlock` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint16_t IndexBlock_NumEntries(const struct IndexBlock *ib);
 
@@ -137,7 +147,9 @@ uint16_t IndexBlock_NumEntries(const struct IndexBlock *ib);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 IndexFlags IndexReader_Flags(const struct IndexReader *ir);
 
@@ -147,8 +159,10 @@ IndexFlags IndexReader_Flags(const struct IndexReader *ir);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance created using
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance created using
  *   [`NewIndexReader`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexReader_Free(struct IndexReader *ir);
 
@@ -158,7 +172,9 @@ void IndexReader_Free(struct IndexReader *ir);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_HasMulti(const struct IndexReader *ir);
 
@@ -168,8 +184,10 @@ bool IndexReader_HasMulti(const struct IndexReader *ir);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ * - `ii` must be either NULL or a [valid] pointer to an `InvertedIndex` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
 
@@ -181,7 +199,9 @@ bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedInde
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_NeedsRevalidation(struct IndexReader *ir);
 
@@ -193,8 +213,10 @@ bool IndexReader_NeedsRevalidation(struct IndexReader *ir);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a [valid] pointer to an `RSIndexResult` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
 
@@ -204,7 +226,9 @@ bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint64_t IndexReader_NumEstimated(const struct IndexReader *ir);
 
@@ -215,7 +239,9 @@ uint64_t IndexReader_NumEstimated(const struct IndexReader *ir);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct NumericFilter *IndexReader_NumericFilter(const struct IndexReader *ir);
 
@@ -225,7 +251,9 @@ const struct NumericFilter *IndexReader_NumericFilter(const struct IndexReader *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexReader_Reset(struct IndexReader *ir);
 
@@ -238,8 +266,10 @@ void IndexReader_Reset(struct IndexReader *ir);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a [valid] pointer to an `RSIndexResult` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, RSIndexResult *res);
 
@@ -252,7 +282,9 @@ bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, RSIndexResult *res
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ir` must be a [valid], non NULL, pointer to an `IndexReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
 
@@ -268,10 +300,12 @@ bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- * - `deltas` must be a valid, non NULL, pointer to a `GcScanDelta` instance created using
+ * - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+ * - `deltas` must be a [valid], non NULL, pointer to a `GcScanDelta` instance created using
  *   [`InvertedIndex_GcDelta_Read`].
- * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
+ * - `apply_info` must be a [valid], non NULL, pointer to a `GcApplyInfo` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
 
@@ -281,7 +315,9 @@ void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGc
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct IndexBlock *InvertedIndex_BlockRef(const struct InvertedIndex *ii, size_t block_idx);
 
@@ -292,8 +328,10 @@ const struct IndexBlock *InvertedIndex_BlockRef(const struct InvertedIndex *ii, 
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- * - `count` must be a valid pointer to a `usize` and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `count` must be a [valid] pointer to a `usize` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct IIBlockSummary *InvertedIndex_BlocksSummary(const struct InvertedIndex *ii, size_t *count);
 
@@ -302,10 +340,12 @@ struct IIBlockSummary *InvertedIndex_BlocksSummary(const struct InvertedIndex *i
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `blocks` must be a valid pointer to an array of `BlockSummary` instances returned by
+ * - `blocks` must be a [valid] pointer to an array of `BlockSummary` instances returned by
  *   [`InvertedIndex_BlocksSummary`].
  * - `count` must have the same value as the `count` output parameter passed to
  *   [`InvertedIndex_BlocksSummary`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void InvertedIndex_BlocksSummaryFree(struct IIBlockSummary *blocks, size_t count);
 
@@ -315,7 +355,9 @@ void InvertedIndex_BlocksSummaryFree(struct IIBlockSummary *blocks, size_t count
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 t_fieldMask InvertedIndex_FieldMask(const struct InvertedIndex *ii);
 
@@ -324,7 +366,9 @@ t_fieldMask InvertedIndex_FieldMask(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 IndexFlags InvertedIndex_Flags(const struct InvertedIndex *ii);
 
@@ -333,8 +377,10 @@ IndexFlags InvertedIndex_Flags(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance created using
+ * - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance created using
  *   [`NewInvertedIndex_Ex`] or `NewInvertedIndex`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void InvertedIndex_Free(struct InvertedIndex *ii);
 
@@ -344,8 +390,10 @@ void InvertedIndex_Free(struct InvertedIndex *ii);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `deltas` must be a valid pointer to a `GcScanDelta` instance created using
+ * - `deltas` must be a [valid] pointer to a `GcScanDelta` instance created using
  *   [`InvertedIndex_GcDelta_Read`], or NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
 
@@ -356,7 +404,9 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `rd` must be a valid, non NULL, pointer to an `InvertedIndexGCReader` instance.
+ * - `rd` must be a [valid], non NULL, pointer to an `InvertedIndexGCReader` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct InvertedIndexGcDelta *InvertedIndex_GcDelta_Read(struct II_GCReader *rd);
 
@@ -367,12 +417,14 @@ struct InvertedIndexGcDelta *InvertedIndex_GcDelta_Read(struct II_GCReader *rd);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `wr` must be a valid, non NULL, pointer to an `InvertedIndexGCWriter` instance.
- * - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
- * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- * - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
- * - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
+ * - `wr` must be a [valid], non NULL, pointer to an `InvertedIndexGCWriter` instance.
+ * - `sctx` must be a [valid], non NULL, pointer to a `RedisSearchCtx` instance.
+ * - `idx` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+ * - `cb` must be a [valid], non NULL, pointer to an `InvertedIndexGCCallback` instance.
+ * - The `spec` field of the `RedisSearchCtx` must be a [valid], non NULL, pointer to an
  *   `IndexSpec` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, struct InvertedIndex *idx, struct II_GCCallback *cb);
 
@@ -382,7 +434,9 @@ bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, st
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t InvertedIndex_GcMarker(const struct InvertedIndex *ii);
 
@@ -392,7 +446,9 @@ uint32_t InvertedIndex_GcMarker(const struct InvertedIndex *ii);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
 
@@ -402,7 +458,9 @@ void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
 
@@ -411,7 +469,9 @@ t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and must not be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and must not be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 
@@ -420,7 +480,9 @@ size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t InvertedIndex_NumBlocks(const struct InvertedIndex *ii);
 
@@ -429,7 +491,9 @@ size_t InvertedIndex_NumBlocks(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
 
@@ -439,7 +503,9 @@ uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
 
@@ -448,7 +514,9 @@ size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct IISummary InvertedIndex_Summary(const struct InvertedIndex *ii);
 
@@ -457,8 +525,10 @@ struct IISummary InvertedIndex_Summary(const struct InvertedIndex *ii);
  * memory growth and the number of new index blocks created.
  *
  * # Safety
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `record` must be a [valid] pointer to an `RSIndexResult` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const RSIndexResult *record);
 
@@ -468,7 +538,9 @@ struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii
  * growth and the number of new index blocks created.
  *
  * # Safety
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a [valid] pointer to an `InvertedIndex` instance and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
 
@@ -479,10 +551,12 @@ struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `ii` must be a [valid], non NULL, pointer to an `InvertedIndex` instance.
  *
  * # Panics
  * This function will panic if the provided filter is not compatible with the `InvertedIndex` type.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, union IndexDecoderCtx ctx);
 
@@ -499,7 +573,7 @@ struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, union IndexDe
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `mem_size` must be a valid pointer to a `usize`.
+ * - `mem_size` must be a [valid] pointer to a `usize`.
  *
  * # Panics
  * This function will panic if the provided flags does not set at least one of the following
@@ -509,6 +583,8 @@ struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, union IndexDe
  * - `StoreTermOffsets`
  * - `StoreNumeric`
  * - `DocIdsOnly`
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct InvertedIndex *NewInvertedIndex_Ex(IndexFlags flags, bool raw_doc_id_encoding, bool compress_floats, size_t *mem_size);
 

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -20,6 +20,10 @@
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.
 typedef struct timespec timespec;
+// `AREQ` is forward-declared as a struct tag in `query.h` (above) but its
+// typedef lives in `aggregate/aggregate.h`. cheadergen emits `*mut ffi::AREQ`
+// as the bare `AREQ *`, so we surface the typedef here for the C compiler.
+typedef struct AREQ AREQ;
 
 
 /**
@@ -160,8 +164,10 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
- * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
+ * 1. `header` must be a [valid] non-null pointer created via [`NewIntersectionIterator()`].
+ * 2. `child` must be a [valid] non-null pointer to a `QueryIterator`, not aliased.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
 
@@ -185,9 +191,11 @@ void GeoFilter_FreeNumericFilters(NumericFilter * *filters);
  *
  * # Safety
  *
- * 1. `self_` must be a valid pointer to a Hybrid iterator.
- * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
- * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+ * 1. `self_` must be a [valid] pointer to a Hybrid iterator.
+ * 2. `map` must be a [valid] pointer to a [`redis_reply::MapBuilder`].
+ * 3. `ctx` must be a [valid] pointer to a [`ProfilePrintCtx`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void Hybrid_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
 
@@ -201,8 +209,10 @@ void Hybrid_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, str
  *
  * # Safety
  *
- * 1. `iter` must be a valid non-null pointer to an implementation of the C query iterator API.
+ * 1. `iter` must be a [valid] non-null pointer to an implementation of the C query iterator API.
  * 2. `iter` must not be aliased.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *IntoProfiled(QueryIterator *iter);
 
@@ -211,7 +221,9 @@ QueryIterator *IntoProfiled(QueryIterator *iter);
  *
  * # Safety
  *
- * `it`, when non-null, must point to a valid [`QueryIterator`].
+ * `it`, when non-null, must point to a [valid] [`QueryIterator`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IsWildcardIterator(const QueryIterator *it);
 
@@ -230,14 +242,16 @@ QueryIterator *NewEmptyIterator(void);
  *
  * # Safety
  *
- * 1. `ctx` must be a valid non-NULL pointer to a `RedisSearchCtx`, remaining valid for the
+ * 1. `ctx` must be a [valid] non-NULL pointer to a `RedisSearchCtx`, remaining [valid] for the
  *    lifetime of all returned iterators.
- * 2. `ctx.spec` must be a valid non-NULL pointer to an `IndexSpec`.
- * 3. `gf` must be a valid non-NULL pointer to a `GeoFilter`.
- *    - `gf.fieldSpec` must be a valid non-NULL pointer to a `FieldSpec`.
+ * 2. `ctx.spec` must be a [valid] non-NULL pointer to an `IndexSpec`.
+ * 3. `gf` must be a [valid] non-NULL pointer to a `GeoFilter`.
+ *    - `gf.fieldSpec` must be a [valid] non-NULL pointer to a `FieldSpec`.
  *    - `gf.numericFilters` must be NULL on entry; it is populated by this function and
  *      freed by `GeoFilter_Free`.
- * 4. `config` must be a valid non-NULL pointer to an `IteratorsConfig`.
+ * 4. `config` must be a [valid] non-NULL pointer to an `IteratorsConfig`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, const struct IteratorsConfig *config);
 
@@ -256,19 +270,21 @@ QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, con
  *
  * # Safety
  *
- * 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
- *    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
+ * 1. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
+ *    `spec` is a [valid] [`IndexSpec`](ffi::IndexSpec); both must outlive the
  *    returned iterator, and `sctx` must stay at a stable address for that
- *    whole window: the iterator reads the request-owned deadline back on every
+ *    whole window: the iterator reads `sctx.time.timeout` back on every
  *    timeout probe. No write to that deadline may overlap a probe.
- * 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
+ * 2. `filter_ctx` must be a non-null pointer to a [valid] [`FieldFilterContext`].
  * 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
  *    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`
  *    is null, `num` must be zero.
- * 4. `allocated`, when non-null, must point to a valid, initialized `usize`
+ * 4. `allocated`, when non-null, must point to a [valid], initialized `usize`
  *    (it is read-modify-written) that outlives the iterator and is only
  *    accessed single-threaded (it is mutated without synchronization, which
  *    holds under the spec lock).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewGeometryQueryIterator(const RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx, t_docId *ids, size_t num, size_t *allocated);
 
@@ -287,10 +303,12 @@ QueryIterator *NewGeometryQueryIterator(const RedisSearchCtx *sctx, const struct
  *
  * # Safety
  *
- * 1. `its` must be a valid non-null pointer to an array of `num` `QueryIterator*` values,
+ * 1. `its` must be a [valid] non-null pointer to an array of `num` `QueryIterator*` values,
  *    allocated with the Redis allocator (`rm_malloc`). Ownership is transferred to this function.
- * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose callbacks are set.
+ * 2. Every non-null pointer in `its` must be a [valid] `QueryIterator` whose callbacks are set.
  * 3. Null entries in `its` are treated as empty iterators.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t max_slop, bool in_order, double weight);
 
@@ -311,14 +329,16 @@ QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t
  *
  * The following invariants must be upheld when calling this function:
  *
- * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ * 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
  *    mechanism detects when the index has been replaced via `spec.missingFieldDict`
  *    lookup.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
  * 5. `field_index` must be a valid index into `sctx.spec.fields`.
- * 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+ * 6. `sctx.spec.missingFieldDict` must be a non-null, [valid] dict pointer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex field_index);
 
@@ -345,17 +365,19 @@ QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const Re
  *
  * The following invariants must be upheld when calling this function:
  *
- * 1. `idx` must be a valid pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
+ * 1. `idx` must be a [valid] pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
  *    [`InvertedIndex`](ffi::InvertedIndex) and cannot be NULL.
- * 2. `idx` must remain valid between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
+ * 2. `idx` must remain [valid] between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
  *    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) `TrieMap` lookup.
- * 3. `tag_idx` must be a valid pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
- * 4. `tag_idx` and `tag_idx.values` must remain valid for the lifetime of the returned
+ * 3. `tag_idx` must be a [valid] pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
+ * 4. `tag_idx` and `tag_idx.values` must remain [valid] for the lifetime of the returned
  *    iterator.
- * 5. `sctx` must be a valid pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) and cannot be NULL.
- * 6. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 7. `term` must be a valid pointer to a heap-allocated [`RSQueryTerm`] (e.g. created by
+ * 5. `sctx` must be a [valid] pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) and cannot be NULL.
+ * 6. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
+ * 7. `term` must be a [valid] pointer to a heap-allocated [`RSQueryTerm`] (e.g. created by
  *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
@@ -378,14 +400,16 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  *
  * The following invariants must be upheld when calling this function:
  *
- * 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ * 1. `idx` must be a [valid] pointer to a term `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
  *    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
  *    pointer comparison.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
+ * 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
+ * 5. `term` must be a [valid] pointer to a heap-allocated `RSQueryTerm` (e.g. created by
  *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
@@ -406,12 +430,14 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
  *
  * The following invariants must be upheld when calling this function:
  *
- * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ * 1. `idx` must be a [valid] pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain [valid] between `revalidate()` calls, since the revalidation
  *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
  *    comparison.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 3. `sctx` must be a [valid] pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain [valid] for the lifetime of the returned iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
 
@@ -434,7 +460,9 @@ QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const R
  * 1. `produce` must run the query against `ctx` and return a valid [`VectorRangeResults`]
  *    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
  * 2. `free_ctx` must free `ctx` and be safe to call exactly once.
- * 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
+ * 3. `ctx` must remain [valid] until the iterator is freed; ownership transfers to the iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducerCtxFn free_ctx, void *ctx, bool yields_metric, bool sorted_by_id, size_t num_estimated, enum MetricType type_);
 
@@ -472,29 +500,40 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
  * If the child is trivially reducible (empty or wildcard), a simplified
  * iterator is returned directly.
  *
- * The request timeout reached through `q.sctx.timeout` selects no timeout,
- * the Blocked Client Timeout, or the Clock Based Timeout. Clock deadlines are
- * read back on every probe so a re-armed deadline is honoured.
+ * `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
+ * Client Timeout path is used: every iterator timeout probe forwards to
+ * `AREQ_CheckTimedOut` and `q.sctx.time` is ignored.
+ * When null, the Clock Based Timeout path is used, driven entirely by `q.sctx.time`:
+ * `timeout` is the deadline, read back on every probe so that a re-armed deadline is
+ * honoured, and `skipTimeoutChecks` disables the check entirely. There is deliberately no
+ * deadline parameter — a caller wanting a different deadline sets `q.sctx.time.timeout`,
+ * which is the only value the iterator will ever consult. The C caller is expected to
+ * pre-filter the owning request via `AREQ_TimeoutAreqOrNull` before passing it here.
  *
  * # Safety
  *
- * 1. `child` must be null or a valid pointer to a [`QueryIterator`].
+ * 1. `child` must be null or a [valid] pointer to a [`QueryIterator`].
  *    A null `child` is treated as empty.
  * 2. When non-null, `child` must not be aliased.
- * 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
- * 4. `q.sctx` must be a non-null pointer to a valid
- *    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay valid and at a stable
+ * 3. `q` must be a [valid] non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
+ * 4. `q.sctx` must be a non-null pointer to a [valid]
+ *    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay [valid] and at a stable
  *    address for the lifetime of the returned iterator: on the Clock Based Timeout path
- *    the iterator reads the request-owned deadline back on every probe. No write to that
+ *    the iterator reads `q.sctx.time.timeout` back on every probe. No write to that
  *    deadline may overlap a probe.
- * 5. `q.sctx.spec` must be a non-null pointer to a valid
+ * 5. `q.sctx.spec` must be a non-null pointer to a [valid]
  *    [`IndexSpec`](ffi::IndexSpec).
- * 6. `q.sctx.spec.rule`, when non-null, must point to a valid
+ * 6. `q.sctx.spec.rule`, when non-null, must point to a [valid]
  *    [`SchemaRule`](ffi::SchemaRule).
  * 7. When the optimized path is taken, the preconditions of
  *    [`crate::wildcard::NewWildcardIterator`] must hold.
+ * 8. When `bc_timeout_areq` is non-null, it must satisfy the
+ *    [`TimeoutContextBlockedClient::new`] safety contract and remain
+ *    [valid] for the lifetime of the returned iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, QueryEvalCtx *q);
+QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, AREQ *bc_timeout_areq, QueryEvalCtx *q);
 
 /**
  * Opens the numeric/geo index and creates an iterator over all matching sub-ranges.
@@ -509,15 +548,17 @@ QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double w
  *
  * # Safety
  *
- * 1. `ctx` must be a valid non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
+ * 1. `ctx` must be a [valid] non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining [valid]
  *    for the lifetime of the returned iterator.
- * 2. `ctx.spec` must be a valid non-NULL pointer to an [`ffi::IndexSpec`].
- * 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
- *    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
+ * 2. `ctx.spec` must be a [valid] non-NULL pointer to an [`ffi::IndexSpec`].
+ * 3. `flt` must be a [valid] non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
+ *    is a [valid] non-NULL pointer to a [`FieldSpec`], remaining [valid] for the lifetime of the
  *    returned iterator.
- * 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
- * 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
+ * 4. `config` must be a [valid] non-NULL pointer to an [`IteratorsConfig`].
+ * 5. `filter_ctx` must be a [valid] non-NULL pointer to a [`FieldFilterContext`] with a field
  *    index (not a field mask).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const struct IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
 
@@ -531,9 +572,11 @@ QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct 
  *
  * # Safety
  *
- * 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
- * 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
+ * 1. `child`, when non-null, must be a [valid] owning pointer to a C query iterator that is not aliased.
+ * 2. `q` must be a [valid] non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
  *    [`new_optional_iterator`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docId max_doc_id, double weight);
 
@@ -542,11 +585,13 @@ QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docI
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ * 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
  *    The array must be sorted in ascending order.
  * 2. The caller must ensure that `ids` is not null unless `num` is zero.
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that the pointer was allocated in a compatible manner.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 
@@ -558,15 +603,17 @@ QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight
  *
  * # Safety
  *
- * 1. `its` must be a valid non-null pointer to an array of `num`
+ * 1. `its` must be a [valid] non-null pointer to an array of `num`
  *    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
  *    Ownership is transferred to this function.
- * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
+ * 2. Every non-null pointer in `its` must be a [valid] `QueryIterator` whose
  *    callbacks are set.
  * 3. Null entries in `its` are treated as empty iterators.
- * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
- * 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
+ * 4. `config` must be a [valid] non-null pointer to an [`IteratorsConfig`].
+ * 5. `q_str` must be null or a [valid], NUL-terminated C string that outlives
  *    the returned iterator — the requirement of [`build_union`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
 
@@ -575,10 +622,12 @@ QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_ex
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ * 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
  * 2. The caller must ensure that `ids` is not null unless `num` is zero.
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that the pointer was allocated in a compatible manner.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 
@@ -612,11 +661,10 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
  *    duration of this call.
  * 6. `sctx` is non-null and [valid] for a [`RedisSearchCtx`] with a [valid]
  *    `spec`, both outliving the returned iterator.
- * 7. `timeout` is non-null and remains valid for the returned iterator's lifetime.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, QueryRequestTimeout *timeout, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
+QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, timespec timeout, bool skip_timeout_checks, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
 
 /**
  * Creates a new wildcard iterator from a query evaluation context.
@@ -633,24 +681,26 @@ QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vecto
  *
  * # Safety
  *
- * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`](ffi::QueryEvalCtx)
- *    that remains valid for the lifetime of the returned iterator.
- * 2. `q.sctx` must be a non-null pointer to a valid
- *    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains valid for the lifetime
+ * 1. `q` must be a non-null pointer to a [valid] [`QueryEvalCtx`](ffi::QueryEvalCtx)
+ *    that remains [valid] for the lifetime of the returned iterator.
+ * 2. `q.sctx` must be a non-null pointer to a [valid]
+ *    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains [valid] for the lifetime
  *    of the returned iterator.
- * 3. `q.sctx.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) that
- *    remains valid for the lifetime of the returned iterator.
- * 4. `q.sctx.spec.rule`, when non-null, must point to a valid [`SchemaRule`](ffi::SchemaRule).
+ * 3. `q.sctx.spec` must be a non-null pointer to a [valid] [`IndexSpec`](ffi::IndexSpec) that
+ *    remains [valid] for the lifetime of the returned iterator.
+ * 4. `q.sctx.spec.rule`, when non-null, must point to a [valid] [`SchemaRule`](ffi::SchemaRule).
  * 5. When [`SchemaRule`](ffi::SchemaRule)`.index_all` is true, the preconditions of
  *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`] must also hold.
- * 6. `q.docTable` must be a non-null pointer to a valid [`DocTable`](ffi::DocTable).
- * 7. `q.sctx.spec.diskSpec`, when non-null, must point to a valid
- *    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains valid for the
+ * 6. `q.docTable` must be a non-null pointer to a [valid] [`DocTable`](ffi::DocTable).
+ * 7. `q.sctx.spec.diskSpec`, when non-null, must point to a [valid]
+ *    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains [valid] for the
  *    lifetime of the returned iterator, and the disk iterator backend must be initialized.
  * 8. When `q.sctx.spec.diskSpec` is non-null, `q.sctx.diskSnapshot` must be a **non-null**
  *    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for `q.sctx.spec.diskSpec`
- *    that remains valid for the lifetime of the returned iterator. The disk path requires a
+ *    that remains [valid] for the lifetime of the returned iterator. The disk path requires a
  *    point-in-time view: a null snapshot alongside a non-null `diskSpec` makes the call panic.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight);
 
@@ -664,9 +714,11 @@ QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
  *
  * # Safety
  *
- * 1. `self_` must be a valid pointer to an Optimus iterator.
- * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
- * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+ * 1. `self_` must be a [valid] pointer to an Optimus iterator.
+ * 2. `map` must be a [valid] pointer to a [`redis_reply::MapBuilder`].
+ * 3. `ctx` must be a [valid] pointer to a [`ProfilePrintCtx`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
 
@@ -680,8 +732,10 @@ void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, st
  *
  * # Safety
  *
- * 1. `root` must be a valid non-null pointer to a `*mut QueryIterator`.
- * 2. `*root` must be null or a valid non-null, non-aliased pointer to a `QueryIterator`.
+ * 1. `root` must be a [valid] non-null pointer to a `*mut QueryIterator`.
+ * 2. `*root` must be null or a [valid] non-null, non-aliased pointer to a `QueryIterator`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void Profile_AddIters(QueryIterator * *root);
 
@@ -704,9 +758,11 @@ void Profile_AddIters(QueryIterator * *root);
  *
  * # Safety
  *
- * 1. `ctx` must be a valid [`RedisModuleCtx`] pointer.
- * 2. `root` must be null or a valid pointer to a [`QueryIterator`] tree
+ * 1. `ctx` must be a [valid] [`RedisModuleCtx`] pointer.
+ * 2. `root` must be null or a [valid] pointer to a [`QueryIterator`] tree
  *    that has been profile-wrapped via `Profile_AddIters`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void Profile_PrintIterators(struct RedisModuleCtx *ctx, const QueryIterator *root, bool limited, bool print_profile_clock);
 
@@ -735,8 +791,10 @@ void RQEIterators_SetMockRevalidateTimeout(bool enabled);
  *
  * # Safety
  *
- * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
+ * 1. `it` must be a [valid] non-null pointer to a non-reduced union iterator
  *    created via [`NewUnionIterator`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 
@@ -770,8 +828,10 @@ void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);
  *
  * # Safety
  *
- * 1. `spec` must be a valid non-null pointer to an [`ffi::IndexSpec`].
- * 2. `fs` must be a valid non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+ * 1. `spec` must be a [valid] non-null pointer to an [`ffi::IndexSpec`].
+ * 2. `fs` must be a [valid] non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool create_if_missing);
 

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -471,12 +471,14 @@ QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducer
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ * 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
  *    The array must be sorted in ascending order.
- * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+ * 2. `metric_list` must be a [valid] pointer to an array of `f64` with at least `num` elements.
  * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
  * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that these pointers were allocated in a compatible manner.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewMetricIteratorSortedById(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
 
@@ -485,11 +487,13 @@ QueryIterator *NewMetricIteratorSortedById(t_docId *ids, double *metric_list, si
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
- * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+ * 1. `ids` must be a [valid] pointer to an array of `DocId` with at least `num` elements.
+ * 2. `metric_list` must be a [valid] pointer to an array of `f64` with at least `num` elements.
  * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
  * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that these pointers were allocated in a compatible manner.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
 
@@ -638,7 +642,7 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
  * [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
  * accessors below must not be called on such a handle.
  *
- * Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
+ * Pass `child = NULL` for a pure KNN query; pass a [valid] owning child iterator
  * for a hybrid (filtered) query.
  *
  * The `query_params` pointer is read once to copy the parameters into the
@@ -820,7 +824,9 @@ RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
  *
  * 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
  *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
- * 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
+ * 2. `handle` is either null or a [valid] pointer to a [`RLookupKeyHandle`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);
 

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -20,10 +20,6 @@
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.
 typedef struct timespec timespec;
-// `AREQ` is forward-declared as a struct tag in `query.h` (above) but its
-// typedef lives in `aggregate/aggregate.h`. cheadergen emits `*mut ffi::AREQ`
-// as the bare `AREQ *`, so we surface the typedef here for the C compiler.
-typedef struct AREQ AREQ;
 
 
 /**
@@ -273,7 +269,7 @@ QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, con
  * 1. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
  *    `spec` is a [valid] [`IndexSpec`](ffi::IndexSpec); both must outlive the
  *    returned iterator, and `sctx` must stay at a stable address for that
- *    whole window: the iterator reads `sctx.time.timeout` back on every
+ *    whole window: the iterator reads the request-owned deadline back on every
  *    timeout probe. No write to that deadline may overlap a probe.
  * 2. `filter_ctx` must be a non-null pointer to a [valid] [`FieldFilterContext`].
  * 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
@@ -504,15 +500,9 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
  * If the child is trivially reducible (empty or wildcard), a simplified
  * iterator is returned directly.
  *
- * `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
- * Client Timeout path is used: every iterator timeout probe forwards to
- * `AREQ_CheckTimedOut` and `q.sctx.time` is ignored.
- * When null, the Clock Based Timeout path is used, driven entirely by `q.sctx.time`:
- * `timeout` is the deadline, read back on every probe so that a re-armed deadline is
- * honoured, and `skipTimeoutChecks` disables the check entirely. There is deliberately no
- * deadline parameter — a caller wanting a different deadline sets `q.sctx.time.timeout`,
- * which is the only value the iterator will ever consult. The C caller is expected to
- * pre-filter the owning request via `AREQ_TimeoutAreqOrNull` before passing it here.
+ * The request timeout reached through `q.sctx.timeout` selects no timeout,
+ * the Blocked Client Timeout, or the Clock Based Timeout. Clock deadlines are
+ * read back on every probe so a re-armed deadline is honoured.
  *
  * # Safety
  *
@@ -523,7 +513,7 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
  * 4. `q.sctx` must be a non-null pointer to a [valid]
  *    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay [valid] and at a stable
  *    address for the lifetime of the returned iterator: on the Clock Based Timeout path
- *    the iterator reads `q.sctx.time.timeout` back on every probe. No write to that
+ *    the iterator reads the request-owned deadline back on every probe. No write to that
  *    deadline may overlap a probe.
  * 5. `q.sctx.spec` must be a non-null pointer to a [valid]
  *    [`IndexSpec`](ffi::IndexSpec).
@@ -531,13 +521,10 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
  *    [`SchemaRule`](ffi::SchemaRule).
  * 7. When the optimized path is taken, the preconditions of
  *    [`crate::wildcard::NewWildcardIterator`] must hold.
- * 8. When `bc_timeout_areq` is non-null, it must satisfy the
- *    [`TimeoutContextBlockedClient::new`] safety contract and remain
- *    [valid] for the lifetime of the returned iterator.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, AREQ *bc_timeout_areq, QueryEvalCtx *q);
+QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, QueryEvalCtx *q);
 
 /**
  * Opens the numeric/geo index and creates an iterator over all matching sub-ranges.
@@ -665,10 +652,11 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
  *    duration of this call.
  * 6. `sctx` is non-null and [valid] for a [`RedisSearchCtx`] with a [valid]
  *    `spec`, both outliving the returned iterator.
+ * 7. `timeout` is non-null and remains valid for the returned iterator's lifetime.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, timespec timeout, bool skip_timeout_checks, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
+QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, QueryRequestTimeout *timeout, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
 
 /**
  * Creates a new wildcard iterator from a query evaluation context.

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -21,7 +21,9 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
+ * 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexResult_ResetAggregate(RSIndexResult *r);
 
@@ -31,9 +33,11 @@ void IndexResult_ResetAggregate(RSIndexResult *r);
  *
  * # Safety
  *
- * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
+ * 1. `metrics` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
  * 2. The returned slice borrows from the `MetricsVec`; the caller must
  *    not mutate or free the `MetricsVec` while the slice is in use.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
 
@@ -55,8 +59,10 @@ MetricsVec MetricsVec_New(void);
  *
  * # Safety
  *
- * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
+ * 1. `metrics` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
+ * 2. `key` must point to a [valid] `RLookupKey`. Compared by pointer identity.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void MetricsVec_UpdateValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
 
@@ -65,8 +71,10 @@ void MetricsVec_UpdateValue(MetricsVec *metrics, const RLookupKey *key, double n
  *
  * # Safety
  *
- * 1. `parent` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. `child` must point to a valid `MetricsVec`, or be null (no-op).
+ * 1. `parent` must point to a [valid] `MetricsVec` (e.g. `&result.metrics`).
+ * 2. `child` must point to a [valid] `MetricsVec`, or be null (no-op).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RSYieldableMetric_Concat(MetricsVec *parent, MetricsVec *child);
 
@@ -75,9 +83,11 @@ void RSYieldableMetric_Concat(MetricsVec *parent, MetricsVec *child);
  *
  * # Safety
  *
- * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
- * 2. `key` must be a valid `*const RLookupKey` that outlives the result
+ * 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+ * 2. `key` must be a [valid] `*const RLookupKey` that outlives the result
  *    (or null).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void ResultMetrics_Add(RSIndexResult *r, const RLookupKey *key, double val);
 
@@ -86,7 +96,9 @@ void ResultMetrics_Add(RSIndexResult *r, const RLookupKey *key, double val);
  *
  * # Safety
  *
- * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
+ * 1. `r` must point to a [valid] `RSIndexResult` and cannot be null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void ResultMetrics_Reset(RSIndexResult *r);
 

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -28,7 +28,9 @@ extern "C" {
  *
  * # Safety
  *
- * `ctx` must either be null or point to a valid `RedisModuleInfoCtx`.
+ * `ctx` must either be null or point to a [valid] `RedisModuleInfoCtx`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
 
@@ -51,8 +53,10 @@ void RustPanicHook_Init(void);
  *
  * # Safety
  *
- * `level` must point to a valid, null-terminated C string. `ctx` must either
- * be null or point to a valid `RedisModuleCtx`.
+ * `level` must point to a [valid], null-terminated C string. `ctx` must either
+ * be null or point to a [valid] `RedisModuleCtx`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TracingRedisModule_Init(struct RedisModuleCtx *ctx, const char *level);
 
@@ -62,7 +66,9 @@ void TracingRedisModule_Init(struct RedisModuleCtx *ctx, const char *level);
  *
  * # Safety
  *
- * `level` must point to a valid, null-terminated C string.
+ * `level` must point to a [valid], null-terminated C string.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TracingRedisModule_SetLogLevel(const char *level);
 

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -81,9 +81,11 @@ struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `node` must point to a valid [`NumericRangeNode`] obtained from
+ * - `node` must point to a [valid] [`NumericRangeNode`] obtained from
  *   [`crate::iterator::NumericRangeTreeIterator_Next`] and cannot be NULL.
  * - The tree from which this node came must still be valid.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct NumericRange *NumericRangeNode_GetRange(const struct NumericRangeNode *node);
 
@@ -106,9 +108,11 @@ void NumericRangeTreeFindResult_Free(struct NumericRangeTreeFindResult result);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
+ * - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
  *   [`NumericRangeTreeIterator_New`], or be NULL (in which case this is a no-op).
  * - After calling this function, `it` must not be used again.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void NumericRangeTreeIterator_Free(NumericRangeTreeIterator *it);
 
@@ -121,10 +125,12 @@ void NumericRangeTreeIterator_Free(NumericRangeTreeIterator *it);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`crate::NewNumericRangeTree`] and cannot be NULL.
  * - `t` must not be freed while the iterator lives.
  * - The tree must not be mutated while the iterator lives.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRangeTree *t);
 
@@ -140,9 +146,11 @@ NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRange
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
+ * - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
  *   [`NumericRangeTreeIterator_New`] and cannot be NULL.
  * - The tree from which this iterator was created must still be valid.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct NumericRangeNode *NumericRangeTreeIterator_Next(NumericRangeTreeIterator *it);
 
@@ -162,8 +170,10 @@ size_t NumericRangeTree_BaseSize(void);
  *
  * # Safety
  *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ * - `ctx` must be a [valid] Redis module context.
+ * - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void NumericRangeTree_DebugDumpIndex(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool with_headers);
 
@@ -176,8 +186,10 @@ void NumericRangeTree_DebugDumpIndex(struct RedisModuleCtx *ctx, const struct Nu
  *
  * # Safety
  *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ * - `ctx` must be a [valid] Redis module context.
+ * - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void NumericRangeTree_DebugDumpTree(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool minimal);
 
@@ -189,8 +201,10 @@ void NumericRangeTree_DebugDumpTree(struct RedisModuleCtx *ctx, const struct Num
  *
  * # Safety
  *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ * - `ctx` must be a [valid] Redis module context.
+ * - `t` must be either NULL or a [valid] pointer to a [`NumericRangeTree`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void NumericRangeTree_DebugSummary(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t);
 
@@ -204,9 +218,11 @@ void NumericRangeTree_DebugSummary(struct RedisModuleCtx *ctx, const struct Nume
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`] and cannot be NULL.
- * - `nf` must point to a valid [`NumericFilter`] and cannot be NULL.
+ * - `nf` must point to a [valid] [`NumericFilter`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct NumericRangeTreeFindResult NumericRangeTree_Find(const struct NumericRangeTree *t, const struct NumericFilter *nf);
 
@@ -216,10 +232,12 @@ struct NumericRangeTreeFindResult NumericRangeTree_Find(const struct NumericRang
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`], or be NULL (in which case this is a no-op).
  * - After calling this function, `t` must not be used again.
  * - Any iterators obtained from this tree must be freed before calling this.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void NumericRangeTree_Free(struct NumericRangeTree *t);
 
@@ -228,7 +246,9 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRangeTree_GetInvertedIndexesSize(const struct NumericRangeTree *t);
 
@@ -237,7 +257,9 @@ size_t NumericRangeTree_GetInvertedIndexesSize(const struct NumericRangeTree *t)
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRangeTree_GetNumEntries(const struct NumericRangeTree *t);
 
@@ -246,7 +268,9 @@ size_t NumericRangeTree_GetNumEntries(const struct NumericRangeTree *t);
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRangeTree_GetNumRanges(const struct NumericRangeTree *t);
 
@@ -258,7 +282,9 @@ size_t NumericRangeTree_GetNumRanges(const struct NumericRangeTree *t);
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t NumericRangeTree_GetRevisionId(const struct NumericRangeTree *t);
 
@@ -267,8 +293,10 @@ uint32_t NumericRangeTree_GetRevisionId(const struct NumericRangeTree *t);
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
  * - The returned pointer is valid until the tree is modified or freed.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct NumericRangeNode *NumericRangeTree_GetRoot(const struct NumericRangeTree *t);
 
@@ -277,7 +305,9 @@ const struct NumericRangeNode *NumericRangeTree_GetRoot(const struct NumericRang
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t NumericRangeTree_GetUniqueId(const struct NumericRangeTree *t);
 
@@ -292,8 +322,10 @@ uint32_t NumericRangeTree_GetUniqueId(const struct NumericRangeTree *t);
  *
  * # Safety
  *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
  * - The caller must have unique access to `t`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t NumericRangeTree_IncrementRevisionId(struct NumericRangeTree *t);
 
@@ -303,8 +335,10 @@ uint32_t NumericRangeTree_IncrementRevisionId(struct NumericRangeTree *t);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRangeTree_MemUsage(const struct NumericRangeTree *t);
 
@@ -317,9 +351,11 @@ size_t NumericRangeTree_MemUsage(const struct NumericRangeTree *t);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`] and cannot be NULL.
  * - No iterators should be active on this tree while calling this function.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct TrimEmptyLeavesResult NumericRangeTree_TrimEmptyLeaves(struct NumericRangeTree *t);
 
@@ -331,9 +367,11 @@ struct TrimEmptyLeavesResult NumericRangeTree_TrimEmptyLeaves(struct NumericRang
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `range` must point to a valid [`NumericRange`] obtained from
+ * - `range` must point to a [valid] [`NumericRange`] obtained from
  *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
  * - The tree from which this range came must still be valid.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRange_GetCardinality(const struct NumericRange *range);
 
@@ -345,8 +383,10 @@ size_t NumericRange_GetCardinality(const struct NumericRange *range);
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
  * - The returned pointer points to memory owned by the range; do not free it.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct InvertedIndexNumeric *NumericRange_GetEntries(const struct NumericRange *range);
 
@@ -355,7 +395,9 @@ const struct InvertedIndexNumeric *NumericRange_GetEntries(const struct NumericR
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t NumericRange_InvertedIndexSize(const struct NumericRange *range);
 
@@ -364,7 +406,9 @@ size_t NumericRange_InvertedIndexSize(const struct NumericRange *range);
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 double NumericRange_MaxVal(const struct NumericRange *range);
 
@@ -373,7 +417,9 @@ double NumericRange_MaxVal(const struct NumericRange *range);
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 double NumericRange_MinVal(const struct NumericRange *range);
 
@@ -389,12 +435,14 @@ double NumericRange_MinVal(const struct NumericRange *range);
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
- * - `filter` may be NULL for no filtering, or must point to a valid [`NumericFilter`].
+ * - `range` must point to a [valid] [`NumericRange`] and cannot be NULL.
+ * - `filter` may be NULL for no filtering, or must point to a [valid] [`NumericFilter`].
  * - The returned reader holds a reference to the range's inverted index. The range
  *   must not be freed or modified while the reader exists.
  * - The filter (if non-NULL) must remain valid for the lifetime of the reader.
  * - Free the returned reader with `IndexReader_Free()` when done.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct IndexReader *NumericRange_NewIndexReader(const struct NumericRange *range, const struct NumericFilter *filter);
 
@@ -409,8 +457,10 @@ struct IndexReader *NumericRange_NewIndexReader(const struct NumericRange *range
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ * - `t` must point to a [valid] [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct AddResult _NumericRangeTree_Add(struct NumericRangeTree *t, t_docId doc_id, double value, bool has_field_expiration, int isMulti, size_t maxDepthRange);
 

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -75,7 +75,7 @@ struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
  * Returns a pointer to the range, or NULL if the node has no range
  * (e.g., an internal node whose range has been trimmed).
  *
- * The returned pointer is valid until the tree is modified or freed.
+ * The returned pointer is [valid] until the tree is modified or freed.
  * Do NOT free the returned pointer - it points to memory owned by the tree.
  *
  * # Safety
@@ -83,7 +83,7 @@ struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
  * The following invariants must be upheld when calling this function:
  * - `node` must point to a [valid] [`NumericRangeNode`] obtained from
  *   [`crate::iterator::NumericRangeTreeIterator_Next`] and cannot be NULL.
- * - The tree from which this node came must still be valid.
+ * - The tree from which this node came must still be [valid].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -140,7 +140,7 @@ NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRange
  * Returns a pointer to the next [`NumericRangeNode`] in the traversal,
  * or NULL if the iteration is complete.
  *
- * The returned pointer is valid until the tree is modified or freed.
+ * The returned pointer is [valid] until the tree is modified or freed.
  * Do NOT free the returned pointer - it points to memory owned by the tree.
  *
  * # Safety
@@ -148,7 +148,7 @@ NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRange
  * The following invariants must be upheld when calling this function:
  * - `it` must point to a [valid] [`NumericRangeTreeIterator`] obtained from
  *   [`NumericRangeTreeIterator_New`] and cannot be NULL.
- * - The tree from which this iterator was created must still be valid.
+ * - The tree from which this iterator was created must still be [valid].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -294,7 +294,7 @@ uint32_t NumericRangeTree_GetRevisionId(const struct NumericRangeTree *t);
  * # Safety
  *
  * - `t` must point to a [valid] [`NumericRangeTree`] and cannot be NULL.
- * - The returned pointer is valid until the tree is modified or freed.
+ * - The returned pointer is [valid] until the tree is modified or freed.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -369,7 +369,7 @@ struct TrimEmptyLeavesResult NumericRangeTree_TrimEmptyLeaves(struct NumericRang
  * The following invariants must be upheld when calling this function:
  * - `range` must point to a [valid] [`NumericRange`] obtained from
  *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
- * - The tree from which this range came must still be valid.
+ * - The tree from which this range came must still be [valid].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -379,7 +379,7 @@ size_t NumericRange_GetCardinality(const struct NumericRange *range);
  * Get the inverted index entries from a range.
  *
  * Returns a pointer to the [`InvertedIndexNumeric`] (which is a `NumericIndex` enum)
- * stored inside the range. The returned pointer is valid until the tree is modified or freed.
+ * stored inside the range. The returned pointer is [valid] until the tree is modified or freed.
  *
  * # Safety
  *
@@ -439,7 +439,7 @@ double NumericRange_MinVal(const struct NumericRange *range);
  * - `filter` may be NULL for no filtering, or must point to a [valid] [`NumericFilter`].
  * - The returned reader holds a reference to the range's inverted index. The range
  *   must not be freed or modified while the reader exists.
- * - The filter (if non-NULL) must remain valid for the lifetime of the reader.
+ * - The filter (if non-NULL) must remain [valid] for the lifetime of the reader.
  * - Free the returned reader with `IndexReader_Free()` when done.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/headers/query_error_ffi.h
+++ b/src/redisearch_rs/headers/query_error_ffi.h
@@ -110,7 +110,9 @@ QueryErrorCode QueryError_GetCode(const struct QueryError *query_error);
  *
  * # Safety
  *
- * - `message` must be a valid C string or a NULL pointer.
+ * - `message` must be a [valid] C string or a NULL pointer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryErrorCode QueryError_GetCodeFromMessage(const char *message);
 
@@ -215,7 +217,9 @@ void QueryError_SetCode(struct QueryError *query_error, uint8_t code);
  * # Safety
  *
  * - `query_error` must have been created by [`QueryError_Default`].
- * - `detail` must be a valid C string or a NULL pointer.
+ * - `detail` must be a [valid] C string or a NULL pointer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void QueryError_SetDetail(struct QueryError *query_error, const char *detail);
 
@@ -236,7 +240,9 @@ void QueryError_SetDetail(struct QueryError *query_error, const char *detail);
  * # Safety
  *
  * - `query_error` must have been created by [`QueryError_Default`].
- * - `message` must be a valid C string or a NULL pointer.
+ * - `message` must be a [valid] C string or a NULL pointer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void QueryError_SetError(struct QueryError *query_error, uint8_t code, const char *message);
 
@@ -292,7 +298,9 @@ const char *QueryError_StrerrorPrefix(uint8_t maybe_code);
  *
  * # Safety
  *
- * - `message` must be a valid C string or a NULL pointer.
+ * - `message` must be a [valid] C string or a NULL pointer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryWarningCode QueryWarningCode_GetCodeFromMessage(const char *message);
 

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -16,10 +16,6 @@
 // Rust type name `RSQueryNode` as a bare reference, so we surface a matching
 // typedef here for the C compiler.
 typedef struct RSQueryNode RSQueryNode;
-// `AREQ` is defined in `aggregate/aggregate.h`, a heavy header we avoid pulling
-// in here. `QAST_Iterate` only takes an `AREQ *`, so a forward typedef (matching
-// the full `typedef struct AREQ { ... } AREQ;` definition) is sufficient.
-typedef struct AREQ AREQ;
 
 
 typedef struct QueryError QueryError;
@@ -53,7 +49,6 @@ extern "C" {
  * 3. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
  *    `spec` is a [valid], non-null [`IndexSpec`](ffi::IndexSpec).
  * 4. `status` must be a non-null pointer to a [valid] [`QueryError`].
- * 5. `areq`, when non-null, must point to a [valid] [`AREQ`].
  *
  * Together these are exactly the invariants documented on
  * [`QueryEvalContext::new`] for the assembled context, which remains [valid] for
@@ -61,7 +56,7 @@ extern "C" {
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx, uint32_t reqflags, AREQ *areq, QueryError *status);
+QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx, uint32_t reqflags, QueryError *status);
 
 /**
  * Evaluate a single query AST node, producing the corresponding

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -16,6 +16,10 @@
 // Rust type name `RSQueryNode` as a bare reference, so we surface a matching
 // typedef here for the C compiler.
 typedef struct RSQueryNode RSQueryNode;
+// `AREQ` is defined in `aggregate/aggregate.h`, a heavy header we avoid pulling
+// in here. `QAST_Iterate` only takes an `AREQ *`, so a forward typedef (matching
+// the full `typedef struct AREQ { ... } AREQ;` definition) is sufficient.
+typedef struct AREQ AREQ;
 
 
 typedef struct QueryError QueryError;
@@ -40,21 +44,24 @@ extern "C" {
  *
  * # Safety
  *
- * 1. `qast` must be a non-null pointer to a valid [`QueryAST`] whose `root` is
- *    a valid [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
+ * 1. `qast` must be a non-null pointer to a [valid] [`QueryAST`] whose `root` is
+ *    a [valid] [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
  *    must stay valid and exclusively borrowed for the duration of the call. The
  *    root's subtree must meet the token-buffer requirement of
  *    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
- * 2. `opts` must be a non-null pointer to a valid [`RSSearchOptions`].
- * 3. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
- *    `spec` is a valid, non-null [`IndexSpec`](ffi::IndexSpec).
- * 4. `status` must be a non-null pointer to a valid [`QueryError`].
+ * 2. `opts` must be a non-null pointer to a [valid] [`RSSearchOptions`].
+ * 3. `sctx` must be a non-null pointer to a [valid] [`RedisSearchCtx`] whose
+ *    `spec` is a [valid], non-null [`IndexSpec`](ffi::IndexSpec).
+ * 4. `status` must be a non-null pointer to a [valid] [`QueryError`].
+ * 5. `areq`, when non-null, must point to a [valid] [`AREQ`].
  *
  * Together these are exactly the invariants documented on
  * [`QueryEvalContext::new`] for the assembled context, which remains valid for
  * the lifetime of the returned iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx, uint32_t reqflags, QueryError *status);
+QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx, uint32_t reqflags, AREQ *areq, QueryError *status);
 
 /**
  * Evaluate a single query AST node, producing the corresponding
@@ -65,19 +72,21 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
  *
  * # Safety
  *
- * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
+ * 1. `q` must be a non-null pointer to a [valid] [`QueryEvalCtx`] that satisfies
  *    all the invariants documented on [`QueryEvalContext::new`] and remains
- *    valid for the lifetime of the returned iterator.
- * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`]. Evaluation
+ *    [valid] for the lifetime of the returned iterator.
+ * 2. `n` must be a non-null pointer to a [valid] [`RSQueryNode`]. Evaluation
  *    rewrites some tokens in place, so every node in the subtree that carries a
  *    rewritable one — see [`QueryNodeMut::token_mut`] — must additionally satisfy
  *    invariant (4) of [`QueryNodeMut::new`]. A parser-produced AST does; one
  *    assembled by hand, with a token borrowing a read-only or length-delimited
  *    string, does not.
  * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
- *    pointing to a valid [`Config`] that stays valid for the duration of the
+ *    pointing to a [valid] [`Config`] that stays valid for the duration of the
  *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
  *    dispatcher.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConfig *eval_config);
 
@@ -86,8 +95,10 @@ QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConf
  *
  * # Safety
  *
- * `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
- * null or point to a valid [`QueryNodeOptions`].
+ * `scorer_name` must be null or a [valid] NUL-terminated C string; `opts` must be
+ * null or point to a [valid] [`QueryNodeOptions`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *opts);
 
@@ -100,7 +111,9 @@ bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *o
  *
  * # Safety
  *
- * `scorer_name` must be null or a valid NUL-terminated C string.
+ * `scorer_name` must be null or a [valid] NUL-terminated C string.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool scorerNeedsOffsets(const char *scorer_name);
 

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -46,7 +46,7 @@ extern "C" {
  *
  * 1. `qast` must be a non-null pointer to a [valid] [`QueryAST`] whose `root` is
  *    a [valid] [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
- *    must stay valid and exclusively borrowed for the duration of the call. The
+ *    must stay [valid] and exclusively borrowed for the duration of the call. The
  *    root's subtree must meet the token-buffer requirement of
  *    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
  * 2. `opts` must be a non-null pointer to a [valid] [`RSSearchOptions`].
@@ -56,7 +56,7 @@ extern "C" {
  * 5. `areq`, when non-null, must point to a [valid] [`AREQ`].
  *
  * Together these are exactly the invariants documented on
- * [`QueryEvalContext::new`] for the assembled context, which remains valid for
+ * [`QueryEvalContext::new`] for the assembled context, which remains [valid] for
  * the lifetime of the returned iterator.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -82,7 +82,7 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
  *    assembled by hand, with a token borrowing a read-only or length-delimited
  *    string, does not.
  * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
- *    pointing to a [valid] [`Config`] that stays valid for the duration of the
+ *    pointing to a [valid] [`Config`] that stays [valid] for the duration of the
  *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
  *    dispatcher.
  *

--- a/src/redisearch_rs/headers/query_term_ffi.h
+++ b/src/redisearch_rs/headers/query_term_ffi.h
@@ -32,12 +32,14 @@ extern "C" {
  *
  * # Safety
  *
- * - `tok` must point to a valid `RSToken` and cannot be NULL.
+ * - `tok` must point to a [valid] `RSToken` and cannot be NULL.
  * - `tok->str` may be NULL, in which case the resulting term will have a
  *   NULL `str` field.
- * - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
+ * - If not NULL, `tok->str` must be a [valid] byte slice of `tok->len` bytes.
  * - The returned pointer is heap-allocated and must be freed with
  *   [`Term_Free`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSQueryTerm *NewQueryTerm(const RSToken *tok, int id);
 
@@ -46,8 +48,10 @@ struct RSQueryTerm *NewQueryTerm(const RSToken *tok, int id);
  *
  * # Safety
  *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
  * allocated by [`NewQueryTerm`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 double QueryTerm_GetBM25_IDF(const struct RSQueryTerm *term);
 
@@ -58,8 +62,10 @@ double QueryTerm_GetBM25_IDF(const struct RSQueryTerm *term);
  *
  * # Safety
  *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
  * allocated by [`NewQueryTerm`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int QueryTerm_GetID(const struct RSQueryTerm *term);
 
@@ -68,8 +74,10 @@ int QueryTerm_GetID(const struct RSQueryTerm *term);
  *
  * # Safety
  *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
  * allocated by [`NewQueryTerm`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 double QueryTerm_GetIDF(const struct RSQueryTerm *term);
 
@@ -78,8 +86,10 @@ double QueryTerm_GetIDF(const struct RSQueryTerm *term);
  *
  * # Safety
  *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
  * allocated by [`NewQueryTerm`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t QueryTerm_GetLen(const struct RSQueryTerm *term);
 
@@ -90,8 +100,10 @@ size_t QueryTerm_GetLen(const struct RSQueryTerm *term);
  *
  * # Safety
  *
- * - `term` must be valid and non-null
- * - `out_len` must be a valid pointer to write the length to
+ * - `term` must be [valid] and non-null
+ * - `out_len` must be a [valid] pointer to write the length to
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const char *QueryTerm_GetStrAndLen(const struct RSQueryTerm *term, size_t *out_len);
 
@@ -102,8 +114,10 @@ const char *QueryTerm_GetStrAndLen(const struct RSQueryTerm *term, size_t *out_l
  *
  * # Safety
  *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * `term` must be a [valid], non-null pointer to an [`RSQueryTerm`] previously
  * allocated by [`NewQueryTerm`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void QueryTerm_SetIDFs(struct RSQueryTerm *term, double idf, double bm25_idf);
 

--- a/src/redisearch_rs/headers/reducers_ffi.h
+++ b/src/redisearch_rs/headers/reducers_ffi.h
@@ -69,7 +69,7 @@ Reducer *CollectReducer_CreateLocal(const RLookupKey *input_key, const char *con
  *    `field_keys_len` [valid] `*const RLookupKey` pointers.
  * 2. If `sort_keys_len > 0`, `sort_keys` must point to an array of at least
  *    `sort_keys_len` [valid] `*const RLookupKey` pointers.
- * 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
+ * 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain [valid] for the
  *    lifetime of the returned reducer.
  * 4. `srclookup` is either null or a [valid] pointer to a
  *    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the

--- a/src/redisearch_rs/headers/reducers_ffi.h
+++ b/src/redisearch_rs/headers/reducers_ffi.h
@@ -47,10 +47,10 @@ extern "C" {
  * 1. `input_key` must be a [valid] pointer to an [`RLookupKey`] that remains
  *    alive for the lifetime of the returned reducer.
  * 2. If `field_names_len > 0`, `field_names` must point to an array of at
- *    least `field_names_len` valid, NUL-terminated C strings. Ignored when
+ *    least `field_names_len` [valid], NUL-terminated C strings. Ignored when
  *    `load_all` is `true`.
  * 3. If `sort_names_len > 0`, `sort_names` must point to an array of at
- *    least `sort_names_len` valid, NUL-terminated C strings.
+ *    least `sort_names_len` [valid], NUL-terminated C strings.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -82,64 +82,80 @@ Reducer *CollectReducer_CreateRemote(const RLookupKey *const *field_keys, size_t
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t CollectReducer_GetFieldKeysLen(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint64_t CollectReducer_GetLimitCount(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint64_t CollectReducer_GetLimitOffset(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint64_t CollectReducer_GetSortAscMap(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t CollectReducer_GetSortKeysLen(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool CollectReducer_HasLimit(const Reducer *r);
 
 /**
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `r` must point to a [valid] [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool CollectReducer_IsLoadAll(const Reducer *r);
 
 /**
  * # Safety
  *
- * 1. `r` must point to a valid [`LocalCollectReducer`] originally created by
+ * 1. `r` must point to a [valid] [`LocalCollectReducer`] originally created by
  *    [`CollectReducer_CreateLocal`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool CollectReducer_IsLocalLoadAll(const Reducer *r);
 

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -201,7 +201,7 @@ void RLookupRow_Reset(struct RLookupRow *row);
  *
  * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
  * 2. `sv` must be either null or a [valid] pointer to an [`sorting_vector::RSSortingVector`].
- *    The pointed-to vector must remain valid for the lifetime of the row.
+ *    The pointed-to vector must remain [valid] for the lifetime of the row.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -320,7 +320,7 @@ void RLookup_AddKeysFrom(const struct RLookup *src, struct RLookup *dest, uint32
 /**
  * Releases any resources created by this lookup object. Note that if there are
  * lookup keys created with RLOOKUP_F_NOINCREF, those keys will no longer be
- * valid after this call!
+ * [valid] after this call!
  *
  * # Safety
  *
@@ -571,7 +571,7 @@ bool RLookup_HasIndexSpecCache(const struct RLookup *lookup);
  * # Safety
  *
  * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The returned iterator must only be used as long as the `lookup` remains valid.
+ * 2. The returned iterator must only be used as long as the `lookup` remains [valid].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
@@ -583,7 +583,7 @@ struct RLookupIterator RLookup_Iter(const struct RLookup *lookup);
  * # Safety
  *
  * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The returned iterator must only be used as long as the `lookup` remains valid.
+ * 2. The returned iterator must only be used as long as the `lookup` remains [valid].
  * 3. The caller must treat the returned `current` pointer as pinned. Specifically
  *    a. Not move (memcpy/memmove) out of the pointer.
  *    b. The pointed-to value must remain at its original address in memory and never be relocated.

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -644,7 +644,7 @@ int RLookup_LoadDocumentIndividual(struct RLookup *lookup, struct RLookupRow *ds
  *     1. The entire memory range of this `CStr` must be contained within a single allocation!
  *     2. `key` must be non-null even for a zero-length cstr.
  * 7. The nul terminator must be within `isize::MAX` from `key`
- * 8. `open_key`, if non-null, must be a valid, already-open `redis_module::RedisModuleKey` handle for
+ * 8. `open_key`, if non-null, must be a [valid], already-open `redis_module::RedisModuleKey` handle for
  *    `key` that outlives this call. It is borrowed, not closed here. Pass null to open by name.
  * 9. `status` must be a [valid], non-null pointer to an `ffi::QueryError` that is properly initialized.
  *
@@ -719,9 +719,11 @@ void RLookup_WriteOwnKey(const RLookupKey *key, struct RLookupRow *row, struct R
  *
  * # Safety
  *
- * 1. `keys` must point to an array of at least `nkeys` valid, non-null `RLookupKey` pointers.
- * 2. `h1` and `h2` must be valid, non-null pointers to a `SearchResult`.
- * 3. `qerr`, when non-null, must be a valid, writable pointer to a `QueryError`.
+ * 1. `keys` must point to an array of at least `nkeys` [valid], non-null `RLookupKey` pointers.
+ * 2. `h1` and `h2` must be [valid], non-null pointers to a `SearchResult`.
+ * 3. `qerr`, when non-null, must be a [valid], writable pointer to a `QueryError`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int SearchResult_CmpByFields(const RLookupKey *const *keys, size_t nkeys, const struct SearchResult *h1, const struct SearchResult *h2, uint64_t ascend_map, struct QueryError *qerr);
 

--- a/src/redisearch_rs/headers/slots_tracker_ffi.h
+++ b/src/redisearch_rs/headers/slots_tracker_ffi.h
@@ -43,9 +43,11 @@ extern "C" {
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct OptionSlotTrackerVersion slots_tracker_check_availability(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -71,9 +73,11 @@ struct RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool slots_tracker_has_fully_available_overlap(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -89,9 +93,11 @@ bool slots_tracker_has_fully_available_overlap(const struct RedisModuleSlotRange
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void slots_tracker_mark_fully_available_slots(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -109,9 +115,11 @@ void slots_tracker_mark_fully_available_slots(const struct RedisModuleSlotRangeA
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t slots_tracker_mark_partially_available_slots(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -127,9 +135,11 @@ uint32_t slots_tracker_mark_partially_available_slots(const struct RedisModuleSl
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void slots_tracker_promote_to_local_slots(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -142,9 +152,11 @@ void slots_tracker_promote_to_local_slots(const struct RedisModuleSlotRangeArray
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void slots_tracker_remove_deleted_slots(const struct RedisModuleSlotRangeArray *ranges);
 
@@ -176,9 +188,11 @@ void slots_tracker_reset(void);
  * # Safety
  *
  * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
+ * The `ranges` pointer must be [valid] and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` [valid] elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t slots_tracker_set_local_slots(const struct RedisModuleSlotRangeArray *ranges);
 

--- a/src/redisearch_rs/headers/trie_rdb_ffi.h
+++ b/src/redisearch_rs/headers/trie_rdb_ffi.h
@@ -53,9 +53,11 @@ struct LexTrieRs *LexTrieRs_New(void);
  *
  * # Safety
  *
- * - `io` must be a valid `*mut RedisModuleIO` supplied by the calling
+ * - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
  *   Redis module type loader and remain valid for the duration of the
  *   call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct LexTrieRs *LexTrieRs_RdbLoad(struct RedisModuleIO *io, bool load_payloads, bool load_num_docs);
 
@@ -68,12 +70,14 @@ struct LexTrieRs *LexTrieRs_RdbLoad(struct RedisModuleIO *io, bool load_payloads
  *
  * # Safety
  *
- * - `io` must be a valid `*mut RedisModuleIO` supplied by the calling
+ * - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
  *   Redis module command and remain valid for the duration of the call.
- * - `map` must be a valid pointer to a [`LexTrieRs`] (typically obtained
+ * - `map` must be a [valid] pointer to a [`LexTrieRs`] (typically obtained
  *   from [`LexTrieRs_New`] / [`LexTrieRs_RdbLoad`]). It is borrowed
  *   immutably for the duration of the call; no aliasing mutable
  *   references must exist.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void LexTrieRs_RdbSave(struct RedisModuleIO *io, const struct LexTrieRs *map, bool save_payloads, bool save_num_docs);
 

--- a/src/redisearch_rs/headers/trie_rdb_ffi.h
+++ b/src/redisearch_rs/headers/trie_rdb_ffi.h
@@ -54,7 +54,7 @@ struct LexTrieRs *LexTrieRs_New(void);
  * # Safety
  *
  * - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
- *   Redis module type loader and remain valid for the duration of the
+ *   Redis module type loader and remain [valid] for the duration of the
  *   call.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -71,7 +71,7 @@ struct LexTrieRs *LexTrieRs_RdbLoad(struct RedisModuleIO *io, bool load_payloads
  * # Safety
  *
  * - `io` must be a [valid] `*mut RedisModuleIO` supplied by the calling
- *   Redis module command and remain valid for the duration of the call.
+ *   Redis module command and remain [valid] for the duration of the call.
  * - `map` must be a [valid] pointer to a [`LexTrieRs`] (typically obtained
  *   from [`LexTrieRs_New`] / [`LexTrieRs_RdbLoad`]). It is borrowed
  *   immutably for the duration of the call; no aliasing mutable

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -212,8 +212,10 @@ int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, T
  * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  * - `len` can be 0. If so, `str` is regarded as an empty string.
- * - if `func` is not NULL, it must be a [valid] function pointer of the type [`freeCB`].
+ * - if `func` is not NULL, it must be an [ABI-compatible] function pointer of the type
+ *   [`freeCB`].
  *
+ * [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
@@ -266,11 +268,12 @@ TrieMapResultBuf TrieMap_FindPrefixes(const struct TrieMap *t, const char *str, 
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `func` must either be NULL or a [valid] pointer to a function of type [`freeCB`].
+ * - `func` must either be NULL or an [ABI-compatible] pointer to a function of type
+ *   [`freeCB`].
  * - The Redis allocator must be initialized before calling this function,
  *   and `RedisModule_Free` must not get mutated while running this function.
  *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ * [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
  */
 void TrieMap_Free(struct TrieMap *t, freeCB func);
 
@@ -309,8 +312,10 @@ struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
  * - `minlen` can be 0. If so, `min` is regarded as an empty string.
  * - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
  * - `maxlen` can be 0. If so, `max` is regarded as an empty string.
- * - `callback` must be a [valid] pointer to a function of type [`TrieMapRangeCallback`]
+ * - `callback` must be an [ABI-compatible] pointer to a function of type
+ *   [`TrieMapRangeCallback`]
  *
+ * [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
  * [`NewTrieMap`]: crate::NewTrieMap
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -106,8 +106,10 @@ struct TrieMap *NewTrieMap(void);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ * - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
  *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TrieMapIterator_Free(struct TrieMapIterator *it);
 
@@ -117,12 +119,14 @@ void TrieMapIterator_Free(struct TrieMapIterator *it);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ * - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
  *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
- * - `ptr` must point to a valid pointer to a byte sequence, which will be set to the current key. This
+ * - `ptr` must point to a [valid] pointer to a byte sequence, which will be set to the current key. This
  *   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
- * - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
- * - `value` must point to a valid pointer, which will be set to the value of the current key.
+ * - `len` must point to a [valid] `tm_len_t` which will be set to the length of the current key.
+ * - `value` must point to a [valid] pointer, which will be set to the value of the current key.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len, void * *value);
 
@@ -135,8 +139,10 @@ int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len,
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ * - `it` must point to a [valid] [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
  *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
 
@@ -153,7 +159,9 @@ void TrieMapResultBuf_Free(TrieMapResultBuf buf);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ * - `buf` must point to a [valid] TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
 
@@ -163,7 +171,9 @@ void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ * - `buf` must point to a [valid] TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
 
@@ -179,13 +189,15 @@ size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- *  - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ *  - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  *  - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  *  - `len` can be 0. If so, `str` is regarded as an empty string.
  *  - `value` holds a pointer to the value of the record, which can be NULL
  *  - `cb` must not free the value it returns
  *  - The Redis allocator must be initialized before calling this function,
  *    and `RedisModule_Free` must not get mutated while running this function.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
 
@@ -197,10 +209,12 @@ int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, T
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  * - `len` can be 0. If so, `str` is regarded as an empty string.
- * - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
+ * - if `func` is not NULL, it must be a [valid] function pointer of the type [`freeCB`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
 
@@ -217,13 +231,15 @@ int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  * - `len` can be 0. If so, `str` is regarded as an empty string.
  * - The value behind the returned pointer must not be destroyed by the caller.
  *   Use [`TrieMap_Delete`] to remove it instead.
  * - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
  *   and the pointer must not be dereferenced.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void *TrieMap_Find(const struct TrieMap *t, const char *str, tm_len_t len);
 
@@ -235,11 +251,12 @@ void *TrieMap_Find(const struct TrieMap *t, const char *str, tm_len_t len);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  * - `len` can be 0. If so, `str` is regarded as an empty string.
  *
  * [`NewTrieMap`]: crate::NewTrieMap
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 TrieMapResultBuf TrieMap_FindPrefixes(const struct TrieMap *t, const char *str, tm_len_t len);
 
@@ -249,9 +266,11 @@ TrieMapResultBuf TrieMap_FindPrefixes(const struct TrieMap *t, const char *str, 
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `func` must either be NULL or a valid pointer to a function of type [`freeCB`].
+ * - `func` must either be NULL or a [valid] pointer to a function of type [`freeCB`].
  * - The Redis allocator must be initialized before calling this function,
  *   and `RedisModule_Free` must not get mutated while running this function.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TrieMap_Free(struct TrieMap *t, freeCB func);
 
@@ -263,8 +282,10 @@ void TrieMap_Free(struct TrieMap *t, freeCB func);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `t` must not be freed while the iterator lives.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
 
@@ -283,14 +304,15 @@ struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `trie` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `trie` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `min` can be NULL only if `minlen == 0` or `minlen == -1`. It is not necessarily NULL-terminated.
  * - `minlen` can be 0. If so, `min` is regarded as an empty string.
  * - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
  * - `maxlen` can be 0. If so, `max` is regarded as an empty string.
- * - `callback` must be a valid pointer to a function of type [`TrieMapRangeCallback`]
+ * - `callback` must be a [valid] pointer to a function of type [`TrieMapRangeCallback`]
  *
  * [`NewTrieMap`]: crate::NewTrieMap
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minlen, bool includeMin, const char *max, int maxlen, bool includeMax, TrieMapRangeCallback callback, void *ctx);
 
@@ -309,10 +331,12 @@ void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minle
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `t` must not be freed while the iterator lives.
- * - `prefix` must point to a valid pointer to a byte sequence of length `prefix_len`,
+ * - `prefix` must point to a [valid] pointer to a byte sequence of length `prefix_len`,
  *   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char *prefix, tm_len_t prefix_len, enum tm_iter_mode iter_mode);
 
@@ -321,7 +345,9 @@ struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char 
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t TrieMap_MemUsage(struct TrieMap *t);
 
@@ -333,7 +359,9 @@ size_t TrieMap_MemUsage(struct TrieMap *t);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t TrieMap_NNodes(const struct TrieMap *t);
 
@@ -343,7 +371,9 @@ size_t TrieMap_NNodes(const struct TrieMap *t);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must point to a [valid] TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t TrieMap_NUniqueKeys(const struct TrieMap *t);
 

--- a/src/redisearch_rs/headers/ttl_table.h
+++ b/src/redisearch_rs/headers/ttl_table.h
@@ -47,7 +47,9 @@ struct FieldExpirationSlice FieldExpirationsSlice_Empty(void);
  * the caller.
  *
  * # Safety
- *  - `fields`, when non-null, must point to a valid [`FieldExpirations`].
+ *  - `fields`, when non-null, must point to a [valid] [`FieldExpirations`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct FieldExpirationSlice FieldExpirations_AsSlice(const FieldExpirations *fields);
 
@@ -119,12 +121,14 @@ FieldExpirations FieldExpirations_WithCapacity(size_t cap);
  * afterwards.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`] (no
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`] (no
  *    other reference to it must exist for the duration of the call).
  *  - `field_expirations` must have been produced by [`FieldExpirations_Empty`]
  *    or [`FieldExpirations_WithCapacity`] and must be non-empty.
  *    Sortedness and uniqueness-by-`index` are carried by the type itself.
  *  - `doc_id` must not already be present in the table.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TimeToLiveTable_Add(struct TimeToLiveTable *table, t_docId doc_id, FieldExpirations field_expirations);
 
@@ -133,9 +137,11 @@ void TimeToLiveTable_Add(struct TimeToLiveTable *table, t_docId doc_id, FieldExp
  * No-op if `*table` is already null.
  *
  * # Safety
- *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+ *  - `table` must be a [valid], writable `*mut *mut TimeToLiveTable`.
  *  - If `*table` is non-null, it must point to a value previously returned
  *    by [`TimeToLiveTable_VerifyInit`] and not yet destroyed.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
 
@@ -148,7 +154,7 @@ void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
  * the full [`FieldMask`] width is walked.
  *
  * `ft_id_to_field_index` must point to at least
- * `highest_set_bit(field_mask) + 1` valid `u16` entries.
+ * `highest_set_bit(field_mask) + 1` [valid] `u16` entries.
  * May be `NULL` when `field_mask == 0`.
  *
  * # Returns
@@ -162,9 +168,11 @@ void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
  * Documents with no entry trivially return `true` under either predicate.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
- *  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+ *  - `expiration_point` must be a [valid] `*const t_expirationTimePoint`.
  *  - `ft_id_to_field_index` must satisfy the bound above.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool TimeToLiveTable_FieldMaskSatisfiesPredicate(const struct TimeToLiveTable *table, t_docId doc_id, t_fieldMask field_mask, enum FieldExpirationPredicate predicate, const t_expirationTimePoint *expiration_point, const uint16_t *ft_id_to_field_index, bool wide);
 
@@ -183,8 +191,10 @@ bool TimeToLiveTable_FieldMaskSatisfiesPredicate(const struct TimeToLiveTable *t
  * Documents with no entry trivially satisfy any predicate and return `true`.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
- *  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+ *  - `expiration_point` must be a [valid] `*const t_expirationTimePoint`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool TimeToLiveTable_FieldSatisfiesPredicate(const struct TimeToLiveTable *table, t_docId doc_id, uint16_t field_index, enum FieldExpirationPredicate predicate, const t_expirationTimePoint *expiration_point);
 
@@ -197,7 +207,9 @@ bool TimeToLiveTable_FieldSatisfiesPredicate(const struct TimeToLiveTable *table
  * not be freed by the caller.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct FieldExpirationSlice TimeToLiveTable_GetFieldExpirations(const struct TimeToLiveTable *table, t_docId doc_id);
 
@@ -205,7 +217,9 @@ struct FieldExpirationSlice TimeToLiveTable_GetFieldExpirations(const struct Tim
  * Returns whether the table holds no entries.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool TimeToLiveTable_IsEmpty(const struct TimeToLiveTable *table);
 
@@ -220,8 +234,10 @@ bool TimeToLiveTable_IsEmpty(const struct TimeToLiveTable *table);
  * The current bucket-array length, or `0` if `table` is `NULL`.
  *
  * # Safety
- *  - If non-null, `table` must point to a valid, initialized
+ *  - If non-null, `table` must point to a [valid], initialized
  *    [`TimeToLiveTable`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t TimeToLiveTable_NAllocatedBuckets(const struct TimeToLiveTable *table);
 
@@ -229,8 +245,10 @@ size_t TimeToLiveTable_NAllocatedBuckets(const struct TimeToLiveTable *table);
  * Remove the entry for `doc_id`, if any. No-op if absent.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`] with
+ *  - `table` must point to a [valid], initialized [`TimeToLiveTable`] with
  *    no other live references.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TimeToLiveTable_Remove(struct TimeToLiveTable *table, t_docId doc_id);
 
@@ -243,7 +261,9 @@ void TimeToLiveTable_Remove(struct TimeToLiveTable *table, t_docId doc_id);
  * `max_size` must be ≥ 1, otherwise the function panics
  *
  * # Safety
- *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+ *  - `table` must be a [valid], writable `*mut *mut TimeToLiveTable`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TimeToLiveTable_VerifyInit(struct TimeToLiveTable * *table, size_t max_size);
 

--- a/src/redisearch_rs/headers/types_ffi.h
+++ b/src/redisearch_rs/headers/types_ffi.h
@@ -78,7 +78,7 @@ extern "C" {
  *
  * **Borrowed aggregates:** When `parent.is_copy()` is false, the parent
  * stores a borrowed reference to `child`. The caller retains ownership
- * and must ensure `child` remains valid for the lifetime of `parent`.
+ * and must ensure `child` remains [valid] for the lifetime of `parent`.
  *
  * # Safety
  *

--- a/src/redisearch_rs/headers/types_ffi.h
+++ b/src/redisearch_rs/headers/types_ffi.h
@@ -83,8 +83,10 @@ extern "C" {
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `parent` must point to a valid `RSIndexResult` and cannot be NULL.
- * - `child` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `parent` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ * - `child` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child);
 
@@ -94,7 +96,9 @@ void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t AggregateResult_Capacity(const RSAggregateResult *agg);
 
@@ -115,7 +119,9 @@ void AggregateResult_Free(RSAggregateResult agg);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const RSIndexResult *AggregateResult_Get(const RSAggregateResult *agg, size_t index);
 
@@ -125,9 +131,11 @@ const RSIndexResult *AggregateResult_Get(const RSAggregateResult *agg, size_t in
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * 1. `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
  * 2. `index` must be lower than the length of the aggregate result children vector.
  * 3. `agg` must be of the `Owned` variant.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RSIndexResult *AggregateResult_GetMutUnchecked(RSAggregateResult *agg, size_t index);
 
@@ -136,7 +144,9 @@ RSIndexResult *AggregateResult_GetMutUnchecked(RSAggregateResult *agg, size_t in
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const RSAggregateResult *agg);
 
@@ -146,8 +156,10 @@ struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const RSAggregateRe
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * 1. `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
  * 2. `index` must be lower than the length of the aggregate result children vector.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const RSIndexResult *AggregateResult_GetUnchecked(const RSAggregateResult *agg, size_t index);
 
@@ -157,7 +169,9 @@ const RSIndexResult *AggregateResult_GetUnchecked(const RSAggregateResult *agg, 
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint8_t AggregateResult_KindMask(const RSAggregateResult *agg);
 
@@ -174,7 +188,9 @@ RSAggregateResult AggregateResult_New(size_t cap);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - `agg` must point to a [valid] `RSAggregateResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t AggregateResult_NumChildren(const RSAggregateResult *agg);
 
@@ -185,7 +201,9 @@ size_t AggregateResult_NumChildren(const RSAggregateResult *agg);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const RSAggregateResult *IndexResult_AggregateRef(const RSIndexResult *result);
 
@@ -200,8 +218,10 @@ const RSAggregateResult *IndexResult_AggregateRef(const RSIndexResult *result);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * 1. `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
  * 2. `result`'s data payload must be of the aggregate kind
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RSAggregateResult *IndexResult_AggregateRefMutUnchecked(RSIndexResult *result);
 
@@ -216,8 +236,10 @@ RSAggregateResult *IndexResult_AggregateRefMutUnchecked(RSIndexResult *result);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * 1. `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
  * 2. `result`'s data payload must be of the aggregate kind
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const RSAggregateResult *IndexResult_AggregateRefUnchecked(const RSIndexResult *result);
 
@@ -228,7 +250,9 @@ const RSAggregateResult *IndexResult_AggregateRefUnchecked(const RSIndexResult *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexResult_AggregateReset(RSIndexResult *result);
 
@@ -240,7 +264,9 @@ void IndexResult_AggregateReset(RSIndexResult *result);
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
 
@@ -249,7 +275,7 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
  * - `result` must have been created using one of these:
  *   - [`NewIntersectResult`]
  *   - [`NewUnionResult`]
@@ -259,6 +285,8 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
  *   - [`NewHybridResult`]
  *   - [`NewTokenRecord`]
  *   - [`IndexResult_DeepCopy`]
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexResult_Free(RSIndexResult *result);
 
@@ -268,7 +296,9 @@ void IndexResult_Free(RSIndexResult *result);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool IndexResult_IsAggregate(const RSIndexResult *result);
 
@@ -279,7 +309,9 @@ bool IndexResult_IsAggregate(const RSIndexResult *result);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 double IndexResult_NumValue(const RSIndexResult *result);
 
@@ -290,7 +322,9 @@ double IndexResult_NumValue(const RSIndexResult *result);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSQueryTerm *IndexResult_QueryTermRef(const RSIndexResult *result);
 
@@ -301,7 +335,9 @@ struct RSQueryTerm *IndexResult_QueryTermRef(const RSIndexResult *result);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void IndexResult_SetNumValue(RSIndexResult *result, double value);
 
@@ -312,7 +348,9 @@ void IndexResult_SetNumValue(RSIndexResult *result, double value);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `result` must point to a [valid] `RSIndexResult` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const RSOffsetSlice *IndexResult_TermOffsetsRef(const RSIndexResult *result);
 
@@ -369,7 +407,9 @@ RSIndexResult *NewVirtualResult(double weight, t_fieldMask field_mask);
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+ * - `filter` must point to a [valid] `NumericFilter` and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool NumericFilter_Match(const struct NumericFilter *filter, double value);
 
@@ -382,10 +422,12 @@ bool NumericFilter_Match(const struct NumericFilter *filter, double value);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `dest` must point to a valid [`RSOffsetVector`] and cannot be NULL.
- * - `src` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ * - `dest` must point to a [valid] [`RSOffsetVector`] and cannot be NULL.
+ * - `src` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
  *   and cannot be NULL.
- * - `src` data should point to a valid array of `src.len` offsets.
+ * - `src` data should point to a [valid] array of `src.len` offsets.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RSOffsetVector_CopyData(RSOffsetVector *dest, const RSOffsetSlice *src);
 
@@ -395,9 +437,11 @@ void RSOffsetVector_CopyData(RSOffsetVector *dest, const RSOffsetSlice *src);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+ * - `offsets` must point to a [valid] [`RSOffsetVector`] and cannot be NULL.
  * - The data pointer of `offsets` had been allocated via the global allocator
  *   and points to an array matching the length of `offsets`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RSOffsetVector_FreeData(RSOffsetVector *offsets);
 
@@ -410,9 +454,11 @@ void RSOffsetVector_FreeData(RSOffsetVector *offsets);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ * - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
  *   and cannot be NULL.
  * - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const char *RSOffsetVector_GetData(const RSOffsetSlice *offsets, uint32_t *len);
 
@@ -422,8 +468,10 @@ const char *RSOffsetVector_GetData(const RSOffsetSlice *offsets, uint32_t *len);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ * - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
  *   and cannot be NULL.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t RSOffsetVector_Len(const RSOffsetSlice *offsets);
 
@@ -436,10 +484,12 @@ uint32_t RSOffsetVector_Len(const RSOffsetSlice *offsets);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ * - `offsets` must point to a [valid] offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
  *   and cannot be NULL.
  * - `data` must point to an array of `len` offsets.
  * - if `data` is NULL then `len` should be 0.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RSOffsetVector_SetData(RSOffsetSlice *offsets, const char *data, uint32_t len);
 

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -445,7 +445,7 @@ struct RSValue *RSValue_NewArrayFromBuilder(struct RSValue * *values, uint32_t l
  * 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
  * 2. A nul-terminator is expected in memory at `str+len`.
  * 3. The size determined by `len` excludes the nul-terminator.
- * 4. The memory pointed to by `str` must remain valid and not be mutated for the entire
+ * 4. The memory pointed to by `str` must remain [valid] and not be mutated for the entire
  *    lifetime of the returned [`RSValue`] and any clones of it.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -743,7 +743,7 @@ void RSValue_Replace(struct RSValue * *dstpp, const struct RSValue *src);
  * 3. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
  * 4. A nul-terminator is expected in memory at `str+len`.
  * 5. The size determined by `len` excludes the nul-terminator.
- * 6. The memory pointed to by `str` must remain valid and not be mutated for the entire
+ * 6. The memory pointed to by `str` must remain [valid] and not be mutated for the entire
  *    lifetime of the returned [`RSValue`] and any clones of it.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -356,7 +356,7 @@ void RSValue_MakeReference(const struct RSValue *dst, const struct RSValue *src)
  *
  * # Safety
  *
- * 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
+ * 1. `map` must be a [valid] pointer to an [`RSValueMapBuilder`] created by
  *    [`RSValue_NewMapBuilder`].
  * 2. `key` and `value` must be [valid], non-null pointers to [`RSValue`]s.
  *
@@ -377,7 +377,7 @@ void RSValue_MapBuilderSetEntry(struct RSValueMapBuilder *map, size_t index, str
  * # Safety
  *
  * 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `key` and `value` must be valid, non-null pointers to writable
+ * 2. `key` and `value` must be [valid], non-null pointers to writable
  *    `*mut RSValue` locations.
  *
  * # Panics
@@ -426,7 +426,9 @@ struct RSValue * *RSValue_NewArrayBuilder(uint32_t len);
  *
  * 1. `values` must have been allocated via [`RSValue_NewArrayBuilder`] with
  *    a capacity equal to `len`.
- * 2. All `len` entries in `values` must have been filled with valid [`RSValue`] pointers.
+ * 2. All `len` entries in `values` must have been filled with [valid] [`RSValue`] pointers.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSValue *RSValue_NewArrayFromBuilder(struct RSValue * *values, uint32_t len);
 
@@ -490,9 +492,11 @@ struct RSValueMapBuilder *RSValue_NewMapBuilder(uint32_t len);
  *
  * # Safety
  *
- * 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
+ * 1. `map` must be a [valid] pointer to an [`RSValueMapBuilder`] created by
  *    [`RSValue_NewMapBuilder`].
  * 2. All entries in the map must have been initialized via [`RSValue_MapBuilderSetEntry`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSValue *RSValue_NewMapFromBuilder(struct RSValueMapBuilder *map);
 
@@ -576,7 +580,9 @@ struct RSValue *RSValue_NewRedisString(struct RedisModuleString *str);
  *
  * # Safety
  *
- * 1. `src` must point to a valid [`RSValue`].
+ * 1. `src` must point to a [valid] [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSValue *RSValue_NewReference(const struct RSValue *src);
 

--- a/src/redisearch_rs/headers/varint_ffi.h
+++ b/src/redisearch_rs/headers/varint_ffi.h
@@ -45,8 +45,10 @@ struct VarintVectorWriter *NewVarintVectorWriter(size_t cap);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
+ * 1. `b` must point to a [valid] `BufferReader` instance and cannot be NULL.
  * 2. The caller must have exclusive access to the buffer reader.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint32_t ReadVarint(BufferReader *b);
 
@@ -59,8 +61,10 @@ uint32_t ReadVarint(BufferReader *b);
  *
  * # Safety
  * The following invariants must be upheld when calling this function:
- * 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
+ * 1. `b` must point to a [valid] `BufferReader` instance and cannot be NULL.
  * 2. The caller must have exclusive access to the buffer reader.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 t_fieldMask ReadVarintFieldMask(BufferReader *b);
 
@@ -72,8 +76,10 @@ t_fieldMask ReadVarintFieldMask(BufferReader *b);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void VVW_Free(struct VarintVectorWriter *writer);
 
@@ -84,7 +90,9 @@ void VVW_Free(struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const uint8_t *VVW_GetByteData(const struct VarintVectorWriter *writer);
 
@@ -95,7 +103,9 @@ const uint8_t *VVW_GetByteData(const struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t VVW_GetByteLength(const struct VarintVectorWriter *writer);
 
@@ -106,7 +116,9 @@ size_t VVW_GetByteLength(const struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t VVW_GetCount(const struct VarintVectorWriter *writer);
 
@@ -118,8 +130,10 @@ size_t VVW_GetCount(const struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void VVW_Reset(struct VarintVectorWriter *writer);
 
@@ -131,9 +145,11 @@ void VVW_Reset(struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
  * 3. `len` cannot be NULL and the caller must have exclusive access to it.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 uint8_t *VVW_TakeByteData(struct VarintVectorWriter *writer, size_t *len);
 
@@ -143,8 +159,10 @@ uint8_t *VVW_TakeByteData(struct VarintVectorWriter *writer, size_t *len);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t VVW_Truncate(struct VarintVectorWriter *writer);
 
@@ -158,8 +176,10 @@ size_t VVW_Truncate(struct VarintVectorWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
+ * 1. `writer` must point to a [valid] [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t VVW_Write(struct VarintVectorWriter *writer, uint32_t value);
 
@@ -175,8 +195,10 @@ size_t VVW_Write(struct VarintVectorWriter *writer, uint32_t value);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+ * 1. `writer` must point to a [valid] `BufferWriter` instance and cannot be NULL.
  * 2. The caller must have exclusive access to the buffer writer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t WriteVarint(uint32_t value, BufferWriter *writer);
 
@@ -192,8 +214,10 @@ size_t WriteVarint(uint32_t value, BufferWriter *writer);
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+ * 1. `writer` must point to a [valid] `BufferWriter` instance and cannot be NULL.
  * 2. The caller must have exclusive access to the buffer writer.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
 


### PR DESCRIPTION
Brought up here https://github.com/RediSearch/RediSearch/pull/11066#pullrequestreview-5019043305.

## Describe the changes in the pull request

1. Current: the `[valid]` shorthand linking to std's pointer-validity rules is wired up in six FFI crates; in the other twenty the same word sits as plain prose, so a reader of those `# Safety` contracts has to guess what "valid" guarantees.
2. Change: every pointer-validity use of the word in an FFI doc comment now links to std's definition, with the reference definition added per doc block. Callback parameters get a different link, since std's rules do not govern them.
3. Outcome: internal-only — comments, rustdoc reference definitions and the C headers generated from them, no code. It makes the safety contracts say what they mean, and gives the convention one spelling for future FFI crates to follow.

#### Which additional issues this PR fixes

1. MOD-18065

#### Main objects this PR modified

1. `# Safety` doc comments across 20 `c_entrypoint/*_ffi` crates (58 files) — 390 mentions bracketed as `[valid]`, including the "must remain valid for the lifetime of" duration clauses, whose pointer sense is std's even though the duration it adds is not.
2. `triemap_ffi` callback parameters — `TrieMap_Delete`, `TrieMap_Free` and `TrieMap_IterateRange` require an `[ABI-compatible]` function pointer, linked to std's `primitive.fn` ABI section. std's pointer-validity rules cover accesses through data pointers and say nothing about whether an address is callable under a given ABI.
3. Non-pointer senses left in plain form: `valid UTF-8`, a valid enum variant, a valid nul terminator and a valid index — std's definition says nothing about any of them.
4. `src/redisearch_rs/headers/` — 20 headers regenerated, since cheadergen copies these doc comments into the C API.
5. `// SAFETY:` comments untouched, deliberately: rustdoc does not render non-doc comments, so brackets there would stay literal text.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
