### PR TITLE
[MOD-18065] Document the "valid" pointer-validity link convention for Rust docs

### DIFF
--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -11,6 +11,13 @@ Standards to follow when writing Rust documentation.
 
 - Key concepts should be explained only once. All other documentation should use an intra-documentation link to the first explanation.
 - Always use an intra-documentation link when mentioning a Rust symbol (type, function, constant, etc.).
+- In a `# Safety` section, link the word `valid` to std's pointer-validity rules: write it as
+  `[valid]` and put a `[valid]: https://doc.rust-lang.org/std/ptr/index.html#safety` reference
+  definition at the end of the doc block. Only where it means pointer or memory validity —
+  `valid UTF-8`, a valid enum variant, a valid nul terminator, and "remains valid for the
+  lifetime of" keep their plain form, since std's definition says nothing about them.
+  Non-doc `// SAFETY:` comments keep the plain form too: rustdoc does not render them, so the
+  brackets would stay literal text.
 - Avoid referring to specific lines or line ranges, as they may change over time.
   Use line comments if the documentation needs to be attached to a specific code section inside
   a function/method body.

--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -16,8 +16,9 @@ Standards to follow when writing Rust documentation.
   ```text
   [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
   ```
-  Only where it means pointer or memory validity — `valid UTF-8`, a valid enum variant and a
-  valid nul terminator keep their plain form, since std's definition says nothing about them.
+  Only where it means pointer or memory validity — `valid UTF-8`, a valid enum variant, a valid
+  nul terminator and a by-value struct whose fields must agree keep their plain form, since
+  std's definition says nothing about them.
   A duration clause such as "must remain valid for the lifetime of the returned iterator" does
   mean it, so link it as well; the duration it adds is orthogonal to what validity means.
   A callback parameter is the other way round: std's rules cover accesses through data

--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -12,8 +12,13 @@ Standards to follow when writing Rust documentation.
 - Key concepts should be explained only once. All other documentation should use an intra-documentation link to the first explanation.
 - Always use an intra-documentation link when mentioning a Rust symbol (type, function, constant, etc.).
 - In a `# Safety` section, link the word `valid` to std's pointer-validity rules: write it as
-  `[valid]` and put a `[valid]: https://doc.rust-lang.org/std/ptr/index.html#safety` reference
-  definition at the end of the doc block. Only where it means pointer or memory validity —
+  `[valid]` and put this reference definition at the end of the doc block —
+
+  ```text
+  [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+  ```
+
+  Only where it means pointer or memory validity —
   `valid UTF-8`, a valid enum variant, a valid nul terminator, and "remains valid for the
   lifetime of" keep their plain form, since std's definition says nothing about them.
   Non-doc `// SAFETY:` comments keep the plain form too: rustdoc does not render them, so the

--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -13,11 +13,9 @@ Standards to follow when writing Rust documentation.
 - Always use an intra-documentation link when mentioning a Rust symbol (type, function, constant, etc.).
 - In a `# Safety` section, link the word `valid` to std's pointer-validity rules: write it as
   `[valid]` and put this reference definition at the end of the doc block —
-
   ```text
   [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
   ```
-
   Only where it means pointer or memory validity —
   `valid UTF-8`, a valid enum variant, a valid nul terminator, and "remains valid for the
   lifetime of" keep their plain form, since std's definition says nothing about them.

--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -16,9 +16,10 @@ Standards to follow when writing Rust documentation.
   ```text
   [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
   ```
-  Only where it means pointer or memory validity —
-  `valid UTF-8`, a valid enum variant, a valid nul terminator, and "remains valid for the
-  lifetime of" keep their plain form, since std's definition says nothing about them.
+  Only where it means pointer or memory validity — `valid UTF-8`, a valid enum variant and a
+  valid nul terminator keep their plain form, since std's definition says nothing about them.
+  A duration clause such as "must remain valid for the lifetime of the returned iterator" does
+  mean it, so link it as well; the duration it adds is orthogonal to what validity means.
   Non-doc `// SAFETY:` comments keep the plain form too: rustdoc does not render them, so the
   brackets would stay literal text.
 - Avoid referring to specific lines or line ranges, as they may change over time.

--- a/.skills/rust-docs-guidelines/SKILL.md
+++ b/.skills/rust-docs-guidelines/SKILL.md
@@ -20,6 +20,12 @@ Standards to follow when writing Rust documentation.
   valid nul terminator keep their plain form, since std's definition says nothing about them.
   A duration clause such as "must remain valid for the lifetime of the returned iterator" does
   mean it, so link it as well; the duration it adds is orthogonal to what validity means.
+  A callback parameter is the other way round: std's rules cover accesses through data
+  pointers, not whether an address is callable under a given ABI, so require the signature
+  to be `[ABI-compatible]` instead and define it as —
+  ```text
+  [ABI-compatible]: https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility
+  ```
   Non-doc `// SAFETY:` comments keep the plain form too: rustdoc does not render them, so the
   brackets would stay literal text.
 - Avoid referring to specific lines or line ranges, as they may change over time.


### PR DESCRIPTION
Brought up here https://github.com/RediSearch/RediSearch/pull/11066#pullrequestreview-5019043305.

## Describe the changes in the pull request

1. Current: the Rust docs guidelines say to intra-doc-link every Rust symbol mentioned, but say nothing about the word "valid" in a `# Safety` section, so some FFI crates link it to std's pointer-validity rules and some leave it as prose.
2. Change: the guidelines now name that link as the convention and draw the boundaries — the pointer sense links, including duration clauses; non-pointer senses and non-doc `// SAFETY:` comments keep their plain form; callback parameters ask for an `[ABI-compatible]` signature instead, because std's validity rules govern accesses through data pointers rather than whether an address is callable.
3. Outcome: internal-only, one agent-facing skill file. It gives the convention a written home so future FFI docs match rather than diverge again.

#### Which additional issues this PR fixes

1. MOD-18065

#### Main objects this PR modified

1. `.skills/rust-docs-guidelines/SKILL.md` — one bullet under the intra-doc-link rule, naming both link targets and the cases that keep the plain form.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
