### PR TITLE
[DRAFT] Add inline block repair on the write path

### DIFF
--- a/deps/fast_float/CMakeLists.txt
+++ b/deps/fast_float/CMakeLists.txt
@@ -1,3 +1,7 @@
 ADD_LIBRARY(fast_float_strtod OBJECT fast_float_strtod.cpp)
+# fast_float.h needs C++11 or newer (scoped enums, constexpr). Nothing set a
+# standard for this target, so it fell back to the compiler default — fine on
+# gcc, but Apple clang defaults to C++98 and the header fails to parse.
+target_compile_features(fast_float_strtod PRIVATE cxx_std_20)
 target_compile_definitions(fast_float_strtod PRIVATE FASTFLOAT_SKIP_WHITE_SPACE)
 target_compile_definitions(fast_float_strtod PRIVATE FASTFLOAT_ALLOWS_LEADING_PLUS)

--- a/openspec/changes/inline-block-repair-on-write/benchmarks.md
+++ b/openspec/changes/inline-block-repair-on-write/benchmarks.md
@@ -1,0 +1,353 @@
+# Benchmark results: task 1 gate
+
+Bench: `src/redisearch_rs/inverted_index_bencher/benches/tail_block_repair.rs`
+
+```bash
+cargo bench --manifest-path src/redisearch_rs/Cargo.toml \
+  -p inverted_index_bencher --bench tail_block_repair
+```
+
+Measures one full-block repair (via `scan_gc` on an index built to hold exactly one block)
+against one `add_record` onto an almost-full tail block. `arith` and `hashset` are the two
+`doc_exist` predicates bracketing the real `DocTable_Exists`; see the bench's module docs.
+
+Criterion medians, Apple M-series laptop, single run. **Not a controlled environment** — treat
+the ratios as order-of-magnitude, not as numbers to quote.
+
+## Raw
+
+| Encoding | entries/block | add_record | repair 0% dead | 5% | 25% | 50% |
+|---|---|---|---|---|---|---|
+| `Full` (text) | 100 | 160 ns | 7.10 µs | 6.39 µs | 6.05 µs | 4.61 µs |
+| `DocIdsOnly` (tag) | 1000 | 72.9 ns | 28.18 µs | 24.93 µs | 25.76 µs | 19.96 µs |
+| `Numeric` | 100 | 107 ns | 5.52 µs | 5.49 µs | 5.05 µs | 4.39 µs |
+
+Repair column is the `hashset` predicate — the closer proxy to a doc-table lookup. The `arith`
+predicate runs 10–40% faster on `DocIdsOnly` (17.7 µs at 0%), where 1000 liveness checks are a
+large share of the work; on the 100-entry encodings the two are within run-to-run noise.
+
+## Derived
+
+Repairing each tail block exactly once before it rotates costs `repair / entries_per_block`
+per write:
+
+| Encoding | repair amortized per write | add_record | write-path overhead |
+|---|---|---|---|
+| `Full` | 71 ns | 160 ns | **+44%** |
+| `DocIdsOnly` | 28 ns | 72.9 ns | **+39%** |
+| `Numeric` | 55 ns | 107 ns | **+52%** |
+
+Against the proposal's 5% write-path budget, the affordable repair rate is:
+
+| Encoding | blocks between repairs at 5% budget |
+|---|---|
+| `Full` | ~9 |
+| `DocIdsOnly` | ~8 |
+| `Numeric` | ~10 |
+
+## Verdict on the gate
+
+**The stride mechanism as written in `design.md` does not survive.**
+
+The design assumed a stride of writes could amortize repair to negligible. It cannot, because
+the stride needed (~880 writes for `Full`) is 8–10× the block capacity (100). By the time the
+stride fires, the tail block has rotated 8–10 times. The repair would land on an arbitrary
+freshly-rotated block, which is the block least likely to hold dead entries — maximum cost,
+minimum benefit.
+
+Put plainly: at a 5% budget you can afford to repair roughly one tail block in nine, and you
+cannot choose which one.
+
+## Why, and what it implies
+
+The cost is dominated by **re-encoding survivors, not by detecting them**. Evidence:
+
+1. Repair gets *cheaper* as more entries die — `Full` runs 7.10 µs at 0% dead and 4.61 µs at
+   50%. Fewer survivors, less re-encoding.
+2. `IndexBlock::repair` calls `tmp_inverted_index.add_record(&result)` for every surviving
+   record unconditionally, and when no entry turned out to be dead it returns `None`, throwing
+   the entire re-encoded block away.
+
+So **the most expensive case is the one with zero benefit**, and any triggering heuristic that
+guesses wrong pays full price. That is the wrong cost curve for a write-path feature.
+
+### This is also a live inefficiency in the fork GC
+
+The waste is not specific to this proposal. Every fork-GC scan pays full re-encode on every
+clean block it visits, and in a healthy index most blocks are clean. Making the re-encode lazy
+— start the temporary block only once the first dead entry is seen, and copy the already-read
+prefix at that point — costs a clean block a decode pass and nothing else.
+
+That is worth doing on its own merits, independent of whether inline repair ever ships.
+
+## Recommended next step
+
+Do not proceed to task 2 as written. Instead:
+
+1. Implement lazy re-encode in `IndexBlock::repair`. Ships as a fork-GC improvement with no
+   inline-repair machinery attached, and is independently reviewable.
+2. Re-run this bench. The 0%-dead column is the one to watch; if it drops far enough, the cost
+   model changes shape — a cheap "is this block dirty" pass plus a re-encode paid only when it
+   reclaims something — and the stride objection above may no longer apply.
+3. Only then revisit the inline-repair mechanism in `design.md`, rewritten against the new
+   numbers.
+
+---
+
+# Round 2: lazy re-encode (task 1a)
+
+`IndexBlock::repair` now defers building the replacement block until it sees the first dead
+entry, replaying the surviving prefix from the buffer at that point. A block with no dead
+entries costs a decode pass and no allocation.
+
+Measured as a paired run: current code, then the same bench with only `gc.rs` reverted,
+back to back. `add_record` is the untouched control — the drift it shows is the floor on
+how precisely the two runs can be compared. It moved 1.2% for `Full`, −8.7% for `DocIdsOnly`,
+and −25.6% for `Numeric`, so **the `Full` column is the trustworthy one** and `Numeric`'s
+should be read as direction-only.
+
+The bench also gained deletion patterns, because the position of the first dead entry —
+not the number of dead entries — decides how much prefix has to be replayed. The original
+`prefix-N%` patterns kill the *first* entries, so they never exercise the replay at all;
+`last-only` is its worst case and `every-10th` is the realistic middle.
+
+## One block (`hashset` predicate, medians)
+
+| Encoding | pattern | eager | lazy | change |
+|---|---|---|---|---|
+| `Full` | prefix-0% (clean) | 6.58 µs | **1.87 µs** | **−72%** |
+| `Full` | prefix-5% | 8.26 µs | 8.97 µs | +9% |
+| `Full` | prefix-25% | 6.74 µs | 7.91 µs | +17% |
+| `Full` | prefix-50% | 6.43 µs | 6.39 µs | −1% |
+| `Full` | every-10th | 8.26 µs | 8.50 µs | +3% |
+| `Full` | last-only (worst) | 8.76 µs | 9.70 µs | +11% |
+| `DocIdsOnly` | prefix-0% (clean) | 39.25 µs | **12.90 µs** | **−67%** |
+| `DocIdsOnly` | last-only (worst) | 39.91 µs | 37.07 µs | −7% |
+| `Numeric` | prefix-0% (clean) | 5.99 µs | **2.18 µs** | **−64%** |
+| `Numeric` | last-only (worst) | 8.33 µs | 8.08 µs | −3% |
+
+With the cheap `arith` predicate, where decode dominates and the liveness check is nearly
+free, the clean-block win is larger still: −88% (`Full`), −85% (`DocIdsOnly`), −76%
+(`Numeric`).
+
+**Clean blocks get 3–7× cheaper. Dirty blocks land between −7% and +17%**, consistent with
+the extra decode of the surviving prefix — which shrinks as more entries die, and vanishes
+when the first entry is dead.
+
+## Whole index (`garbage_collection` bench, `Scan`)
+
+This is the number that matters for the fork GC, and it splits sharply by how deletions are
+distributed across blocks.
+
+| Pattern | 1 000 records | | 100 000 records | |
+|---|---|---|---|---|
+| | eager | lazy | eager | lazy |
+| Random 30% — every block dirty | 51.8 µs | 66.7 µs **(+29%)** | 5.33 ms | 5.85 ms **(+10%)** |
+| First 30% — 70% of blocks clean | 62.0 µs | **21.0 µs (−66%)** | 4.87 ms | **1.85 ms (−62%)** |
+| Every 3rd block — 67% clean | 53.2 µs | **18.2 µs (−66%)** | 5.18 ms | **1.58 ms (−69%)** |
+
+**The win is entirely a function of how many blocks are wholly clean.** Where deletions are
+clustered or sparse, a scan gets ~3× cheaper. Where every single block holds a dead entry,
+it gets 10–29% more expensive.
+
+### Is the regression case realistic?
+
+Partly, and it deserves care rather than dismissal. For a block of 100 entries and uniformly
+random deletions, the chance a block is entirely clean is `(1-d)^100`: about 90% at `d`=0.1%,
+36% at 1%, and effectively zero at 30%. So a high uniform deletion rate is genuinely the
+losing case.
+
+But the fork GC scans the *whole index* each cycle, and the dominant term is not blocks
+within one posting list — it is posting lists with no deletions at all, whose blocks are all
+clean and which the eager path currently re-encodes in full before discarding the work. The
+`garbage_collection` bench cannot show that: it only ever measures a single index that does
+have deletions in it. The measured −62% to −69% is therefore closer to the whole-scan reality
+than the +10% to +29% is.
+
+That reasoning is an argument, not a measurement, and it should be confirmed end-to-end
+before this is treated as settled — see below.
+
+## Verdict
+
+Land it. Clean blocks 3–7× cheaper is a large, unambiguous win on the common case; the
+worst measured regression is +29%, on a pattern (30% of documents deleted and uniformly
+spread) that also implies the GC has far more real work to do than the scan overhead.
+
+The regression is removable rather than inherent. The prefix is re-decoded only because the
+survivors were decoded and dropped; since no entry before the first dead one was removed,
+their encoded bytes are still valid verbatim in the replacement block. Copying that byte
+range instead of replaying it would make the lazy path never worse than the eager one. It
+needs care around block metadata and the expiration bitset, so it belongs in its own change.
+
+## Follow-ups
+
+- [ ] Copy the surviving prefix as raw bytes instead of re-decoding it, removing the
+      dirty-block regression.
+- [ ] Confirm the whole-scan argument above against a real index via the macro benchmarks,
+      rather than inferring it from a single-posting-list bench.
+- [ ] Re-open the inline-repair cost model in `design.md`. The clean-block case is now 3–7×
+      cheaper, which is exactly the case a write-path trigger hits most often — the
+      arithmetic in "Verdict on the gate" above was computed against the eager numbers and
+      needs redoing.
+
+## Caveats
+
+- Single run, laptop, no pinning, no controlled CPU frequency. Some `Full` and `Numeric`
+  measurements had 15–35% outliers.
+- Both predicates are proxies. Real `DocTable_Exists` is a C call this crate cannot link — the
+  bencher stubs it with `panic!`. It is plausibly *more* expensive than the `HashSet` probe,
+  which would make these ratios optimistic.
+- Deleted documents are a contiguous prefix, the cheapest pattern to re-encode. Scattered
+  deletions cost more.
+- Single-block, cache-hot, no lock contention, no allocator pressure. All of these push the
+  real cost up, none down.
+
+---
+
+# Round 3: end-to-end macro benchmark
+
+Answers the round-2 follow-up "confirm the whole-scan argument against a real index via the
+macro benchmarks". Measures the shipped feature — `INLINE_GC_BLOCK_REPAIR_THRESHOLD` 0 vs 20
+— on a churning index, plus a threshold sweep, plus two prototypes that are **not** part of
+this change and are recorded here only as evidence for follow-up proposals.
+
+Apple M-series laptop, 24 GB, release build, Redis 8.4.6 built from source (the module
+refuses to load below 8.4.0). Same caveats as rounds 1 and 2: no pinning, no CPU frequency
+control, `fork` on macOS.
+
+## The stock GC benchmark cannot measure this feature
+
+`tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-gc.yml` describes its client phase as
+"continuous HSET updates". It is not. The dataset's keys are `doc:<uuid>:<id>`, while its
+memtier arguments generate `doc:<N>` — the two sets never intersect, so every write inserts a
+new single-field document instead of updating an existing one.
+
+Measured, at threshold 0: `num_docs` rose 1,000,000 → 1,034,374 while memtier reported 34,143
+writes, i.e. every write created a document. Thirty-five forced GC cycles reclaimed 13,545
+bytes in total. With no updates there are no logical deletes, so there is no garbage for
+either GC path to collect, and `inline_gc_repairs` stays 0 whatever the threshold is set to.
+
+That benchmark is also throttled to ~114 ops/s by its own `GC_FORCEINVOKE` calls: a forced
+cycle on a 1.5 GB index takes 6–8 s and the client runs at `-c 1 -t 1`, so it spends most of
+the run blocked. Fixing the key overlap is worth a separate change; it is not a defect in
+this one.
+
+## Harness used instead
+
+- 200,000 real enwiki documents (`title`, `url`, `abstract`, all `TEXT SORTABLE`), loaded by
+  `ftsb_redisearch` from the first 200k rows of the 1M enwiki dataset. A natural-language
+  vocabulary matters: posting-list length distribution is what decides how much of the index
+  a tail-block mechanism can reach.
+- A churn client that discovers the loaded keys via `SCAN` and overwrites them with field
+  values drawn from the same corpus, so updates are real updates and the term distribution is
+  preserved as the index churns. memtier cannot do this — it can only write keys it invents.
+- 180 s, 4 connections, `GC_FORCEINVOKE` from a *separate* connection every 45 s. Firing GC
+  from a writer folds a minutes-long stall into the write latency being compared.
+- ~5.1 M writes per run. Each arm reloads the dataset, so both start from identical state.
+
+## Threshold 0 vs 20
+
+Two reps per arm; both reps are given where they differ.
+
+| Metric | thr 0 | thr 20 | Δ |
+|---|---|---|---|
+| write ops/s | 28,532 / 30,466 | 28,216 / 28,021 | −4.7% |
+| write p50 | 0.124 / 0.118 ms | 0.128 / 0.128 ms | +5.8% |
+| write p99 | 0.378 / 0.350 ms | 0.366 / 0.374 ms | +1.6% |
+| `num_records` | 87.0 / 93.7 M | 72.2 / 71.5 M | −20% |
+| `inverted_sz_mb` | 700 / 750 | 580 / 576 | −22% |
+| peak `used_memory` | 1062 / 1070 MB | 899 / 895 MB | **−16%** |
+| fork GC cycle time | 160 / 128 s | 124 / 122 s | −15% |
+| `gc_blocks_denied` | 408,224 / 408,043 | 406,072 / 406,161 | −0.5% |
+| `inline_gc_repairs` | 0 | 371,660 / 369,007 | — |
+| share of reclaimed bytes | 0% | 44.3% / 44.0% | — |
+
+**Success criterion 1 is met.** Peak RSS is 16% lower and the index 22% smaller, with the
+arms non-overlapping across reps. The cost is ~4.7% write throughput, which is the trade the
+config's help text advertises.
+
+**Success criterion 2 is not met.** `gc_blocks_denied` is unchanged. Inline repair does not
+stop the fork GC from denying tail blocks; it reduces how much garbage those blocks hold.
+Criterion 2 should be restated or dropped — the mechanism does not act on the denial path.
+
+The write-path overhead measured here (+5.8% p50) is far below round 1's +39–52% projection,
+because repairs are rare relative to writes: a repair needs the tail block to be full *and*
+20% dead, and most writes meet neither.
+
+## Threshold sweep
+
+One rep each, same harness, full-block trigger throughout.
+
+| Threshold | write ops/s | peak RSS | `inverted_sz_mb` | `num_records` | inline repairs |
+|---|---|---|---|---|---|
+| 0 (off) | 29,118 | 1046 MB | 712 | 88.5 M | 0 |
+| 5 | 27,984 | 872 | 553 | 68.6 M | 794,072 |
+| 10 | 28,232 | 882 | 564 | 70.0 M | 569,806 |
+| 20 | 26,864 | 868 | 550 | 68.0 M | 351,751 |
+| 50 | 29,118 | 960 | 640 | 79.9 M | 170,331 |
+
+5, 10 and 20 are indistinguishable on residency and within run-to-run noise on write cost.
+50 gives up most of the benefit. The threshold is a weak lever within 5–20; the default of 20
+is defensible and there is no evidence for moving it.
+
+## Prototypes measured, not included in this change
+
+Both were env-gated hacks built only to size the opportunity. Neither is in the diff.
+
+**Removing the full-block gate.** `repair_full_tail_block` returns early unless the tail
+block is full, so a posting list shorter than one block is never repaired — and such a list
+is *entirely* tail, so the fork GC skips it too. Those terms are reclaimed by nothing today,
+and in a natural-language index they are most of the vocabulary. Probing the tail on a stride
+(every 8 appends, and every append below 8 entries) instead:
+
+| | thr 0 | thr 20, full-block | thr 20, stride probe |
+|---|---|---|---|
+| write ops/s | 29,118 | 26,864 | 21,488 (−26%) |
+| write p50 | 0.121 ms | 0.130 ms | 0.171 ms |
+| `num_records` | 88.5 M | 68.0 M | **7.5 M** |
+| `inverted_sz_mb` | 712 | 550 | **95** |
+| peak RSS | 1046 MB | 868 MB | **675 MB** |
+| fork GC cycle time | 146 / 115 s | 129 / 113 s | 67 / 60 s |
+
+The index stays essentially clean, and fork-GC cycles halve because there is far less to
+scan. It costs 26% write throughput at stride 8 — a dial, not a verdict.
+
+**Reconciling the denied tail block in `apply_gc`.** When a writer appends to the last block
+after the fork, the parent drops that block's delta and counts a denial. Repairing the live
+tail block in the parent instead, with `min_reclaim_pct = 0`, measured with inline repair off
+in both arms so the two mechanisms do not mask each other:
+
+| Metric | off | on | Δ |
+|---|---|---|---|
+| `gc_blocks_denied` | 408,524 / 411,435 | 2,773 / 3,066 | **−99.3%** |
+| `bytes_collected` per cycle | 205 / 192 MB | 299 / 310 MB | +55% |
+| `num_records` | 85.9 / 88.5 M | 77.5 / 76.2 M | −12% |
+| peak RSS | 1049 / 1062 MB | 941 / 976 MB | −9% |
+| write ops/s | 28,376 | 28,798 | +1.5% |
+| write p50 / p99 / p99.9 | 0.124 / 0.393 / 0.857 ms | 0.122 / 0.400 / 0.788 ms | ~0 |
+
+This adds parent-side work under the GIL, so a stall was expected; none was measurable at any
+percentile, and cycle time did not grow. It is the only thing measured here that moves
+`gc_blocks_denied`, and it recovers work the child already paid for.
+
+## Follow-ups
+
+- [ ] Fix the key overlap in `search-ftsb-1M-enwiki_abstract-hashes-gc.yml`, or retire it —
+      as written it cannot produce garbage.
+- [ ] Restate or drop success criterion 2. Inline repair does not reduce `gc_blocks_denied`.
+- [ ] Propose the tail-block reconciliation in `apply_gc` as its own change. On this evidence
+      it is close to free and independent of inline repair.
+- [ ] Propose relaxing the full-block gate, with the stride as a tunable. It reaches short
+      posting lists, which nothing reclaims today.
+- [ ] Measure reconciliation and inline repair together. They target the same bytes at
+      different points, so the combination is likely sublinear.
+
+## Caveats
+
+- Two reps per arm for the 0-vs-20 comparison and the reconciliation pair; one rep each for
+  the threshold sweep. Laptop, no pinning, no CPU frequency control.
+- A forced fork-GC cycle takes 2+ minutes on this index, so only one or two cycles complete
+  per 180 s run. Denial and reclaim counts come from that small number of cycles.
+- Automatic GC scheduling is stopped (`GC_STOP_SCHEDULE`) and cycles are forced, so cycle
+  cadence is set by the harness rather than by `FORK_GC_CLEAN_THRESHOLD`.
+- Single index, single shard, one document shape.

--- a/openspec/changes/inline-block-repair-on-write/benchmarks.md
+++ b/openspec/changes/inline-block-repair-on-write/benchmarks.md
@@ -360,10 +360,12 @@ bytes, as expected, but each still reaches garbage the other misses — roughly 
 - [x] Relax the full-block gate — done in this change; the numbers above are the shipped
       trigger.
 - [x] Measure reconciliation and inline repair together — ~70% additive, see above.
-- [ ] Tune the probe stride. 8 costs 26% write throughput; the `num_entries < 8` rule decodes
-      on every append for the shortest lists and is the first thing to try relaxing.
+- [x] Expose the probe stride as a config — `INLINE_GC_BLOCK_REPAIR_STRIDE`, with `0`
+      reproducing the full-block-only trigger and its ~5% cost.
+- [ ] Measure the stride between its endpoints. Only 0 and 8 have numbers; the curve between
+      them is assumed.
 - [ ] Re-measure reconciliation's write cost on a fixed-write-count harness, to settle the
-      contradiction above.
+      contradiction above. Round 4 supplies that harness.
 
 ## Caveats
 
@@ -374,3 +376,67 @@ bytes, as expected, but each still reaches garbage the other misses — roughly 
 - Automatic GC scheduling is stopped (`GC_STOP_SCHEDULE`) and cycles are forced, so cycle
   cadence is set by the harness rather than by `FORK_GC_CLEAN_THRESHOLD`.
 - Single index, single shard, one document shape.
+
+---
+
+# Round 4: automatic GC scheduling, fixed write count
+
+Every earlier round forced GC on a timer with scheduling stopped, so cycle frequency was set
+by the harness rather than by `FORK_GC_CLEAN_THRESHOLD` — the knob an operator actually has.
+This round leaves the scheduler alone and bounds each arm by **write count instead of
+duration**, so the arms produce the same amount of garbage. That matters: in the earlier
+factorial, cells did between 2.17 M and 5.05 M writes, and a faster arm accumulating more
+garbage reads as the slower arm looking cleaner.
+
+200 000 enwiki documents, 3 000 003 writes per arm (exact, all eight arms), 4 connections, no
+forced GC. Two reps per cell.
+
+| Arm | ops/s | p50 | p99.9 | GC cycles | total GC time | `num_records` | peak RSS | `gc_blocks_denied` |
+|---|---|---|---|---|---|---|---|---|
+| inline off, threshold 100 | 23.7k | 0.186 ms | 0.85 ms | 1 | 144.7 s | 49.3 M | 849 MB | 375k |
+| inline on, threshold 100 | 21.8k | 0.170 ms | 0.63 ms | 1.5 | **93.0 s** | 16.4 M | 618 MB | 204k |
+| inline off, threshold 10k | 32.4k | 0.114 ms | 0.47 ms | 1 | 92.8 s | 46.0 M | 815 MB | 409k |
+| inline on, threshold 10k | 21.7k | 0.170 ms | 0.68 ms | 1 | **75.1 s** | 21.0 M | 626 MB | 229k |
+
+## Inline repair reduces total fork-GC time
+
+144.7 s → 93.0 s at threshold 100 (−36%), 92.8 s → 75.1 s at threshold 10k (−19%). The
+inline arms earn that while running *longer in wall-clock* — they write more slowly, so 3 M
+writes take ~138 s against ~93 s — which gives the GC more opportunity, not less. Per second
+of wall clock the GC duty cycle roughly halves.
+
+Residency at equal work: 46–49 M records against 16–21 M, peak RSS 815–849 MB against
+618–626 MB (−25%).
+
+## Denials do drop here, unlike in round 3
+
+375–409k against 204–229k, roughly halved. Round 3 measured them as unchanged and concluded
+inline repair does not touch the denial path. Both are true of their own setup: a denial
+fires per *index* whose last block moved since the fork, and under forced GC on a fully
+garbage-laden index that is nearly every index either way. With automatic scheduling and a
+much smaller index there are fewer indexes with a dirty tail to deny in the first place. The
+round-3 phrasing — that inline repair changes how much garbage a denied block holds rather
+than whether it is denied — remains the mechanism; the count moves as a second-order effect.
+
+## The threshold lever does not appear at this scale
+
+Raising `FORK_GC_CLEAN_THRESHOLD` from 100 to 10000 left the cycle count at 1 either way. A
+cycle on this index takes 75–145 s while 3 M writes take 90–140 s, so the GC is
+**duration-bound, not trigger-bound**: it runs one cycle essentially back to back for the
+whole run and the trigger never becomes the binding constraint. A threshold cannot reduce a
+frequency that is already one-per-run.
+
+The hypothesis it was meant to test — that inline repair slows the growth of
+`deletedOrUpdatedDocsFromLastRun` and so makes a higher threshold affordable — is therefore
+neither confirmed nor refuted here. It needs a regime where cycles are short relative to
+write volume; round 4b uses a 20 000-document index at the same write volume for that.
+
+## Caveats
+
+- `off-t100` is the noisy cell: reps of 14,664 and 32,702 ops/s, a 2.2× spread. Its mean and
+  the −36% derived from it are soft. The other three cells agree within ~1% between reps.
+- The inline-on arms sit at ~21.7k ops/s regardless of threshold, consistent with the
+  write-path cost being a fixed tax. Against the fastest inline-off arm that is a 33%
+  throughput cost, above the 26% measured under forced GC in round 3.
+- One cycle per arm means the GC numbers rest on a single sample of a long, variable
+  operation.

--- a/openspec/changes/inline-block-repair-on-write/benchmarks.md
+++ b/openspec/changes/inline-block-repair-on-write/benchmarks.md
@@ -290,11 +290,9 @@ One rep each, same harness, full-block trigger throughout.
 50 gives up most of the benefit. The threshold is a weak lever within 5–20; the default of 20
 is defensible and there is no evidence for moving it.
 
-## Prototypes measured, not included in this change
+## Removing the full-block gate — measured here, and now shipped
 
-Both were env-gated hacks built only to size the opportunity. Neither is in the diff.
-
-**Removing the full-block gate.** `repair_full_tail_block` returns early unless the tail
+**This is the trigger the change ships.** `repair_full_tail_block` returns early unless the tail
 block is full, so a posting list shorter than one block is never repaired — and such a list
 is *entirely* tail, so the fork GC skips it too. Those terms are reclaimed by nothing today,
 and in a natural-language index they are most of the vocabulary. Probing the tail on a stride
@@ -310,7 +308,18 @@ and in a natural-language index they are most of the vocabulary. Probing the tai
 | fork GC cycle time | 146 / 115 s | 129 / 113 s | 67 / 60 s |
 
 The index stays essentially clean, and fork-GC cycles halve because there is far less to
-scan. It costs 26% write throughput at stride 8 — a dial, not a verdict.
+scan. It costs 26% write throughput at stride 8, against ~5% for the full-block trigger — the
+stride is the dial between them, and 8 is the value measured, not a tuned optimum.
+
+The gain comes from short posting lists. A list that never fills a block is entirely tail, so
+the fork GC skips it (it discards deltas touching the last block) and the full-block trigger
+skipped it too; in a natural-language index those terms are most of the vocabulary. Both
+paths ignoring the same terms is why the full-block-only variant left 68 M records behind
+where this leaves 7.5 M.
+
+## Prototype measured, not included in this change
+
+An env-gated hack built only to size the opportunity. It is not in the diff.
 
 **Reconciling the denied tail block in `apply_gc`.** When a writer appends to the last block
 after the fork, the parent drops that block's delta and counts a denial. Repairing the live
@@ -326,9 +335,20 @@ in both arms so the two mechanisms do not mask each other:
 | write ops/s | 28,376 | 28,798 | +1.5% |
 | write p50 / p99 / p99.9 | 0.124 / 0.393 / 0.857 ms | 0.122 / 0.400 / 0.788 ms | ~0 |
 
-This adds parent-side work under the GIL, so a stall was expected; none was measurable at any
-percentile, and cycle time did not grow. It is the only thing measured here that moves
-`gc_blocks_denied`, and it recovers work the child already paid for.
+It is the only thing measured here that moves `gc_blocks_denied`, and it recovers work the
+child already paid for.
+
+**Its write cost is unresolved.** The pair above shows none. A later factorial — inline ×
+reconcile, interleaved, 2 reps — showed reconciliation pinned at ~12.3k ops/s in both reps
+while the arms without it reached 25–28k when the machine was fast, with fork-GC cycle time
+179 s → 242 s. Those two measurements contradict each other and I cannot explain the
+difference; the GIL stall predicted for parent-side work may well be real. Treat
+"reconciliation is free" as unsupported until it is re-measured on a fixed-write-count
+harness.
+
+That factorial did answer the interaction question, on garbage retained per million writes:
+inline alone −23%, reconciliation alone −21%, both −31%. They overlap on the same tail-block
+bytes, as expected, but each still reaches garbage the other misses — roughly 70% additive.
 
 ## Follow-ups
 
@@ -337,10 +357,13 @@ percentile, and cycle time did not grow. It is the only thing measured here that
 - [ ] Restate or drop success criterion 2. Inline repair does not reduce `gc_blocks_denied`.
 - [ ] Propose the tail-block reconciliation in `apply_gc` as its own change. On this evidence
       it is close to free and independent of inline repair.
-- [ ] Propose relaxing the full-block gate, with the stride as a tunable. It reaches short
-      posting lists, which nothing reclaims today.
-- [ ] Measure reconciliation and inline repair together. They target the same bytes at
-      different points, so the combination is likely sublinear.
+- [x] Relax the full-block gate — done in this change; the numbers above are the shipped
+      trigger.
+- [x] Measure reconciliation and inline repair together — ~70% additive, see above.
+- [ ] Tune the probe stride. 8 costs 26% write throughput; the `num_entries < 8` rule decodes
+      on every append for the shortest lists and is the first thing to try relaxing.
+- [ ] Re-measure reconciliation's write cost on a fixed-write-count harness, to settle the
+      contradiction above.
 
 ## Caveats
 

--- a/openspec/changes/inline-block-repair-on-write/design.md
+++ b/openspec/changes/inline-block-repair-on-write/design.md
@@ -85,32 +85,39 @@ outcome — a clean block — was the most expensive to discover, so every wrong
 price. Now cost tracks benefit: a clean block is cheap to rule out, and the expensive
 re-encode only happens when there is something to reclaim.
 
-#### The trigger: block rotation, not a write counter
+#### The trigger: block fill, plus a stride
 
-A write counter was the plan, and implementation replaced it with something strictly better.
-`take_block` starts a new block on the first write that arrives when the tail already holds
-`RECOMMENDED_BLOCK_ENTRIES` entries. So "the tail block has just filled" is:
+The first implementation fired only when the tail block filled. That is still the most
+valuable moment to check — `take_block` starts a new block on the first write arriving at a
+full tail, so it is the last chance to repair that block inline, and the point at which it
+holds the most reclaimable garbage it ever will while still reachable by a writer.
 
-- **The last chance to repair that block inline.** Once it rotates, no writer touches it
-  again — it is the fork GC's from then on.
-- **The point at which it holds the most reclaimable garbage it ever will** while still
-  reachable by a writer, since it has been accumulating for the whole time it was the tail.
-- **Free to detect.** `blocks.last().num_entries >= RECOMMENDED_BLOCK_ENTRIES` — no state to
-  keep. That matters more than it looks: there is one `InvertedIndex` per *term*, so a
-  counter field would spend memory on every term in the index to answer a question the block
-  length already answers.
+It is not sufficient on its own. **A posting list shorter than one block never fills, so it
+was never repaired — and such a list is entirely tail, so the fork GC skips it too**, because
+it discards any delta touching the last block. Every term below block capacity was therefore
+reclaimed by neither path. In a natural-language index those terms are most of the
+vocabulary; measured end-to-end, closing this gap was worth far more than the full-block case
+alone (`benchmarks.md`, round 3).
 
-The resulting cadence is self-limiting, which is what a write-counter stride had to be tuned
-to approximate:
+So the trigger is: probe when the block has filled, when it holds fewer than
+`PROBE_EVERY_WRITE_BELOW` entries, or every `PROBE_STRIDE` appends in between. The stride
+bounds the added decode rate to one block decode per stride; the every-write bound below it
+exists so there is no gap at the start where a list shorter than one stride is never probed.
+Both constants are equal, which makes it one rule rather than two.
 
-- A clean block is checked once, finds nothing, and rotates away. One check per block — the
-  worst case, and it is exactly the budgeted cost above.
-- A block that reclaims `k` entries drops back below capacity and is checked again only after
-  `k` more writes refill it. Check frequency therefore scales with how much garbage is
-  actually being produced, with no knob to tune.
+The cadence stays self-limiting: a repair that reclaims `k` entries moves the block `k`
+entries back down, so its next probe is `k` writes further away, and check frequency scales
+with how much garbage is actually being produced. No per-index state is needed — there is one
+`InvertedIndex` per *term*, so a counter field would spend memory on every term to answer a
+question the block length already answers.
 
-`repair_full_tail_block` is the gate; `repair_tail_block` is the primitive underneath it, kept
-separate so tests can drive a repair without staging a full block.
+`maybe_repair_tail_block` is the gate; `repair_tail_block` is the primitive underneath it,
+kept separate so tests can drive a repair without staging a particular block length.
+
+The cost is real and is the reason the feature stays off by default: at stride 8 the measured
+write-throughput cost is ~26%, against ~5% for the full-block trigger alone. The stride is the
+dial between the two, and the every-write-below-stride rule is the part most likely to be
+worth revisiting first — it decodes on every append for the shortest lists.
 
 A minimum-reclaim threshold is applied to the *result*: a `Replace` that removes fewer than
 `min_reclaim_pct` of the block's entries is discarded rather than churning the block to drop

--- a/openspec/changes/inline-block-repair-on-write/design.md
+++ b/openspec/changes/inline-block-repair-on-write/design.md
@@ -1,0 +1,245 @@
+# Design: inline block repair on the write path
+
+## Scope
+
+Full-text term indexes and tag indexes first — everything reached through
+`InvertedIndex_WriteEntryGeneric` / `InvertedIndex_WriteForwardIndexEntry`. Numeric range
+trees, the missing-docs and existing-docs indexes, and vector indexes are explicitly out of
+scope for the first iteration; see *Deferred* below.
+
+## Mechanism
+
+### The primitive
+
+`IndexBlock::repair` already does the whole job for one block:
+
+```rust
+pub(crate) fn repair<'block, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
+    &'block self,
+    block_idx: usize,
+    doc_exist: impl Fn(DocId) -> bool,
+    mut repair: Option<impl FnMut(&RSIndexResult<'block>, &RepairContext<'block>)>,
+    _encoder: PhantomData<E>,
+) -> std::io::Result<Option<RepairType>>
+```
+
+It decodes the block, re-encodes surviving records into a temporary index, and returns
+`RepairType::Delete` or `RepairType::Replace { blocks, n_unique_docs_removed }`, or `None`
+when nothing is dead. `InvertedIndex::scan_gc` is a loop over this across all blocks;
+`InvertedIndex::apply_gc` splices the results back in and maintains `n_unique_docs`, the
+block-count delta, and the byte accounting.
+
+Inline repair needs neither the loop nor the fork: one block, repaired and spliced in the
+same call, with no snapshot in between.
+
+### New API
+
+Add to `InvertedIndex<E>` in `src/redisearch_rs/inverted_index/src/gc.rs`:
+
+```rust
+/// Repair the last block in place if at least `threshold_pct` of its entries
+/// belong to documents that no longer exist. Returns `None` when the block was
+/// left untouched.
+pub fn repair_last_block_if_dirty(
+    &mut self,
+    threshold_pct: u8,
+    doc_exist: impl Fn(DocId) -> bool,
+) -> Option<GcApplyInfo>
+```
+
+Contract:
+
+- Operates only on `self.blocks.last()`. A writer has no business touching any other block,
+  and restricting it here keeps the cost bound in the type rather than in a comment.
+- Reuses `IndexBlock::repair` for the decode/re-encode, and the same accounting arithmetic
+  `apply_gc` performs, so `n_unique_docs`, `bytes_freed`, `bytes_allocated`,
+  `entries_removed`, and `block_count_delta` stay consistent between the two paths.
+  Factor the accounting out of `apply_gc` rather than duplicating it — a second copy that
+  drifts is how `n_unique_docs` goes wrong silently.
+- **Must call `gc_marker_inc()` whenever it mutates.** This is the reader-invalidation
+  contract; see *Concurrency* below.
+- `ignored_last_block` is meaningless here (no snapshot) and must be reported as `false`.
+
+### Deciding when to repair
+
+A stride counter, but only viable because of the lazy re-encode landed in task 1a. The first
+attempt at this section was measured and rejected: with eager re-encode, staying inside a 5%
+write budget demanded a stride of 8–10× the block capacity, so a check always landed on a
+block that had long since rotated away.
+
+Lazy re-encode makes a *clean* tail-block check cost a decode pass and nothing else, which is
+what changes the arithmetic:
+
+| Encoding | clean check | `add_record` | writes/check @5% | @10% | block capacity |
+|---|---|---|---|---|---|
+| `Full` | 1.87 µs | 219 ns | 171 | 85 | 100 |
+| `DocIdsOnly` | 12.90 µs | 92 ns | 2804 | 1402 | 1000 |
+| `Numeric` | 2.18 µs | 124 ns | 352 | 176 | 100 |
+
+At a 10% budget the affordable cadence is 0.85–1.4× block capacity — roughly one check per
+block, which is the cadence the mechanism needs. **This is a deliberate trade of write
+throughput for smaller, less bursty GC cycles**, made explicitly rather than as a free win.
+
+The cost curve is also now the right shape. Under eager re-encode the *cheapest* possible
+outcome — a clean block — was the most expensive to discover, so every wrong guess paid full
+price. Now cost tracks benefit: a clean block is cheap to rule out, and the expensive
+re-encode only happens when there is something to reclaim.
+
+#### The trigger: block rotation, not a write counter
+
+A write counter was the plan, and implementation replaced it with something strictly better.
+`take_block` starts a new block on the first write that arrives when the tail already holds
+`RECOMMENDED_BLOCK_ENTRIES` entries. So "the tail block has just filled" is:
+
+- **The last chance to repair that block inline.** Once it rotates, no writer touches it
+  again — it is the fork GC's from then on.
+- **The point at which it holds the most reclaimable garbage it ever will** while still
+  reachable by a writer, since it has been accumulating for the whole time it was the tail.
+- **Free to detect.** `blocks.last().num_entries >= RECOMMENDED_BLOCK_ENTRIES` — no state to
+  keep. That matters more than it looks: there is one `InvertedIndex` per *term*, so a
+  counter field would spend memory on every term in the index to answer a question the block
+  length already answers.
+
+The resulting cadence is self-limiting, which is what a write-counter stride had to be tuned
+to approximate:
+
+- A clean block is checked once, finds nothing, and rotates away. One check per block — the
+  worst case, and it is exactly the budgeted cost above.
+- A block that reclaims `k` entries drops back below capacity and is checked again only after
+  `k` more writes refill it. Check frequency therefore scales with how much garbage is
+  actually being produced, with no knob to tune.
+
+`repair_full_tail_block` is the gate; `repair_tail_block` is the primitive underneath it, kept
+separate so tests can drive a repair without staging a full block.
+
+A minimum-reclaim threshold is applied to the *result*: a `Replace` that removes fewer than
+`min_reclaim_pct` of the block's entries is discarded rather than churning the block to drop
+one entry. A `Replace` that yields more than one block is rejected outright — removing an
+entry can widen a doc-ID delta past the encoder's range and force a split, which would grow
+the index instead of shrinking it. Those entries are left to the fork GC, which can afford the
+split because it is not on the write path.
+
+#### What this does and does not reach
+
+Writers only ever touch the tail block, and garbage accumulates in a block in proportion to
+the time it spends *without* writes. The two facts pull against each other, and they bound
+what inline repair can do:
+
+- **Reaches:** hot terms under update-heavy traffic, where the tail keeps receiving writes
+  while superseded versions of recently-written documents die in it. This is the traffic-spike
+  case that motivated the change.
+- **Does not reach:** cold terms, whose tail block accumulates garbage precisely because
+  nothing writes to it, and non-tail blocks of any term.
+
+Everything in the second row stays the fork GC's job. Inline repair narrows what a fork cycle
+has to reclaim; it does not remove the need for one.
+
+### Where it hooks in
+
+`writeIndexEntry` in `src/indexer.c` is the single funnel for full-text term writes and
+already consumes an `AddRecordOutcome { mem_growth, blocks_added }` to update
+`spec->stats`. `src/tag_index.c` has the parallel call for tags.
+
+The `doc_exist` predicate is the constraint on *where* the hook can live. The
+`inverted_index` crate has no doc-table access; the FFI layer does, and already builds exactly
+this closure for the fork GC:
+
+```rust
+// src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+let doc_exists = |id| unsafe { DocTable_Exists(&doc_table, id) };
+```
+
+So the hook is a new FFI entry point alongside `InvertedIndex_WriteEntryGeneric` that takes the
+doc table, not a change to `add_record` itself. Two options, to be decided in review:
+
+- **(a) Extend the write call.** `InvertedIndex_WriteEntryGeneric` grows a doc-table argument
+  and performs the repair itself, returning the reclaim in an extended `AddRecordOutcome`.
+  One FFI crossing, but couples every writer to the doc table.
+- **(b) Separate follow-up call.** Writers call `InvertedIndex_MaybeRepairTail(idx, &doc_table)`
+  after the write. Two crossings, but writers that cannot supply a doc table (RDB load, the
+  missing/existing-docs indexes) simply do not call it.
+
+(b) is preferred: it keeps `add_record` unchanged, makes the feature opt-in per call site, and
+makes "this path does not do inline repair" explicit at the call site rather than implicit in a
+null argument.
+
+Either way the extra reclaim must reach `spec->stats` with the correct sign.
+`IndexStats_BlockCountAdd` already accepts a signed delta; `spec->stats.invertedSize` and
+`numRecords` are plain counters and need to be decremented, which is new for the write path.
+
+## Concurrency
+
+This is where the proposal lives or dies, and it rested on one claim, now **confirmed**:
+
+> **Open question A (resolved).** Does the full-text write path run under
+> `RedisSearchCtx_LockSpecWrite`, excluding all concurrent readers of the same spec?
+
+Yes. `AddDocumentCtx_Submit` has exactly one caller, and it is bracketed by the write lock
+with no conditional in between:
+
+```
+src/spec.c:3491  RedisSearchCtx_LockSpecWrite(&sctx);
+src/spec.c:3498  AddDocumentCtx_Submit(aCtx, &sctx, DOCUMENT_ADD_REPLACE);
+src/spec.c:3504  RedisSearchCtx_UnlockSpec(&sctx);
+```
+
+and from there `Document_AddToIndexes` → `IndexDocument` → `Indexer_Process` → `indexText` →
+`writeIndexEntry`, which is where the repair hook sits. `document.c` takes no lock of its own
+on this path — the only lock ops in that file guard the partial-update path, and are a *read*
+lock.
+
+The safety argument follows: a repair mutating `self.blocks` is exactly what `apply_gc`
+already does under the same lock, so inline repair introduces no new reader/writer
+interleaving. The existing invalidation contract carries the rest — `RawIndexReaderCore`
+caches `gc_marker` and `ii_unique_id` and compares them against the index to detect that
+blocks moved, which is why `repair_tail_block` must bump the marker on any mutation (and, just
+as deliberately, must *not* bump it on a no-op).
+
+This holds for the full-text path that is wired. Any writer added later must be re-checked
+against the same claim rather than assumed to inherit it — which is a further argument for the
+opt-in call shape in option (b): a path that cannot supply the lock simply does not call.
+
+Two further interactions to settle in review:
+
+- **Suspended readers.** `RawIndexReaderCore` can be suspended across a lock release and
+  re-promoted. A repair between suspend and resume is indistinguishable from a fork-GC apply in
+  the same window, so the existing resume path should cover it — but this needs a test, not an
+  assumption.
+- **Concurrent fork GC.** A fork child scans the tail block, and the parent then discards that
+  delta via `ignored_last_block` if `num_entries` changed. An inline repair changes
+  `num_entries`, so it makes that discard *more* likely, not less — correct but wasteful.
+  Once inline repair owns the tail, the fork GC's scan could skip the last block entirely and
+  save the work. Worth doing, but as a follow-up, not in the first change.
+
+## Failure modes considered
+
+| Mode | Consequence | Mitigation |
+|---|---|---|
+| Repair on every write | Write throughput collapses | Stride counter; threshold; default off |
+| Block churn — repair a block, immediately append, repair again | Wasted CPU, allocation thrash | Stride resets on repair, not on write |
+| `n_unique_docs` drifts between inline and fork paths | Wrong `FT.INFO` doc counts, wrong IDF | Shared accounting helper, property test asserting the two paths agree |
+| Repair splits one block into several (`Replace` with >1 block) | Tail is no longer the block the writer expects | Reject a `Replace` that does not reduce block count when applied to the tail |
+| Doc table lookup per entry is slow | Repair cost exceeds the budget | Benchmark `DocTable_Exists` in the repair loop before committing to the design |
+
+## Alternatives rejected
+
+- **Reader-driven repair.** Iterators already skip dead docs and know exactly which blocks are
+  dirty. Rejected: readers hold the read lock and cannot mutate, so this needs deferred queues
+  or epoch reclamation — a much larger change for a signal the writer can approximate cheaply.
+- **Repair all blocks of the touched index on write.** Unbounded per-write cost proportional to
+  posting-list length; the hot terms with the longest lists would pay the most.
+- **Replacing the fork GC entirely.** Cold terms are never written to, so their garbage would
+  never be reclaimed. See the proposal's complement table.
+- **Budgeted in-process incremental GC** (cursor over the terms trie, N terms per tick, no
+  fork). A genuinely promising alternative that addresses the same latency problem from the
+  other side, and it subsumes more of the fork GC's work. Deferred rather than rejected: it
+  trades a fork stall for many short write-lock windows, and whether that nets out needs a
+  prototype. Inline repair is the smaller, independently useful step and does not preclude it.
+
+## Deferred
+
+- Numeric range trees (`numeric_range_tree`), missing-docs, existing-docs indexes — same
+  primitive applies, but each has its own accounting (numeric carries HLL registers that must
+  be recomputed) and deserves separate benchmarking.
+- Having the fork GC skip the tail block once inline repair owns it.
+- Inline repair on the delete path rather than the next write.

--- a/openspec/changes/inline-block-repair-on-write/design.md
+++ b/openspec/changes/inline-block-repair-on-write/design.md
@@ -100,10 +100,16 @@ vocabulary; measured end-to-end, closing this gap was worth far more than the fu
 alone (`benchmarks.md`, round 3).
 
 So the trigger is: probe when the block has filled, when it holds fewer than
-`PROBE_EVERY_WRITE_BELOW` entries, or every `PROBE_STRIDE` appends in between. The stride
-bounds the added decode rate to one block decode per stride; the every-write bound below it
-exists so there is no gap at the start where a list shorter than one stride is never probed.
-Both constants are equal, which makes it one rule rather than two.
+`PROBE_EVERY_WRITE_BELOW` entries, or every `INLINE_GC_BLOCK_REPAIR_STRIDE` appends in
+between. The stride bounds the added decode rate to one block decode per stride; the
+every-append bound below it exists so there is no gap at the start, where a list shorter than
+one stride would never be probed.
+
+**The every-append bound is a constant, not a function of the stride.** Deriving it from the
+stride is the obvious simplification and it is wrong: it inverts the dial. With the two tied
+together, a stride of 1024 puts every block below 1024 entries into the probe-always region,
+so the setting an operator reaches for to *reduce* cost increases it everywhere except full
+blocks. A test pins this (`maybe_repair_tail_block_stride_is_monotonic`).
 
 The cadence stays self-limiting: a repair that reclaims `k` entries moves the block `k`
 entries back down, so its next probe is `k` writes further away, and check frequency scales
@@ -114,10 +120,13 @@ question the block length already answers.
 `maybe_repair_tail_block` is the gate; `repair_tail_block` is the primitive underneath it,
 kept separate so tests can drive a repair without staging a particular block length.
 
-The cost is real and is the reason the feature stays off by default: at stride 8 the measured
-write-throughput cost is ~26%, against ~5% for the full-block trigger alone. The stride is the
-dial between the two, and the every-write-below-stride rule is the part most likely to be
-worth revisiting first — it decodes on every append for the shortest lists.
+The cost is real and is the reason the feature stays off by default: at the default stride of
+8 the measured write-throughput cost is ~26%, against ~5% for the full-block trigger alone.
+
+That span is why the stride is a runtime config rather than a constant.
+`INLINE_GC_BLOCK_REPAIR_STRIDE` moves along it: 0 is the full-block-only trigger and its ~5%,
+8 is the measured aggressive end, and values between trade the two. Only the endpoints have
+been measured; the shape in between is assumed, not established.
 
 A minimum-reclaim threshold is applied to the *result*: a `Replace` that removes fewer than
 `min_reclaim_pct` of the block's entries is discarded rather than churning the block to drop

--- a/openspec/changes/inline-block-repair-on-write/proposal.md
+++ b/openspec/changes/inline-block-repair-on-write/proposal.md
@@ -34,6 +34,11 @@ it just wrote to has accumulated a configurable proportion of entries for docume
 longer exist, repair that one block in place, immediately, inside the write that is already
 in progress.
 
+The writer inspects the tail block when it fills, and periodically before then. The periodic
+check is what reaches posting lists shorter than one block — those are entirely tail, so the
+fork GC never repairs them either, and they are most of the vocabulary in a natural-language
+index.
+
 The writer already holds the index and the block, already holds whatever lock the write path
 holds, and the block is already in cache. The repair is bounded by one block, so the added
 per-write cost is bounded and predictable rather than a periodic spike.
@@ -78,8 +83,9 @@ the cold body of the index. Neither alone is sufficient.
    `logically deleted` docs are lower with inline repair enabled than without, at equal
    fork-GC settings.
 
-   **Met.** Peak RSS 16% lower and the index 22% smaller, for ~4.7% write throughput; see
-   `benchmarks.md` round 3.
+   **Met.** With the shipped trigger, peak RSS 35% lower and the index 87% smaller, for ~26%
+   write throughput; fork-GC cycles also halve, because there is far less left to scan. The
+   full-block-only variant was 16% / 22% for ~4.7%. See `benchmarks.md` round 3.
 
 2. ~~`gc_blocks_denied` per fork-GC cycle drops measurably on the same workload.~~
 
@@ -90,6 +96,19 @@ the cold body of the index. Neither alone is sufficient.
    round 3 and left to its own proposal.
 3. Write-path throughput regression stays within an agreed budget (proposed: p99 of
    `FT.ADD`-equivalent indexing latency within 5% of baseline at the default threshold).
+
+   **Met at the default, exceeded when enabled — needs a maintainer decision.** The default
+   is `0`, where the feature is inert and the cost is nil, so the criterion as literally
+   worded is satisfied. That reading is too convenient to rely on. When enabled, the shipped
+   trigger costs ~26% write throughput (p50 0.121 → 0.171 ms); the full-block-only trigger
+   cost ~5% and would have met the budget on any reading, but reclaimed a fraction as much —
+   68 M residual records against 7.5 M.
+
+   The budget was written before either number existed. Either it should be restated as a
+   budget *when enabled*, with 26% accepted as the price of the reclaim, or the stride should
+   become configurable so an operator picks their own point on that curve. Deciding this is a
+   precondition for the default ever moving off `0`.
+
 4. No change to query results, `FT.INFO` doc counts, or RDB round-trip behavior.
 
 Criteria 1–3 are the gate: if the write-path cost cannot be held inside the budget while

--- a/openspec/changes/inline-block-repair-on-write/proposal.md
+++ b/openspec/changes/inline-block-repair-on-write/proposal.md
@@ -45,8 +45,10 @@ per-write cost is bounded and predictable rather than a periodic spike.
 
 User-visible surface:
 
-- One new runtime config, `INLINE_GC_BLOCK_REPAIR_THRESHOLD` (percent of dead entries in a
-  block, `0` disables the feature). Default off for the first release.
+- Two new runtime configs: `INLINE_GC_BLOCK_REPAIR_THRESHOLD` (percent of dead entries in a
+  block, `0` disables the feature; default off for the first release) and
+  `INLINE_GC_BLOCK_REPAIR_STRIDE` (how often a writer inspects a tail block that has not
+  filled; `0` restricts repair to filled blocks).
 - New counters in `FT.INFO` `gc_stats`: `inline_repairs`, `inline_bytes_collected`.
 - No new command, no change to query results, no change to the persistence format.
 
@@ -104,10 +106,13 @@ the cold body of the index. Neither alone is sufficient.
    cost ~5% and would have met the budget on any reading, but reclaimed a fraction as much —
    68 M residual records against 7.5 M.
 
-   The budget was written before either number existed. Either it should be restated as a
-   budget *when enabled*, with 26% accepted as the price of the reclaim, or the stride should
-   become configurable so an operator picks their own point on that curve. Deciding this is a
-   precondition for the default ever moving off `0`.
+   The budget was written before either number existed, and the resolution taken here is the
+   dial: `INLINE_GC_BLOCK_REPAIR_STRIDE` spans the two points, with `0` giving the
+   full-block-only trigger and its ~5%. An operator who wants the budget can have it; one who
+   would rather trade write throughput for the elimination of GC stalls can have that
+   instead. What remains for maintainers is whether the *default* stride should be the
+   aggressive end (as shipped) or the cheap one — which only bites once the threshold default
+   moves off `0`.
 
 4. No change to query results, `FT.INFO` doc counts, or RDB round-trip behavior.
 

--- a/openspec/changes/inline-block-repair-on-write/proposal.md
+++ b/openspec/changes/inline-block-repair-on-write/proposal.md
@@ -1,0 +1,111 @@
+# Inline block repair on the write path
+
+## Problem
+
+Deleting or updating a document in RediSearch is a *logical* delete: the doc is flagged
+`Document_Deleted` in the doc table and `ForkGC.deletedOrUpdatedDocsFromLastRun` is
+incremented, but every inverted-index posting for that document stays encoded in its block.
+Reclaiming those bytes is the fork GC's job, and the fork GC pays for it in a way that hurts
+exactly when the system is busiest:
+
+1. **The trigger correlates with load.** A cycle fires when
+   `deletedOrUpdatedDocsFromLastRun >= FORK_GC_CLEAN_THRESHOLD`. A traffic spike is largely
+   updates, an update is a delete plus an insert, so a spike drives the counter across the
+   threshold and forks *during* the spike.
+2. **`fork()` stalls the main thread.** `forkGCChild` is called with the GIL held. The stall
+   scales with page-table size, so with RSS.
+3. **Post-fork COW faults tax every writer** that touches a page the child shares, for the
+   whole lifetime of the child.
+4. **The work is then partly discarded.** The child's snapshot is stale by the time the parent
+   applies it. `InvertedIndex::apply_gc` drops any delta touching the last block if its
+   `num_entries` changed since the scan, reporting `ignored_last_block`
+   (surfaced as `gc_blocks_denied` in `FT.INFO`). Under a write-heavy spike this is the common
+   case for hot terms, so the expensive cycle reclaims least where garbage accumulates fastest.
+
+There is also a standing structural gap independent of latency: **the last block of an index
+is never repaired by design**, because a writer may have appended to it since the fork. On an
+append-heavy index with repeated updates to recent documents, dead entries in the tail can
+survive many cycles.
+
+## What changes
+
+Add **inline block repair**: when a writer appends a posting to an inverted index and the block
+it just wrote to has accumulated a configurable proportion of entries for documents that no
+longer exist, repair that one block in place, immediately, inside the write that is already
+in progress.
+
+The writer already holds the index and the block, already holds whatever lock the write path
+holds, and the block is already in cache. The repair is bounded by one block, so the added
+per-write cost is bounded and predictable rather than a periodic spike.
+
+User-visible surface:
+
+- One new runtime config, `INLINE_GC_BLOCK_REPAIR_THRESHOLD` (percent of dead entries in a
+  block, `0` disables the feature). Default off for the first release.
+- New counters in `FT.INFO` `gc_stats`: `inline_repairs`, `inline_bytes_collected`.
+- No new command, no change to query results, no change to the persistence format.
+
+## What does not change
+
+Inline repair **does not replace the fork GC**, and this proposal does not remove or disable
+it. A writer only ever touches the last block of terms that appear in the document being
+written. Dead entries in cold terms, and in non-tail blocks of hot terms, are never visited by
+a writer and remain the fork GC's responsibility. The two are complements:
+
+| | Reclaims | Left to the other |
+|---|---|---|
+| Inline repair | Tail blocks of actively-written terms | Everything not written to |
+| Fork GC | All blocks except the tail | The tail |
+
+Inline repair closes the fork GC's structural last-block gap, and the fork GC keeps covering
+the cold body of the index. Neither alone is sufficient.
+
+## Why this shape
+
+- **No fork, no COW, no stale snapshot.** Repair happens against the live index with no
+  intervening window, so `ignored_last_block` cannot apply and no work is discarded.
+- **The primitive already exists.** `IndexBlock::repair` in
+  `src/redisearch_rs/inverted_index/src/gc.rs` already repairs exactly one block given a
+  `doc_exist` predicate, and `InvertedIndex::scan_gc` is a loop over it. Inline repair is that
+  loop body applied to a single block, plus the accounting that `apply_gc` already performs.
+- **The reader-invalidation contract already exists.** `apply_gc` calls `gc_marker_inc`, and
+  `RawIndexReaderCore` compares its cached marker against the index's to detect that a GC moved
+  the blocks underneath it. Inline repair reuses that contract unchanged.
+
+## Success criteria
+
+1. On a workload of repeated updates to a bounded key set, peak RSS and steady-state
+   `logically deleted` docs are lower with inline repair enabled than without, at equal
+   fork-GC settings.
+
+   **Met.** Peak RSS 16% lower and the index 22% smaller, for ~4.7% write throughput; see
+   `benchmarks.md` round 3.
+
+2. ~~`gc_blocks_denied` per fork-GC cycle drops measurably on the same workload.~~
+
+   **Not met, and wrong as stated.** Denials are unchanged (408k vs 406k). A denial happens
+   whenever a writer touched the last block since the fork, which inline repair does not
+   affect — it changes how much garbage that block holds, not whether the delta for it is
+   dropped. Reclaiming the denied block is a separate mechanism, measured in `benchmarks.md`
+   round 3 and left to its own proposal.
+3. Write-path throughput regression stays within an agreed budget (proposed: p99 of
+   `FT.ADD`-equivalent indexing latency within 5% of baseline at the default threshold).
+4. No change to query results, `FT.INFO` doc counts, or RDB round-trip behavior.
+
+Criteria 1–3 are the gate: if the write-path cost cannot be held inside the budget while
+showing a real reclaim win, the change should not land.
+
+## Open questions for maintainers
+
+1. Should the threshold be a percentage of block entries, an absolute dead-entry count, or
+   both (whichever trips first)? A percentage alone under-triggers on small blocks.
+2. Should inline repair also run on the *delete* path (where the doc-to-dead transition is
+   known) rather than only on the next write that happens to touch the block?
+3. Is `ENABLE_UNSTABLE_FEATURES` the right initial gate, or is a default-off config sufficient
+   given there is no new command surface?
+
+## See also
+
+- [`design.md`](design.md) — mechanism, locking, and the failure modes that decide viability
+- [`tasks.md`](tasks.md) — implementation checklist
+- [`specs/garbage-collection/spec.md`](specs/garbage-collection/spec.md) — behavior delta

--- a/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
+++ b/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
@@ -1,0 +1,102 @@
+# garbage-collection (delta)
+
+> On merge, the requirements below would be folded into
+> `openspec/specs/garbage-collection/spec.md`.
+
+## ADDED Requirements
+
+### Requirement: Inline repair of the tail block on write
+
+When a writer appends a posting to an inverted index, RediSearch SHALL be able to reclaim
+entries in that index's last block belonging to documents that no longer exist, in the same
+operation as the write, without forking a child process.
+
+Inline repair SHALL be confined to the last block of the index being written. It SHALL NOT
+visit or modify any other block.
+
+#### Scenario: Tail block has no dead entries
+- **WHEN** a document is indexed into a term whose last block contains no entries for deleted documents
+- **THEN** the index SHALL be unchanged apart from the appended posting
+- **AND** the index's GC marker SHALL NOT be incremented
+
+#### Scenario: Tail block is partly dead
+- **WHEN** a term's last block contains entries for deleted documents at or above the configured threshold
+- **AND** a document is indexed into that term
+- **THEN** the entries for deleted documents SHALL be removed from that block
+- **AND** the surviving entries SHALL decode to the same records, in the same order, as before the repair
+- **AND** the index's GC marker SHALL be incremented
+
+#### Scenario: Tail block is entirely dead
+- **WHEN** every entry in a term's last block belongs to a deleted document
+- **AND** a document is indexed into that term
+- **THEN** that block SHALL be removed from the index
+- **AND** the index's block count SHALL be reduced accordingly
+
+#### Scenario: Accounting agrees with the fork GC
+- **WHEN** an index is repaired inline
+- **AND** an identical index is repaired by a fork-GC scan and apply
+- **THEN** both indexes SHALL report the same unique document count, the same entry count, and the same decoded contents
+
+#### Scenario: Queries are unaffected by a concurrent repair
+- **WHEN** a query is executing against an index whose tail block is repaired inline during that execution
+- **THEN** the query SHALL return the same result set it would return with no concurrent write
+- **AND** no result SHALL be returned twice
+
+#### Scenario: Persistence round-trip after inline repair
+- **WHEN** an index has been repaired inline
+- **AND** the index is saved to RDB and reloaded
+- **THEN** the reloaded index SHALL contain the same documents and return the same query results
+
+### Requirement: Inline repair is configurable and off by default
+
+RediSearch SHALL expose a runtime configuration controlling the dead-entry proportion at which
+inline repair triggers. The value `0` SHALL disable inline repair entirely. The default SHALL
+be `0`.
+
+#### Scenario: Disabled by default
+- **WHEN** a server is started with no explicit inline-repair configuration
+- **AND** documents are indexed and deleted
+- **THEN** no inline repair SHALL occur
+- **AND** garbage collection behavior SHALL be identical to a build without this feature
+
+#### Scenario: Enabling at runtime
+- **WHEN** the user sets the inline-repair threshold to a non-zero value via `FT.CONFIG SET`
+- **THEN** subsequent writes SHALL be eligible for inline repair
+- **AND** no restart SHALL be required
+
+### Requirement: Inline repair is reported in index statistics
+
+`FT.INFO` SHALL report the number of inline repairs performed and the net bytes they
+reclaimed, as `inline_gc_repairs` and `inline_gc_bytes_collected`. The same values SHALL
+appear in the module's `INFO` section.
+
+These are per-spec counters reported alongside `total_inverted_index_blocks`, not inside the
+`gc_stats` section: `gc_stats` is rendered from the fork GC's own context, which has no access
+to these, and keeping them separate lets the two reclaim paths be compared rather than summed.
+
+#### Scenario: Counters advance
+- **WHEN** inline repair is enabled and at least one repair has occurred on an index
+- **THEN** `FT.INFO` on that index SHALL report a non-zero `inline_gc_repairs`
+- **AND** a non-zero `inline_gc_bytes_collected`
+
+#### Scenario: Counters stay at zero while disabled
+- **WHEN** inline repair is disabled
+- **THEN** both counters SHALL remain 0 regardless of indexing and deletion activity
+
+## MODIFIED Requirements
+
+### Requirement: The fork GC does not repair the last block
+
+This existing behavior is unchanged, but its consequence changes: with inline repair enabled,
+the last block is covered by the write path instead of being left indefinitely.
+
+The fork GC SHALL continue to discard any scan delta referring to the last block when that
+block changed between the scan and the apply, and SHALL continue to report this as
+`gc_blocks_denied`.
+
+#### Scenario: Inline repair changes the tail during a fork-GC cycle
+- **WHEN** a fork-GC child has scanned an index
+- **AND** an inline repair modifies that index's last block before the parent applies the delta
+- **THEN** the parent SHALL discard the delta entry for the last block
+- **AND** the remaining blocks SHALL still be repaired
+- **AND** the index SHALL remain correct

--- a/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
+++ b/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
@@ -14,6 +14,19 @@ operation as the write, without forking a child process.
 Inline repair SHALL be confined to the last block of the index being written. It SHALL NOT
 visit or modify any other block.
 
+Inline repair SHALL be eligible on a posting list whose last block has not filled. A list
+shorter than one block is entirely tail, and the fork GC does not repair the last block, so
+requiring a full block would leave such a list reclaimed by neither path.
+
+The rate at which a writer inspects the tail block SHALL be bounded, so that the added cost
+per write does not scale with how often a term is written.
+
+#### Scenario: Posting list shorter than one block
+- **WHEN** a term's only block holds fewer entries than the block capacity
+- **AND** entries in it belong to deleted documents at or above the configured threshold
+- **AND** a document is indexed into that term
+- **THEN** those entries SHALL be reclaimed
+
 #### Scenario: Tail block has no dead entries
 - **WHEN** a document is indexed into a term whose last block contains no entries for deleted documents
 - **THEN** the index SHALL be unchanged apart from the appended posting

--- a/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
+++ b/openspec/changes/inline-block-repair-on-write/specs/garbage-collection/spec.md
@@ -77,6 +77,23 @@ be `0`.
 - **THEN** subsequent writes SHALL be eligible for inline repair
 - **AND** no restart SHALL be required
 
+### Requirement: The inline repair probe rate is configurable
+
+RediSearch SHALL expose a runtime configuration controlling how often a writer inspects a
+tail block that has not yet filled. The value `0` SHALL restrict inline repair to blocks that
+have filled. Raising the value SHALL NOT increase how often any block is inspected.
+
+#### Scenario: Probe rate set to zero
+- **WHEN** the probe stride is `0` and inline repair is enabled
+- **AND** a term's tail block has not filled
+- **THEN** no inline repair SHALL occur on that block
+- **AND** a term's tail block that has filled SHALL still be repaired
+
+#### Scenario: Raising the stride never probes more
+- **WHEN** the same write is applied under two different stride values
+- **AND** the larger stride would inspect the tail block
+- **THEN** the smaller stride SHALL also inspect it
+
 ### Requirement: Inline repair is reported in index statistics
 
 `FT.INFO` SHALL report the number of inline repairs performed and the net bytes they

--- a/openspec/changes/inline-block-repair-on-write/tasks.md
+++ b/openspec/changes/inline-block-repair-on-write/tasks.md
@@ -1,0 +1,281 @@
+# Tasks: inline block repair on the write path
+
+Each item is intended to be one reviewable commit or PR. Items 0 and 1 are gates — if either
+fails, stop and take the result back to the issue rather than continuing down the list.
+
+## 0. Confirm the locking precondition (gate)
+
+- [ ] Trace every call site of `InvertedIndex_WriteForwardIndexEntry` and
+      `InvertedIndex_WriteEntryGeneric` (`src/indexer.c`, `src/tag_index.c`,
+      `src/forward_index.c`) up to the lock acquisition, including the background indexer queue
+      and the RDB-load path.
+- [ ] Record, per call site, whether `RedisSearchCtx_LockSpecWrite` is held.
+- [ ] **Gate:** if any writer runs without the write lock, document which one and stop.
+      Open question A in [`design.md`](design.md) is unresolved and the design needs revisiting.
+
+## 1. Measure the cost of the primitive (gate) — DONE, GATE NOT PASSED
+
+- [x] Add a Rust benchmark for `IndexBlock::repair` on a full tail block at 0%, 5%, 25%, and
+      50% dead entries, with a realistic `doc_exist` predicate (not a constant closure —
+      `DocTable_Exists` does real work and dominates a cheap decode).
+- [x] Compare against the cost of one `add_record` on the same block.
+- [x] **Gate:** derive the stride needed to keep amortized repair cost under the write-path
+      budget in the proposal. If no stride satisfies it, stop.
+
+**Result: no stride satisfies it.** Repairing every tail block costs +39–52% on the write path;
+a 5%-budget stride fires once per 8–10 block rotations, landing on blocks that are unlikely to
+hold dead entries. Full numbers and reasoning in [`benchmarks.md`](benchmarks.md).
+
+Root cause: `IndexBlock::repair` re-encodes every survivor unconditionally and discards the
+result when nothing was dead, so the zero-benefit case is the most expensive one.
+
+**Tasks 2–10 below are on hold** pending the re-scoped work in task 1a. They are kept because
+most survive a redesign, but the mechanism in `design.md` that they implement does not.
+
+## 1a. Lazy re-encode in `IndexBlock::repair` (re-scoped, do this first)
+
+Independent of inline repair — this is a fork-GC improvement on its own, since every scan
+currently pays full re-encode on every clean block it visits.
+
+- [x] Start the temporary block only when the first dead entry is found, replaying the
+      already-read prefix at that point; a block with no dead entries then costs a decode pass
+      and no allocation.
+- [x] Existing `src/redisearch_rs/inverted_index/src/tests/gc.rs` must pass unchanged —
+      this is an optimization, not a behavior change. (188/188 pass.)
+- [x] Cover the new path: no existing test had a survivor *before* the first dead entry, so
+      the prefix replay was never exercised. Added `index_block_repair_replays_surviving_prefix`,
+      `index_block_repair_replays_prefix_with_duplicate_doc_ids`,
+      `index_block_repair_invokes_callback_once_per_survivor` (the replay must not re-deliver
+      records to the callback — `fork_gc`'s numeric collector folds each survivor into an HLL),
+      and `expiration_bit_survives_prefix_replay` (bits are addressed by ordinal, so an
+      off-by-one in the replay shifts them).
+- [x] Re-run `tail_block_repair`; report the new 0%-dead column against the old.
+- [x] Re-run the existing `garbage_collection` bench to quantify the fork-GC win.
+- [x] **Decision point.** Clean blocks are 3–7× cheaper and a whole-index scan is ~3× cheaper
+      wherever most blocks are clean, so the change stands on its own. Full results and the
+      one regression case in [`benchmarks.md`](benchmarks.md).
+
+Remaining before this ships as its own PR:
+
+- [ ] Run the C/C++ unit tests and the Python flow suite — both need a full `./build.sh`, which
+      has not been done in this checkout (the submodules were uninitialized until now).
+- [ ] `cargo +nightly miri test -p inverted_index`.
+- [ ] Confirm `fork_gc` and `numeric_range_tree` tests pass; both need the C bundle static lib.
+
+## 2. Extract shared GC accounting — DONE
+
+- [x] Factored the `n_unique_docs` / `bytes_freed` / `bytes_allocated` / `entries_removed` /
+      `block_count_delta` arithmetic out of `InvertedIndex::apply_gc` into
+      `absorb_block_repair` and `finish_block_repair`, which both the fork path and the
+      inline path call.
+- [x] No behavior change; existing tests pass untouched.
+
+## 3. `repair_tail_block` — DONE
+
+Named `repair_tail_block`, not `repair_last_block_if_dirty`: the gating moved to a separate
+wrapper (task 4), leaving this as the unconditional primitive.
+
+- [x] Implemented on `InvertedIndex<E>` in `src/redisearch_rs/inverted_index/src/gc.rs`.
+      Returns `std::io::Result<Option<GcApplyInfo>>` rather than swallowing a decode error —
+      a corrupt block should surface, not silently skip.
+- [x] Bumps `gc_marker` on mutation only; a no-op leaves it alone so readers positioned in
+      the block are not made to revalidate for nothing.
+- [x] Rejects a `RepairType::Replace` yielding more than one block (a delta-driven split
+      would grow the index).
+- [x] `min_reclaim_pct` filters the result rather than the trigger, so the decode is paid
+      once.
+- [x] Tests: empty index, clean block, tail-only reclaim (non-tail dead entries must
+      survive), wholly-dead tail, minimum-reclaim accept/reject, and equivalence with
+      `scan_gc` + `apply_gc` on unique-doc count, block count, and decoded contents.
+
+## 4. Trigger — DONE, redesigned
+
+The write counter in the original plan was replaced by gating on block rotation. Rationale in
+[`design.md`](design.md) § *The trigger*: it needs no per-index state (there is one
+`InvertedIndex` per term, so a counter field costs memory on every term), it is the last
+moment a writer can reach the block, and the cadence is self-limiting without tuning.
+
+- [x] `repair_full_tail_block` gates `repair_tail_block` on
+      `num_entries >= RECOMMENDED_BLOCK_ENTRIES`.
+- [x] Tests: no repair until the block fills; a clean full block is checked exactly once and
+      then rotates away.
+- [ ] Confirm the self-limiting cadence claim with a benchmark rather than by construction —
+      that checks scale with garbage produced, and a clean index settles at one check per
+      block.
+
+## 4b. Wrapper index types — DONE (not in the original plan)
+
+`InvertedIndex` is reached from C through an opaque enum that wraps two tracking types, both
+of which had to forward the new call. `EntriesTrackingIndex` in particular keeps its own
+`number_of_entries`, which `apply_gc` decrements — the inline path must too, or the two
+reclaim paths disagree about how many entries the index holds.
+
+- [x] `InvertedIndex::repair_full_tail_block` dispatch wrapper in `index/opaque.rs`.
+- [x] `EntriesTrackingIndex::repair_full_tail_block`, adjusting `number_of_entries`.
+- [x] `FieldMaskTrackingIndex::repair_full_tail_block` (plain forward — the tracked mask is a
+      union over every entry ever added and is never narrowed by a removal).
+
+## 5. FFI entry point — DONE
+
+Named `InvertedIndex_RepairFullTailBlock`, and it takes the `IndexSpec` rather than a doc
+table or a `RedisSearchCtx`: the spec is what the write sites already hold, and the doc table
+comes off it exactly as in `InvertedIndex_GcDelta_Scan`.
+
+- [x] Added in `inverted_index_ffi`, reusing the existing `DocTable_Exists` closure shape.
+- [x] `make generate-rust-headers` (needed `cargo install --locked cheadergen_cli@0.3.2` and
+      `rustup toolchain install nightly-2026-05-01 -c rust-docs-json` first — neither was
+      present in this checkout).
+- [x] Returns the reclaim through an out-param `II_GCScanStats`, which already carries signed
+      block deltas, plus a `bool` for "did anything happen".
+
+## 6. Wire up the C write path — DONE for text; tags deferred
+
+- [x] `maybeRepairTailBlock` called from `writeIndexEntry` (`src/indexer.c`), gated on the
+      config being non-zero.
+- [x] Applies the reclaim to `spec->stats`: `invertedSize` (freed minus allocated),
+      `numRecords`, `IndexStats_BlockCountAdd` (signed).
+- [x] Missing-docs / existing-docs writes and RDB load deliberately not wired.
+- [ ] **Tags not wired.** `tagIndex_Put` and `TagIndex_WritePostings` receive an `IndexStats*`
+      but no `IndexSpec*`, so the spec has to be threaded through two functions first. Split
+      out rather than widened into this change.
+
+## 7. Configuration — DONE
+
+- [x] `INLINE_GC_BLOCK_REPAIR_THRESHOLD` in `src/config.c`, default `0` (disabled), rejecting
+      values above 100 with `QUERY_ERROR_CODE_LIMIT`.
+- [x] Registered in `__configPairs` with an empty native alias, so it is `FT.CONFIG`-only. A
+      `search-` native alias would need `RedisModule_RegisterNumericConfig` plumbing; worth
+      adding before this ships, but it is a separate decision from the mechanism.
+- [ ] Document the interaction with `FORK_GC_CLEAN_THRESHOLD` in the config reference.
+
+## 8. Observability — DONE, relocated
+
+Reported at `FT.INFO` top level next to `total_inverted_index_blocks`, **not** under
+`gc_stats`: that section is rendered from the fork GC's own context (`statsCb` /
+`statsForInfoCb` in `fork_gc.c`), which cannot reach `spec->stats`.
+
+- [x] `inline_gc_repairs` and `inline_gc_bytes_collected` in `FT.INFO`
+      (`src/info/info_command.c`) and the module `INFO` section (`src/spec.c`).
+- [x] Reported separately from the fork GC's `bytes_collected` rather than summed into it, so
+      the two reclaim paths can be compared. Recorded in the spec delta.
+
+## 9. End-to-end tests
+
+- [ ] Python flow test: repeated updates to a bounded key set with fork GC effectively
+      disabled (`FORK_GC_RUN_INTERVAL` very high); assert memory and
+      `FT.INFO` `inline_repairs` move, and that query results stay correct throughout.
+- [ ] Flow test asserting a concurrent query running across an inline repair returns the same
+      result set as one running without concurrent writes.
+- [ ] Flow test: RDB save/load round-trip after inline repairs produces an identical index.
+- [ ] Follow [/write-flow-tests](../../../.skills/write-flow-tests/SKILL.md).
+
+## 10. Validation — partly done
+
+Done:
+
+- [x] `./build.sh DEBUG=1` — full build, 0 errors.
+- [x] `cargo nextest run -p inverted_index -p fork_gc -p numeric_range_tree` — 400/400.
+      Needs `BINDIR=<repo>/bin/macos-aarch64-debug/search-community`, otherwise the build
+      script looks for a *release* C bundle.
+- [x] `./build.sh DEBUG=1 RUN_UNIT_TESTS` — 981 passed, 6 failed. The failures are three
+      `IORuntimeCtxCommonTest.UpdateNodes*` segfaults in coordinator connection auth
+      (`MRConn_SendAuth` on a side thread), confirmed pre-existing by re-running them with
+      every functional change stashed.
+- [x] `cargo fmt --check` and clippy clean on all changed crates.
+
+Done in a Linux container (see § *Container setup* below), which is what unblocked the rest:
+
+- [x] Full Linux build — 0 errors.
+- [x] `test_gc.py` — **passed** (31 tests). The suite that exercises fork GC end-to-end
+      through the real module, so it covers the lazy re-encode and the accounting refactor.
+- [x] `test_info.py` — **passed** (7 tests), with the two new `FT.INFO` fields present.
+- [x] `test_config.py` — 122 passed, 47 failed, against a baseline of 120 passed / 46 failed
+      with every functional change stashed. The change adds exactly three tests:
+      - `testConfigAPILoadTimeNumericParams_INLINE_GC_BLOCK_REPAIR_THRESHOLD` — passes
+      - `testModuleLoadexNumericParamsLastWins_INLINE_GC_BLOCK_REPAIR_THRESHOLD` — passes
+      - `testModuleLoadexNumericParams_INLINE_GC_BLOCK_REPAIR_THRESHOLD` — fails
+
+      The one failure is not a defect in the config: **all 32** `testModuleLoadexNumericParams_*`
+      tests that run in this environment fail at baseline, on
+      `env.envRunner.moduleArgs` being `None`/empty — an RLTest harness problem with
+      module-load arguments, unrelated to config registration. The new config adds a 33rd
+      member of a family that is already 100% failing. The two passing tests are the ones that
+      actually validate its default, range and last-wins semantics.
+
+- [x] `cargo +nightly miri test -p inverted_index gc::` — 21 passed, 0 failed, 1 ignored
+      (`test_refresh_buffer_pointers_after_reallocation`, pre-existing: its memory hack is
+      rejected by miri). No undefined behaviour in the lazy re-encode or the tail repair.
+
+Still open:
+
+- [ ] Macro benchmark of the actual write-path cost with the real `DocTable_Exists`. Every
+      cost figure quoted so far comes from a microbenchmark with a stand-in predicate, so the
+      +8.5–17% estimate is unconfirmed.
+- [ ] Live end-to-end smoke test driving `INLINE_GC_BLOCK_REPAIR_THRESHOLD` against a running
+      server and asserting `inline_gc_repairs` advances — task 9 covers this as flow tests,
+      which are not written yet.
+
+## Container setup (how to reproduce the Linux runs)
+
+The macOS checkout cannot build (see § 11). Everything above was run in a container built
+from the repo's own `Dockerfile`, which needs two adjustments to be usable interactively:
+
+```bash
+docker build --build-arg BASE_IMAGE=ubuntu:24.04 -t rs-dev:ubuntu24 .
+```
+
+1. **Redis is not in the image.** The `.install` scripts provision build dependencies only,
+   and Ubuntu 24.04 ships Redis 7.x, which segfaults in `RedisModule_OnLoad` against current
+   master. Graft the Redis 8 binaries in rather than building from source:
+
+   ```dockerfile
+   FROM redis:8 AS redis
+   FROM rs-dev:ubuntu24
+   COPY --from=redis /usr/local/bin/redis-server /usr/local/bin/redis-server
+   COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
+   ```
+
+2. **`bin/` must be shadowed by a volume.** `build.sh` sets its own Rust target directory
+   (`bin/redisearch_rs`) and so overrides `CARGO_TARGET_DIR`. Bind-mounting the repo without
+   shadowing `bin/` makes the Linux linker consume the macOS object files sitting there, which
+   fails as `unresolvable R_AARCH64_ADR_GOT_PAGE relocation against 'environ@@GLIBC_2.17'`.
+
+```bash
+docker run --rm -v "$PWD":/project -v rs-bin:/project/bin -w /project rs-dev:redis8 \
+  bash -lc 'bash .install/test_deps/install_python_deps.sh && \
+            REJSON=0 ./build.sh DEBUG=1 RUN_PYTEST TEST=test_gc.py'
+```
+
+`REJSON=0` skips building RedisJSON (`runtests.sh:552`). Python test deps are installed at
+run time because the image build passes `SKIP_PYTHON_TEST_DEPS=1` — `uv.lock` is not in the
+Docker build context.
+
+**The harness exit code cannot be trusted.** A run that aborted before executing a single test
+("Cannot find redis-server. Aborting.") reported the same failure text as a genuine test
+failure, and the wrapper still exited 0. Grep the per-file result markers, not `$?`.
+
+## 11. Pre-existing build breakage found on the way
+
+Three separate macOS build failures, all reproduced on a clean `master`, all unrelated to this
+change. The first two are fixed here because nothing builds without them; the third is worked
+around locally only.
+
+- [x] `deps/fast_float` and `src/coord` (`coordinator-core`) never set a C++ standard, so they
+      took the compiler default. That is C++17 on gcc but **C++98 on Apple clang**
+      (`__cplusplus == 199711`), and both use C++11-or-later features. Fixed with
+      `target_compile_features(... cxx_std_20)` on the two targets. The root cause is that
+      `set(CMAKE_CXX_STANDARD 20)` in the top-level `CMakeLists.txt` is function-local with no
+      `PARENT_SCOPE`, so it never escapes — worth fixing properly, separately.
+- [ ] VectorSimilarity's `SVE.cpp`/`SVE2.cpp` **crash** Apple clang (`Abort trap: 6`).
+      `CHECK_CXX_COMPILER_FLAG` accepts `-march=armv8-a+sve` on Apple Silicon even though the
+      hardware has no SVE, so the guard passes and the intrinsics are compiled. Worked around
+      by clearing `CXX_SVE*` in the local `CMakeCache.txt`; the real fix belongs in the
+      VectorSimilarity submodule.
+- [ ] `tests/cpptests/test_cpp_dict_pause_rehash.cpp` uses `std::jthread`, absent from Apple
+      libc++, which blocks the whole `rstest` binary. Excluded locally to run the suite; the
+      exclusion was reverted and is **not** part of this change.
+- [ ] `cargo +nightly miri test` for the new inverted-index code.
+- [ ] `make lint`, `make fmt CHECK=1`.
+- [ ] Macro benchmark before/after on a write-heavy workload — report both the write-path cost
+      and the reclaim, and confirm the success criteria in [`proposal.md`](proposal.md).
+- [ ] Measure `gc_blocks_denied` per fork-GC cycle with the feature on and off.

--- a/src/config.c
+++ b/src/config.c
@@ -89,6 +89,7 @@ configPair_t __configPairs[] = {
   {"GC_POLICY",                       ""},
   {"GCSCANSIZE",                      "search-gc-scan-size"},
   {"INDEX_CURSOR_LIMIT",              "search-index-cursor-limit"},
+  {"INLINE_GC_BLOCK_REPAIR_THRESHOLD", "search-inline-gc-block-repair-threshold"},
   {"MAX_AGGREGATE_GROUPS",            "search-max-aggregate-groups"},
   {"MAXAGGREGATERESULTS",             "search-max-aggregate-results"},
   {"MAXDOCTABLESIZE",                 "search-max-doctablesize"},
@@ -1049,6 +1050,25 @@ CONFIG_GETTER(getForkGcCleanThreshold) {
   return sdscatprintf(ss, "%lu", config->gcConfigParams.gcSettings.forkGcCleanThreshold);
 }
 
+// INLINE_GC_BLOCK_REPAIR_THRESHOLD
+CONFIG_SETTER(setInlineGcBlockRepairThreshold) {
+  size_t threshold = 0;
+  int acrc = AC_GetSize(ac, &threshold, AC_F_GE0);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (threshold > MAX_INLINE_GC_BLOCK_REPAIR_THRESHOLD) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT,
+                        "INLINE_GC_BLOCK_REPAIR_THRESHOLD is a percentage and cannot exceed 100");
+    return REDISMODULE_ERR;
+  }
+  config->gcConfigParams.gcSettings.inlineGcBlockRepairThreshold = threshold;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getInlineGcBlockRepairThreshold) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%zu", config->gcConfigParams.gcSettings.inlineGcBlockRepairThreshold);
+}
+
 // FORK_GC_RETRY_INTERVAL
 CONFIG_SETTER(setForkGcRetryInterval) {
   int acrc = AC_GetSize(ac, &config->gcConfigParams.gcSettings.forkGcRetryInterval, AC_F_GE1);
@@ -1723,6 +1743,13 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "interval (in seconds) in which to retry running the forkgc after failure.",
          .setValue = setForkGcRetryInterval,
          .getValue = getForkGcRetryInterval},
+        {.name = "INLINE_GC_BLOCK_REPAIR_THRESHOLD",
+         .helpText = "percentage of an inverted-index block's entries that must belong to deleted "
+                     "documents before a write reclaims them inline, instead of leaving them to "
+                     "the fork gc. 0 disables inline repair. Trades write throughput for smaller "
+                     "fork gc cycles.",
+         .setValue = setInlineGcBlockRepairThreshold,
+         .getValue = getInlineGcBlockRepairThreshold},
         {.name = "FORK_GC_CLEAN_NUMERIC_EMPTY_NODES",
          .helpText = "clean empty nodes from numeric tree",
          .setValue = setForkGCCleanNumericEmptyNodes,
@@ -2168,6 +2195,17 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED, 1,
       LLONG_MAX, get_size_t_numeric_config, set_size_t_numeric_config, NULL,
       (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterNumericConfig (
+      ctx, "search-inline-gc-block-repair-threshold",
+      DEFAULT_INLINE_GC_BLOCK_REPAIR_THRESHOLD,
+      REDISMODULE_CONFIG_UNPREFIXED, 0,
+      MAX_INLINE_GC_BLOCK_REPAIR_THRESHOLD, get_size_t_numeric_config, set_size_t_numeric_config,
+      NULL,
+      (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.inlineGcBlockRepairThreshold)
     )
   )
 

--- a/src/config.c
+++ b/src/config.c
@@ -89,6 +89,7 @@ configPair_t __configPairs[] = {
   {"GC_POLICY",                       ""},
   {"GCSCANSIZE",                      "search-gc-scan-size"},
   {"INDEX_CURSOR_LIMIT",              "search-index-cursor-limit"},
+  {"INLINE_GC_BLOCK_REPAIR_STRIDE",   "search-inline-gc-block-repair-stride"},
   {"INLINE_GC_BLOCK_REPAIR_THRESHOLD", "search-inline-gc-block-repair-threshold"},
   {"MAX_AGGREGATE_GROUPS",            "search-max-aggregate-groups"},
   {"MAXAGGREGATERESULTS",             "search-max-aggregate-results"},
@@ -1069,6 +1070,25 @@ CONFIG_GETTER(getInlineGcBlockRepairThreshold) {
   return sdscatprintf(ss, "%zu", config->gcConfigParams.gcSettings.inlineGcBlockRepairThreshold);
 }
 
+// INLINE_GC_BLOCK_REPAIR_STRIDE
+CONFIG_SETTER(setInlineGcBlockRepairStride) {
+  size_t stride = 0;
+  int acrc = AC_GetSize(ac, &stride, AC_F_GE0);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (stride > MAX_INLINE_GC_BLOCK_REPAIR_STRIDE) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT,
+                        "INLINE_GC_BLOCK_REPAIR_STRIDE cannot exceed 1024");
+    return REDISMODULE_ERR;
+  }
+  config->gcConfigParams.gcSettings.inlineGcBlockRepairStride = stride;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getInlineGcBlockRepairStride) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%zu", config->gcConfigParams.gcSettings.inlineGcBlockRepairStride);
+}
+
 // FORK_GC_RETRY_INTERVAL
 CONFIG_SETTER(setForkGcRetryInterval) {
   int acrc = AC_GetSize(ac, &config->gcConfigParams.gcSettings.forkGcRetryInterval, AC_F_GE1);
@@ -1743,6 +1763,13 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "interval (in seconds) in which to retry running the forkgc after failure.",
          .setValue = setForkGcRetryInterval,
          .getValue = getForkGcRetryInterval},
+        {.name = "INLINE_GC_BLOCK_REPAIR_STRIDE",
+         .helpText = "appends between inline-repair probes of a tail block that has not yet "
+                     "filled, and the entry count below which every append probes. 0 probes "
+                     "only when a block fills, which never reaches a posting list shorter "
+                     "than one block. Lower reclaims more and costs more write throughput.",
+         .setValue = setInlineGcBlockRepairStride,
+         .getValue = getInlineGcBlockRepairStride},
         {.name = "INLINE_GC_BLOCK_REPAIR_THRESHOLD",
          .helpText = "percentage of an inverted-index block's entries that must belong to deleted "
                      "documents before a write reclaims them inline, instead of leaving them to "
@@ -2195,6 +2222,17 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED, 1,
       LLONG_MAX, get_size_t_numeric_config, set_size_t_numeric_config, NULL,
       (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterNumericConfig (
+      ctx, "search-inline-gc-block-repair-stride",
+      DEFAULT_INLINE_GC_BLOCK_REPAIR_STRIDE,
+      REDISMODULE_CONFIG_UNPREFIXED, 0,
+      MAX_INLINE_GC_BLOCK_REPAIR_STRIDE, get_size_t_numeric_config, set_size_t_numeric_config,
+      NULL,
+      (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.inlineGcBlockRepairStride)
     )
   )
 

--- a/src/config.h
+++ b/src/config.h
@@ -90,6 +90,11 @@ typedef struct {
   // `size_t` so it can share the `get/set_size_t_numeric_config` helpers with the other
   // numeric configs; the 0..100 range is enforced at both entry points.
   size_t inlineGcBlockRepairThreshold;
+  // Appends between two inline-repair probes of a tail block that has not yet filled, and
+  // also the entry count below which every append probes. 0 probes only when the block
+  // fills, which cannot reach a posting list shorter than one block. Smaller values reclaim
+  // more and cost more write throughput; this is the dial between those.
+  size_t inlineGcBlockRepairStride;
 } GCSettings;
 
 typedef struct {
@@ -358,6 +363,13 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 // cycles, which is a choice an operator makes, not a default to impose.
 #define DEFAULT_INLINE_GC_BLOCK_REPAIR_THRESHOLD 0
 #define MAX_INLINE_GC_BLOCK_REPAIR_THRESHOLD 100
+// The stride only has an effect once inline repair is switched on by the threshold above, so
+// its default is the value the change was measured at rather than a conservative one: an
+// operator who enables the feature is asking for the reclaim it was shown to deliver.
+#define DEFAULT_INLINE_GC_BLOCK_REPAIR_STRIDE 8
+// A stride wider than a block would never fire before the block-full check does, so values
+// above this are indistinguishable from each other.
+#define MAX_INLINE_GC_BLOCK_REPAIR_STRIDE 1024
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
 #define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
@@ -443,6 +455,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .gcConfigParams.gcSettings.forkGcRetryInterval = DEFAULT_FORK_GC_RETRY_INTERVAL,\
     .gcConfigParams.gcSettings.forkGcCleanThreshold = DEFAULT_FORK_GC_CLEAN_THRESHOLD,\
     .gcConfigParams.gcSettings.inlineGcBlockRepairThreshold = DEFAULT_INLINE_GC_BLOCK_REPAIR_THRESHOLD,\
+    .gcConfigParams.gcSettings.inlineGcBlockRepairStride = DEFAULT_INLINE_GC_BLOCK_REPAIR_STRIDE,\
     .noMemPool = 0,                                                            \
     .filterCommands = 0,                                                       \
     .maxSearchResults = DEFAULT_MAX_SEARCH_REQUEST_RESULTS,                    \

--- a/src/config.h
+++ b/src/config.h
@@ -84,6 +84,12 @@ typedef struct {
   size_t forkGcRetryInterval;
   size_t forkGcSleepBeforeExit;
   int forkGCCleanNumericEmptyNodes;
+  // Smallest share of an inverted-index block's entries, in percent, that inline repair must
+  // reclaim for the rewrite to be worth it. 0 disables inline repair entirely; it does not
+  // mean "reclaim anything". Trades write throughput for smaller fork GC cycles.
+  // `size_t` so it can share the `get/set_size_t_numeric_config` helpers with the other
+  // numeric configs; the 0..100 range is enforced at both entry points.
+  size_t inlineGcBlockRepairThreshold;
 } GCSettings;
 
 typedef struct {
@@ -348,6 +354,10 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_FORK_GC_RUN_INTERVAL 30
 #define DEFAULT_DISK_GC_RUN_INTERVAL 300
 #define DEFAULT_DISK_GC_CLEAN_THRESHOLD 10000
+// Inline block repair is off by default: it trades write throughput for smaller fork GC
+// cycles, which is a choice an operator makes, not a default to impose.
+#define DEFAULT_INLINE_GC_BLOCK_REPAIR_THRESHOLD 0
+#define MAX_INLINE_GC_BLOCK_REPAIR_THRESHOLD 100
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
 #define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
@@ -432,6 +442,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .gcConfigParams.gcSettings.forkGcSleepBeforeExit = 0,                      \
     .gcConfigParams.gcSettings.forkGcRetryInterval = DEFAULT_FORK_GC_RETRY_INTERVAL,\
     .gcConfigParams.gcSettings.forkGcCleanThreshold = DEFAULT_FORK_GC_CLEAN_THRESHOLD,\
+    .gcConfigParams.gcSettings.inlineGcBlockRepairThreshold = DEFAULT_INLINE_GC_BLOCK_REPAIR_THRESHOLD,\
     .noMemPool = 0,                                                            \
     .filterCommands = 0,                                                       \
     .maxSearchResults = DEFAULT_MAX_SEARCH_REQUEST_RESULTS,                    \

--- a/src/coord/CMakeLists.txt
+++ b/src/coord/CMakeLists.txt
@@ -46,6 +46,12 @@ file(GLOB_RECURSE COORDINATOR_SRC CONFIGURE_DEPENDS *.c *.cpp)
 list(FILTER COORDINATOR_SRC EXCLUDE REGEX "/rmr/")
 add_library(coordinator-core OBJECT ${COORDINATOR_SRC})
 
+# RSCoordinator is a standalone project, so it does not inherit the root's
+# CMAKE_CXX_STANDARD. Without this the standard comes from the compiler default,
+# which is C++98 on Apple clang — the sources use `auto`, lambdas and range-for,
+# so they fail to compile on macOS while building fine against gcc's newer default.
+target_compile_features(coordinator-core PRIVATE cxx_std_20)
+
 
 set(FINAL_OBJECTS
     $<TARGET_OBJECTS:coordinator-core>

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -71,9 +71,13 @@ static void maybeRepairTailBlock(IndexSpec *spec, InvertedIndex *idx) {
   if (threshold == 0) {
     return;
   }
+  // Bounded to 0..MAX_INLINE_GC_BLOCK_REPAIR_STRIDE at both config entry points, so the cast
+  // to uint16_t is safe.
+  const size_t stride = RSGlobalConfig.gcConfigParams.gcSettings.inlineGcBlockRepairStride;
 
   II_GCScanStats info;
-  if (!InvertedIndex_MaybeRepairTailBlock(idx, spec, (uint8_t)threshold, &info)) {
+  if (!InvertedIndex_MaybeRepairTailBlock(idx, spec, (uint8_t)threshold, (uint16_t)stride,
+                                          &info)) {
     return;
   }
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -58,9 +58,10 @@ extern RedisModuleCtx *RSDummyContext;
 #include <stdint.h>
 #include <string.h>
 
-// Reclaim postings for deleted documents from `idx`'s tail block, if this write just filled
-// it. Off unless INLINE_GC_BLOCK_REPAIR_THRESHOLD is set: it buys smaller fork GC cycles with
-// write throughput, which is an operator's call.
+// Reclaim postings for deleted documents from `idx`'s tail block, on the cadence
+// `InvertedIndex::should_probe_tail_block` decides. Off unless
+// INLINE_GC_BLOCK_REPAIR_THRESHOLD is set: it buys smaller fork GC cycles with write
+// throughput, which is an operator's call.
 //
 // Only the tail block is touched, so the added cost is bounded by one block regardless of how
 // long the posting list is. Everything else stays the fork GC's job.
@@ -72,7 +73,7 @@ static void maybeRepairTailBlock(IndexSpec *spec, InvertedIndex *idx) {
   }
 
   II_GCScanStats info;
-  if (!InvertedIndex_RepairFullTailBlock(idx, spec, (uint8_t)threshold, &info)) {
+  if (!InvertedIndex_MaybeRepairTailBlock(idx, spec, (uint8_t)threshold, &info)) {
     return;
   }
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -58,6 +58,37 @@ extern RedisModuleCtx *RSDummyContext;
 #include <stdint.h>
 #include <string.h>
 
+// Reclaim postings for deleted documents from `idx`'s tail block, if this write just filled
+// it. Off unless INLINE_GC_BLOCK_REPAIR_THRESHOLD is set: it buys smaller fork GC cycles with
+// write throughput, which is an operator's call.
+//
+// Only the tail block is touched, so the added cost is bounded by one block regardless of how
+// long the posting list is. Everything else stays the fork GC's job.
+static void maybeRepairTailBlock(IndexSpec *spec, InvertedIndex *idx) {
+  // Bounded to 0..100 at both config entry points, so the cast to uint8_t below is safe.
+  const size_t threshold = RSGlobalConfig.gcConfigParams.gcSettings.inlineGcBlockRepairThreshold;
+  if (threshold == 0) {
+    return;
+  }
+
+  II_GCScanStats info;
+  if (!InvertedIndex_RepairFullTailBlock(idx, spec, (uint8_t)threshold, &info)) {
+    return;
+  }
+
+  // Same accounting as the fork GC's `FGC_updateStats`, including the add-before-subtract
+  // ordering. The net of freed and allocated can be negative when re-encoding a repaired
+  // block costs more than it reclaims, which is why the two are applied separately rather
+  // than as a single difference -- a `size_t` difference would wrap.
+  spec->stats.numRecords -= info.entries_removed;
+  spec->stats.invertedSize += info.bytes_allocated;
+  spec->stats.invertedSize -= info.bytes_freed;
+  IndexStats_BlockCountAdd(&spec->stats, info.block_count_delta);
+  spec->stats.inlineRepairs++;
+  spec->stats.inlineBytesCollected += (ssize_t)info.bytes_freed;
+  spec->stats.inlineBytesCollected -= (ssize_t)info.bytes_allocated;
+}
+
 static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEntry *entry,
                             bool hasFieldExpiration) {
   AddRecordOutcome r = InvertedIndex_WriteForwardIndexEntry(idx, entry, hasFieldExpiration);
@@ -75,6 +106,8 @@ static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEnt
     spec->stats.offsetVecsSize += VVW_GetByteLength(entry->vw);
     spec->stats.offsetVecRecords += VVW_GetCount(entry->vw);
   }
+
+  maybeRepairTailBlock(spec, idx);
 }
 
 // Number of terms for each block-allocator block

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -319,6 +319,10 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   REPLY_KVNUM("inverted_sz_mb", inverted_size / (float)0x100000);
   REPLY_KVNUM("vector_index_sz_mb", vector_indexes_size / (float)0x100000);
   REPLY_KVINT("total_inverted_index_blocks", total_ii_blocks);
+  // Reported separately from the fork GC's `bytes_collected` so the two reclaim paths can be
+  // compared. Both stay 0 while INLINE_GC_BLOCK_REPAIR_THRESHOLD is 0.
+  REPLY_KVINT("inline_gc_repairs", sp->stats.inlineRepairs);
+  REPLY_KVINT("inline_gc_bytes_collected", sp->stats.inlineBytesCollected);
   REPLY_KVNUM("offset_vectors_sz_mb", offset_vecs_size / (float)0x100000);
   REPLY_KVNUM("doc_table_size_mb", doc_table_size / (float)0x100000);
   REPLY_KVNUM("sortable_values_size_mb", sortables_size / (float)0x100000);

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -17,7 +17,7 @@ use std::ffi::c_char;
 use ffi::{
     DocTable_Exists, IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreNumeric, IndexFlags_Index_StoreTermOffsets,
-    IndexFlags_Index_WideSchema, RedisSearchCtx,
+    IndexFlags_Index_WideSchema, IndexSpec, RedisSearchCtx,
 };
 use rqe_core::{DocId, FieldMask};
 
@@ -534,6 +534,66 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
     deltas
         .serialize(&mut rmp_serde::Serializer::new(wr))
         .is_ok()
+}
+
+/// Reclaim entries for deleted documents from `idx`'s tail block, on the write path,
+/// without forking.
+///
+/// Call after writing an entry. Does nothing unless the tail block has just filled, so it is
+/// safe and cheap to call after every write — see
+/// `InvertedIndex::repair_full_tail_block` for why that is the only moment a
+/// writer can usefully repair, and for the resulting cadence.
+///
+/// `min_reclaim_pct` is the smallest share of the block's entries a repair must remove to be
+/// worth rewriting the block for; `0` accepts any reclaim. Pass the
+/// `INLINE_GC_BLOCK_REPAIR_THRESHOLD` config value, and skip the call entirely when it is 0
+/// — the feature is off in that case, not "repair everything".
+///
+/// Writes the reclaim into `out_info` and returns `true` when a repair happened; returns
+/// `false` and leaves `out_info` untouched otherwise, including when the block was decoded
+/// but nothing was worth reclaiming. A decode failure is reported as `false`: the index is
+/// unmodified in that case, and failing a write because a repair could not run would be a
+/// worse outcome than leaving the garbage for the fork GC.
+///
+/// The caller must apply `out_info` to `spec->stats`, and must hold the spec write lock —
+/// this mutates the index's blocks exactly as `InvertedIndex_ApplyGCDelta` does.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+/// - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
+/// - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn InvertedIndex_RepairFullTailBlock(
+    idx: *mut InvertedIndex,
+    spec: *const IndexSpec,
+    min_reclaim_pct: u8,
+    out_info: *mut GcApplyInfo,
+) -> bool {
+    debug_assert!(!idx.is_null(), "idx must not be null");
+    debug_assert!(!spec.is_null(), "spec must not be null");
+    debug_assert!(!out_info.is_null(), "out_info must not be null");
+
+    // SAFETY: The caller must ensure `spec` is a valid pointer to an `IndexSpec`
+    let spec = unsafe { &*spec };
+    let doc_table = spec.docs;
+
+    // SAFETY: We know `doc_table` is a valid `DocTable` because we just got it off the spec
+    let doc_exists = |id| unsafe { DocTable_Exists(&doc_table, id) };
+
+    // SAFETY: The caller must ensure `idx` is a valid pointer to an `InvertedIndex`, and
+    // holds the spec write lock so no reader is traversing it concurrently.
+    let ii = unsafe { &mut *idx };
+
+    let Ok(Some(info)) = ii.repair_full_tail_block(min_reclaim_pct, doc_exists) else {
+        return false;
+    };
+
+    // SAFETY: The caller must ensure `out_info` is a valid pointer to a writable `GcApplyInfo`
+    unsafe { std::ptr::write(out_info, info) };
+
+    true
 }
 
 /// Read a GC delta from the provided reader. The returned pointer must be freed using

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -541,7 +541,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
 ///
 /// Call after writing an entry. Does nothing unless the tail block has just filled, so it is
 /// safe and cheap to call after every write — see
-/// `InvertedIndex::repair_full_tail_block` for why that is the only moment a
+/// `InvertedIndex::maybe_repair_tail_block` for why that is the only moment a
 /// writer can usefully repair, and for the resulting cadence.
 ///
 /// `min_reclaim_pct` is the smallest share of the block's entries a repair must remove to be
@@ -565,7 +565,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
 /// - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
 /// - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_RepairFullTailBlock(
+pub unsafe extern "C" fn InvertedIndex_MaybeRepairTailBlock(
     idx: *mut InvertedIndex,
     spec: *const IndexSpec,
     min_reclaim_pct: u8,
@@ -586,7 +586,7 @@ pub unsafe extern "C" fn InvertedIndex_RepairFullTailBlock(
     // holds the spec write lock so no reader is traversing it concurrently.
     let ii = unsafe { &mut *idx };
 
-    let Ok(Some(info)) = ii.repair_full_tail_block(min_reclaim_pct, doc_exists) else {
+    let Ok(Some(info)) = ii.maybe_repair_tail_block(min_reclaim_pct, doc_exists) else {
         return false;
     };
 

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -569,6 +569,7 @@ pub unsafe extern "C" fn InvertedIndex_MaybeRepairTailBlock(
     idx: *mut InvertedIndex,
     spec: *const IndexSpec,
     min_reclaim_pct: u8,
+    probe_stride: u16,
     out_info: *mut GcApplyInfo,
 ) -> bool {
     debug_assert!(!idx.is_null(), "idx must not be null");
@@ -586,7 +587,8 @@ pub unsafe extern "C" fn InvertedIndex_MaybeRepairTailBlock(
     // holds the spec write lock so no reader is traversing it concurrently.
     let ii = unsafe { &mut *idx };
 
-    let Ok(Some(info)) = ii.maybe_repair_tail_block(min_reclaim_pct, doc_exists) else {
+    let Ok(Some(info)) = ii.maybe_repair_tail_block(min_reclaim_pct, probe_stride, doc_exists)
+    else {
         return false;
     };
 

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -444,6 +444,38 @@ uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
 size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
 
 /**
+ * Reclaim entries for deleted documents from `idx`'s tail block, on the write path,
+ * without forking.
+ *
+ * Call after writing an entry. Does nothing unless the tail block has just filled, so it is
+ * safe and cheap to call after every write — see
+ * `InvertedIndex::repair_full_tail_block` for why that is the only moment a
+ * writer can usefully repair, and for the resulting cadence.
+ *
+ * `min_reclaim_pct` is the smallest share of the block's entries a repair must remove to be
+ * worth rewriting the block for; `0` accepts any reclaim. Pass the
+ * `INLINE_GC_BLOCK_REPAIR_THRESHOLD` config value, and skip the call entirely when it is 0
+ * — the feature is off in that case, not "repair everything".
+ *
+ * Writes the reclaim into `out_info` and returns `true` when a repair happened; returns
+ * `false` and leaves `out_info` untouched otherwise, including when the block was decoded
+ * but nothing was worth reclaiming. A decode failure is reported as `false`: the index is
+ * unmodified in that case, and failing a write because a repair could not run would be a
+ * worse outcome than leaving the garbage for the fork GC.
+ *
+ * The caller must apply `out_info` to `spec->stats`, and must hold the spec write lock —
+ * this mutates the index's blocks exactly as `InvertedIndex_ApplyGCDelta` does.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
+ * - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
+ */
+bool InvertedIndex_RepairFullTailBlock(struct InvertedIndex *idx, const IndexSpec *spec, uint8_t min_reclaim_pct, struct II_GCScanStats *out_info);
+
+/**
  * Get a summary of the inverted index for debugging purposes.
  *
  * # Safety

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -407,6 +407,38 @@ void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
 t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
 
 /**
+ * Reclaim entries for deleted documents from `idx`'s tail block, on the write path,
+ * without forking.
+ *
+ * Call after writing an entry. Does nothing unless the tail block has just filled, so it is
+ * safe and cheap to call after every write — see
+ * `InvertedIndex::maybe_repair_tail_block` for why that is the only moment a
+ * writer can usefully repair, and for the resulting cadence.
+ *
+ * `min_reclaim_pct` is the smallest share of the block's entries a repair must remove to be
+ * worth rewriting the block for; `0` accepts any reclaim. Pass the
+ * `INLINE_GC_BLOCK_REPAIR_THRESHOLD` config value, and skip the call entirely when it is 0
+ * — the feature is off in that case, not "repair everything".
+ *
+ * Writes the reclaim into `out_info` and returns `true` when a repair happened; returns
+ * `false` and leaves `out_info` untouched otherwise, including when the block was decoded
+ * but nothing was worth reclaiming. A decode failure is reported as `false`: the index is
+ * unmodified in that case, and failing a write because a repair could not run would be a
+ * worse outcome than leaving the garbage for the fork GC.
+ *
+ * The caller must apply `out_info` to `spec->stats`, and must hold the spec write lock —
+ * this mutates the index's blocks exactly as `InvertedIndex_ApplyGCDelta` does.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
+ * - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
+ */
+bool InvertedIndex_MaybeRepairTailBlock(struct InvertedIndex *idx, const IndexSpec *spec, uint8_t min_reclaim_pct, struct II_GCScanStats *out_info);
+
+/**
  * Get the memory usage of the inverted index instance in bytes.
  *
  * # Safety
@@ -442,38 +474,6 @@ uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
 size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
-
-/**
- * Reclaim entries for deleted documents from `idx`'s tail block, on the write path,
- * without forking.
- *
- * Call after writing an entry. Does nothing unless the tail block has just filled, so it is
- * safe and cheap to call after every write — see
- * `InvertedIndex::repair_full_tail_block` for why that is the only moment a
- * writer can usefully repair, and for the resulting cadence.
- *
- * `min_reclaim_pct` is the smallest share of the block's entries a repair must remove to be
- * worth rewriting the block for; `0` accepts any reclaim. Pass the
- * `INLINE_GC_BLOCK_REPAIR_THRESHOLD` config value, and skip the call entirely when it is 0
- * — the feature is off in that case, not "repair everything".
- *
- * Writes the reclaim into `out_info` and returns `true` when a repair happened; returns
- * `false` and leaves `out_info` untouched otherwise, including when the block was decoded
- * but nothing was worth reclaiming. A decode failure is reported as `false`: the index is
- * unmodified in that case, and failing a write because a repair could not run would be a
- * worse outcome than leaving the garbage for the fork GC.
- *
- * The caller must apply `out_info` to `spec->stats`, and must hold the spec write lock —
- * this mutates the index's blocks exactly as `InvertedIndex_ApplyGCDelta` does.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- * - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
- * - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
- */
-bool InvertedIndex_RepairFullTailBlock(struct InvertedIndex *idx, const IndexSpec *spec, uint8_t min_reclaim_pct, struct II_GCScanStats *out_info);
 
 /**
  * Get a summary of the inverted index for debugging purposes.

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -436,7 +436,7 @@ t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
  * - `spec` must be a valid, non NULL, pointer to an `IndexSpec`.
  * - `out_info` must be a valid, non NULL, pointer to a writable `II_GCScanStats`.
  */
-bool InvertedIndex_MaybeRepairTailBlock(struct InvertedIndex *idx, const IndexSpec *spec, uint8_t min_reclaim_pct, struct II_GCScanStats *out_info);
+bool InvertedIndex_MaybeRepairTailBlock(struct InvertedIndex *idx, const IndexSpec *spec, uint8_t min_reclaim_pct, uint16_t probe_stride, struct II_GCScanStats *out_info);
 
 /**
  * Get the memory usage of the inverted index instance in bytes.

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -299,43 +299,49 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         }
     }
 
-    /// Appends between two probes of a tail block that is not yet full.
-    ///
-    /// Bounds the added decode rate to one block decode per this many writes. Probing only
-    /// when the block fills would be cheaper still, but see
-    /// [`should_probe_tail_block`](Self::should_probe_tail_block) for why that misses the
-    /// blocks that need it most.
-    const PROBE_STRIDE: u16 = 8;
-
-    /// Entry count below which the tail block is probed on every append.
-    ///
-    /// Deliberately equal to [`Self::PROBE_STRIDE`], so a block is probed on every write
-    /// until the first stride boundary and every stride thereafter — one rule, no gap at
-    /// the start where a list shorter than a stride would never be probed at all.
-    const PROBE_EVERY_WRITE_BELOW: u16 = Self::PROBE_STRIDE;
-
     /// Whether this write should probe the tail block for reclaimable entries.
     ///
-    /// True when the block has filled — the last moment it can be repaired inline, since
-    /// the next new document rotates it away — and periodically before then.
+    /// Always true once the block has filled: that is the last moment it can be repaired
+    /// inline, since the next new document rotates it away, and it is also when it holds
+    /// the most reclaimable garbage it ever will while a writer can still reach it.
     ///
-    /// The periodic case is what reaches short posting lists. A list that never fills a
+    /// Before then, every `stride` appends — and on every append while the block holds
+    /// fewer than [`Self::PROBE_EVERY_WRITE_BELOW`] entries. A `stride` of 0 disables both,
+    /// leaving only the block-full check.
+    ///
+    /// The periodic probe is what reaches short posting lists. A list that never fills a
     /// block is *entirely* tail, so the fork GC never repairs it either: it discards any
-    /// delta touching the last block. Waiting for a full block would leave every such term
-    /// reclaimed by neither path, and in a natural-language index those terms are most of
+    /// delta touching the last block. With the block-full check alone, every such term is
+    /// reclaimed by neither path — and in a natural-language index those terms are most of
     /// the vocabulary.
     ///
-    /// The cadence is self-limiting in the same way the full-block check was. A repair that
-    /// reclaims `k` entries moves the block `k` entries back down, so the next probe is `k`
-    /// writes further away; a clean block simply pays the decode.
-    fn should_probe_tail_block(&self) -> bool {
+    /// The every-append bound is a constant rather than a function of `stride` so that
+    /// raising `stride` always probes less. Tying the two together inverts that for short
+    /// blocks: a stride of 1024 would put every block below 1024 entries in the
+    /// probe-always region, making the dial's expensive end its cheap-looking one.
+    ///
+    /// The cadence is self-limiting. A repair that reclaims `k` entries moves the block `k`
+    /// entries back down, so its next probe is `k` writes further away; a clean block simply
+    /// pays the decode.
+    fn should_probe_tail_block(&self, stride: u16) -> bool {
         self.blocks.last().is_some_and(|b| {
-            b.num_entries >= E::RECOMMENDED_BLOCK_ENTRIES
-                || (b.num_entries > 0
-                    && (b.num_entries < Self::PROBE_EVERY_WRITE_BELOW
-                        || b.num_entries % Self::PROBE_STRIDE == 0))
+            if b.num_entries >= E::RECOMMENDED_BLOCK_ENTRIES {
+                return true;
+            }
+            if stride == 0 || b.num_entries == 0 {
+                return false;
+            }
+            b.num_entries < Self::PROBE_EVERY_WRITE_BELOW || b.num_entries % stride == 0
         })
     }
+
+    /// Entry count below which the tail block is probed on every append, regardless of the
+    /// configured stride.
+    ///
+    /// A posting list this short is cheap to decode, and it is exactly the case no other
+    /// path reclaims — see [`should_probe_tail_block`](Self::should_probe_tail_block).
+    /// Held constant so the stride stays a monotonic dial.
+    const PROBE_EVERY_WRITE_BELOW: u16 = 8;
 
     /// [`repair_tail_block`](Self::repair_tail_block), gated on
     /// [`should_probe_tail_block`](Self::should_probe_tail_block). This is the form the
@@ -347,9 +353,10 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
+        probe_stride: u16,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
-        if !self.should_probe_tail_block() {
+        if !self.should_probe_tail_block(probe_stride) {
             return Ok(None);
         }
 

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -138,6 +138,13 @@ impl IndexBlock {
     /// if blocks are ever decoded into temporary buffers rather than read in place.
     ///
     /// `None` is returned when there is nothing to repair in this block.
+    ///
+    /// Re-encoding is deferred until the first dead entry is seen. A block whose
+    /// entries all survive is the common case in a healthy index, and it would
+    /// otherwise pay to rebuild a block that is then discarded — so it costs a
+    /// decode pass and no allocation. The price is that a block which *does*
+    /// change re-decodes the surviving prefix once, in
+    /// [`reencode_prefix`](Self::reencode_prefix).
     pub(crate) fn repair<'block, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
         &'block self,
         block_idx: usize,
@@ -150,19 +157,23 @@ impl IndexBlock {
         let mut result = D::base_result();
         let mut unique_read = 0;
         let mut unique_write = 0;
-        let mut block_changed = false;
         // Ordinal of the entry being read, used to carry its field-expiration bit
         // (kept in this block's side bitset, not the encoded buffer) onto the
         // re-encoded survivor so `add_record` re-propagates it into the new block.
         let mut ordinal: u16 = 0;
 
-        let mut tmp_inverted_index = InvertedIndex::<E>::new(IndexFlags_Index_DocIdsOnly);
+        // `Some` once a dead entry has proved the block must be rebuilt. While it
+        // is `None`, every entry read so far survives and the block still stands
+        // as it is — which is also what distinguishes "nothing to repair" from
+        // "everything died" at the end, since both leave no blocks behind.
+        let mut tmp_inverted_index: Option<InvertedIndex<E>> = None;
 
         while self.buffer.len() as u64 > cursor.position() {
             let base = D::base_id(self, last_read_doc_id.unwrap_or(self.first_doc_id));
             D::decode(&mut cursor, base, &mut result)?;
             result.has_field_expiration = self.expiration_bit(ordinal);
-            ordinal += 1;
+
+            let starts_new_doc = last_read_doc_id.is_none_or(|id| id != result.doc_id);
 
             if doc_exist(result.doc_id) {
                 if let Some(repair) = repair.as_mut() {
@@ -173,34 +184,77 @@ impl IndexBlock {
                     repair(&result, &ctx);
                 }
 
-                tmp_inverted_index.add_record(&result)?;
+                if let Some(tmp) = tmp_inverted_index.as_mut() {
+                    tmp.add_record(&result)?;
 
-                if last_read_doc_id.is_none_or(|id| id != result.doc_id) {
-                    unique_write += 1;
+                    if starts_new_doc {
+                        unique_write += 1;
+                    }
                 }
-            } else {
-                block_changed = true;
+            } else if tmp_inverted_index.is_none() {
+                // First dead entry. Everything before it survived but was decoded
+                // and dropped, so replay that prefix into a fresh block. The
+                // `repair` callback has already seen those records and must not
+                // observe them twice, which is why the replay does not take it.
+                let (prefix, prefix_unique) = self.reencode_prefix::<E, D>(ordinal)?;
+                tmp_inverted_index = Some(prefix);
+                unique_write = prefix_unique;
             }
 
-            if last_read_doc_id.is_none_or(|id| id != result.doc_id) {
+            if starts_new_doc {
                 unique_read += 1;
+            }
+
+            last_read_doc_id = Some(result.doc_id);
+            ordinal += 1;
+        }
+
+        match tmp_inverted_index {
+            // Every entry survived: the block stands as it is.
+            None => Ok(None),
+            // Something died and nothing was re-encoded, so the whole block goes.
+            Some(tmp) if tmp.blocks.is_empty() => Ok(Some(RepairType::Delete {
+                n_unique_docs_removed: unique_read,
+            })),
+            Some(tmp) => Ok(Some(RepairType::Replace {
+                blocks: SmallVec::from_iter(tmp.blocks),
+                n_unique_docs_removed: unique_read - unique_write,
+            })),
+        }
+    }
+
+    /// Re-encode the first `count` entries of this block, all of which are known
+    /// to belong to live documents, into a fresh index.
+    ///
+    /// Returns the index and the number of distinct documents written, which
+    /// seeds `unique_write` in [`repair`](Self::repair) — entries within a block
+    /// are ordered by document ID, so a document is new when it differs from the
+    /// previous one.
+    fn reencode_prefix<'block, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
+        &'block self,
+        count: u16,
+    ) -> std::io::Result<(InvertedIndex<E>, u32)> {
+        let mut tmp_inverted_index = InvertedIndex::<E>::new(IndexFlags_Index_DocIdsOnly);
+        let mut cursor: std::io::Cursor<&'block [u8]> = std::io::Cursor::new(&self.buffer);
+        let mut last_read_doc_id = None;
+        let mut result = D::base_result();
+        let mut unique_write = 0;
+
+        for ordinal in 0..count {
+            let base = D::base_id(self, last_read_doc_id.unwrap_or(self.first_doc_id));
+            D::decode(&mut cursor, base, &mut result)?;
+            result.has_field_expiration = self.expiration_bit(ordinal);
+
+            tmp_inverted_index.add_record(&result)?;
+
+            if last_read_doc_id.is_none_or(|id| id != result.doc_id) {
+                unique_write += 1;
             }
 
             last_read_doc_id = Some(result.doc_id);
         }
 
-        if tmp_inverted_index.blocks.is_empty() {
-            Ok(Some(RepairType::Delete {
-                n_unique_docs_removed: unique_read,
-            }))
-        } else if block_changed {
-            Ok(Some(RepairType::Replace {
-                blocks: SmallVec::from_iter(tmp_inverted_index.blocks),
-                n_unique_docs_removed: unique_read - unique_write,
-            }))
-        } else {
-            Ok(None)
-        }
+        Ok((tmp_inverted_index, unique_write))
     }
 }
 
@@ -243,6 +297,187 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
                 deltas: results,
             }))
         }
+    }
+
+    /// Whether the last block has reached [`Encoder::RECOMMENDED_BLOCK_ENTRIES`], and so
+    /// will be rotated away by the next write of a new document.
+    fn tail_block_is_full(&self) -> bool {
+        self.blocks
+            .last()
+            .is_some_and(|b| b.num_entries >= E::RECOMMENDED_BLOCK_ENTRIES)
+    }
+
+    /// [`repair_tail_block`](Self::repair_tail_block), but only at the moment the tail
+    /// block has filled. This is the form the write path should call.
+    ///
+    /// A writer can only ever repair the tail, and a block stops being the tail as soon as
+    /// the next new document arrives — so the instant it fills is both the last chance to
+    /// repair it inline and the point at which it holds the most garbage it will ever hold
+    /// while still reachable. Checking here rather than on a write counter also needs no
+    /// per-index state: there is one `InvertedIndex` per term, so a counter field would
+    /// cost memory on every term in the index to answer a question the block length
+    /// already answers.
+    ///
+    /// The cadence this produces is self-limiting. A clean block is checked exactly once
+    /// and then rotates. A block that reclaims `k` entries drops back below capacity and
+    /// is checked again only after `k` more writes refill it — so checks scale with how
+    /// much garbage is actually being produced, and a clean index settles at one check per
+    /// block.
+    ///
+    /// # Errors
+    ///
+    /// See [`repair_tail_block`](Self::repair_tail_block).
+    pub fn repair_full_tail_block(
+        &mut self,
+        min_reclaim_pct: u8,
+        doc_exist: impl Fn(DocId) -> bool,
+    ) -> std::io::Result<Option<GcApplyInfo>> {
+        if !self.tail_block_is_full() {
+            return Ok(None);
+        }
+
+        self.repair_tail_block(min_reclaim_pct, doc_exist)
+    }
+
+    /// Reclaim entries for deleted documents from this index's **last block only**,
+    /// in place, without a garbage-collection scan.
+    ///
+    /// This is the write-path counterpart to [`apply_gc`](Self::apply_gc). A writer only
+    /// ever appends to the last block, so that is the only block it can repair without
+    /// widening the cost of a write past one block — and it is the block a fork
+    /// garbage collection deliberately never repairs, because a concurrent append would
+    /// invalidate the scan. Every other block stays the fork GC's responsibility.
+    ///
+    /// Returns `None` when the block was left untouched, which happens when the index has
+    /// no blocks, when no entry in the last block belongs to a deleted document, or when
+    /// the reclaim would fall below `min_reclaim_pct` of the block's entries. In all three
+    /// cases the GC marker is left alone, so readers positioned in the block are not made
+    /// to revalidate for nothing.
+    ///
+    /// `min_reclaim_pct` of `0` accepts any reclaim at all.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a decode failure from the block being read. The index is unmodified in
+    /// that case — the decode happens before any mutation.
+    pub fn repair_tail_block(
+        &mut self,
+        min_reclaim_pct: u8,
+        doc_exist: impl Fn(DocId) -> bool,
+    ) -> std::io::Result<Option<GcApplyInfo>> {
+        let Some(last_idx) = self.blocks.len().checked_sub(1) else {
+            return Ok(None);
+        };
+        let entries_before = self.blocks[last_idx].num_entries;
+
+        let repair = self.blocks[last_idx].repair(
+            last_idx,
+            doc_exist,
+            None::<fn(&RSIndexResult, &RepairContext<'_>)>,
+            PhantomData::<E>,
+        )?;
+
+        let Some(repair) = repair else {
+            return Ok(None);
+        };
+
+        if !Self::reclaim_is_worthwhile(&repair, entries_before, min_reclaim_pct) {
+            return Ok(None);
+        }
+
+        let blocks_before = self.blocks.len();
+        let mut info = GcApplyInfo::default();
+
+        let block = self
+            .blocks
+            .pop()
+            .expect("`last_idx` was derived from a non-zero length and nothing popped since");
+        self.absorb_block_repair(block, repair, &mut info);
+        self.finish_block_repair(blocks_before, &mut info);
+
+        Ok(Some(info))
+    }
+
+    /// Whether a repair of the tail block earns the rewrite it costs.
+    ///
+    /// A `Replace` that yields more than one block is rejected outright: removing an entry
+    /// can widen a document-ID delta past what the encoder can represent and force a split,
+    /// which would grow the index rather than shrink it. Those entries are left for the
+    /// fork GC, which can afford the split because it is not on the write path.
+    fn reclaim_is_worthwhile(
+        repair: &RepairType,
+        entries_before: u16,
+        min_reclaim_pct: u8,
+    ) -> bool {
+        match repair {
+            // The whole block goes away; nothing is rewritten.
+            RepairType::Delete { .. } => true,
+            RepairType::Replace { blocks, .. } => {
+                if blocks.len() > 1 {
+                    return false;
+                }
+                let kept: u32 = blocks.iter().map(|b| u32::from(b.num_entries)).sum();
+                let removed = u32::from(entries_before).saturating_sub(kept);
+                removed * 100 >= u32::from(entries_before) * u32::from(min_reclaim_pct)
+            }
+        }
+    }
+
+    /// Retire `block`, push whatever replaces it onto [`Self::blocks`], and fold the
+    /// change into `info` and [`Self::n_unique_docs`].
+    ///
+    /// Shared by [`apply_gc`](Self::apply_gc) and
+    /// [`repair_tail_block`](Self::repair_tail_block): the two paths must agree on the
+    /// index's unique-document count, and a second copy of this arithmetic is how that
+    /// count goes wrong without any test noticing.
+    ///
+    /// The caller is responsible for having removed `block` from [`Self::blocks`] first.
+    fn absorb_block_repair(
+        &mut self,
+        block: IndexBlock,
+        repair: RepairType,
+        info: &mut GcApplyInfo,
+    ) {
+        info.entries_removed += block.num_entries as usize;
+        info.bytes_freed += block.mem_usage();
+
+        let (replacements, n_unique_docs_removed) = match repair {
+            RepairType::Delete {
+                n_unique_docs_removed,
+            } => (SmallVec::new(), n_unique_docs_removed),
+            RepairType::Replace {
+                blocks,
+                n_unique_docs_removed,
+            } => (blocks, n_unique_docs_removed),
+        };
+
+        self.n_unique_docs -= n_unique_docs_removed;
+
+        for replacement in replacements {
+            info.entries_removed -= replacement.num_entries as usize;
+            info.bytes_allocated += replacement.mem_usage();
+            self.blocks.push(replacement);
+        }
+    }
+
+    /// Settle the block vector after one or more repairs and mark the index as
+    /// garbage-collected.
+    ///
+    /// The [`gc_marker_inc`](Self::gc_marker_inc) here is what tells a reader holding a
+    /// pointer into a block that the blocks moved, so every path that mutates
+    /// [`Self::blocks`] must end here.
+    fn finish_block_repair(&mut self, blocks_before: usize, info: &mut GcApplyInfo) {
+        // Remove excess capacity from the blocks vector.
+        let had_allocated = self.blocks.has_allocated();
+        self.blocks.shrink_to_fit();
+        // If we got rid of the heap block buffer entirely, we have also freed the memory occupied
+        // by the thin vec header. That hasn't been accounted for yet, so we add it to the bytes freed now.
+        if !self.blocks.has_allocated() && had_allocated {
+            info.bytes_freed += Header::<BlockCapacity>::size_with_padding::<IndexBlock>();
+        }
+
+        info.block_count_delta = self.blocks.len() as i64 - blocks_before as i64;
+        self.gc_marker_inc();
     }
 
     /// Apply the deltas of a garbage collection scan to the index. This will modify the index
@@ -302,29 +537,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
                         )
                     };
 
-                    match delta.repair {
-                        RepairType::Delete {
-                            n_unique_docs_removed,
-                        } => {
-                            info.entries_removed += block.num_entries as usize;
-                            info.bytes_freed += block.mem_usage();
-                            self.n_unique_docs -= n_unique_docs_removed;
-                        }
-                        RepairType::Replace {
-                            blocks,
-                            n_unique_docs_removed,
-                        } => {
-                            info.entries_removed += block.num_entries as usize;
-                            info.bytes_freed += block.mem_usage();
-                            self.n_unique_docs -= n_unique_docs_removed;
-
-                            for block in blocks {
-                                info.entries_removed -= block.num_entries as usize;
-                                info.bytes_allocated += block.mem_usage();
-                                self.blocks.push(block);
-                            }
-                        }
-                    }
+                    self.absorb_block_repair(block, delta.repair, &mut info);
                 }
                 _ => {
                     // This block does not need to be repaired, so just put it back
@@ -333,19 +546,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
-        // Remove excess capacity from the blocks vector.
-        {
-            let had_allocated = self.blocks.has_allocated();
-            self.blocks.shrink_to_fit();
-            // If we got rid of the heap block buffer entirely, we have also freed the memory occupied
-            // by the thin vec header. That hasn't been accounted for yet, so we add it to the bytes freed now.
-            if !self.blocks.has_allocated() && had_allocated {
-                info.bytes_freed += Header::<BlockCapacity>::size_with_padding::<IndexBlock>();
-            }
-        }
-
-        info.block_count_delta = self.blocks.len() as i64 - blocks_before as i64;
-        self.gc_marker_inc();
+        self.finish_block_repair(blocks_before, &mut info);
 
         info
     }

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -299,40 +299,57 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         }
     }
 
-    /// Whether the last block has reached [`Encoder::RECOMMENDED_BLOCK_ENTRIES`], and so
-    /// will be rotated away by the next write of a new document.
-    fn tail_block_is_full(&self) -> bool {
-        self.blocks
-            .last()
-            .is_some_and(|b| b.num_entries >= E::RECOMMENDED_BLOCK_ENTRIES)
+    /// Appends between two probes of a tail block that is not yet full.
+    ///
+    /// Bounds the added decode rate to one block decode per this many writes. Probing only
+    /// when the block fills would be cheaper still, but see
+    /// [`should_probe_tail_block`](Self::should_probe_tail_block) for why that misses the
+    /// blocks that need it most.
+    const PROBE_STRIDE: u16 = 8;
+
+    /// Entry count below which the tail block is probed on every append.
+    ///
+    /// Deliberately equal to [`Self::PROBE_STRIDE`], so a block is probed on every write
+    /// until the first stride boundary and every stride thereafter — one rule, no gap at
+    /// the start where a list shorter than a stride would never be probed at all.
+    const PROBE_EVERY_WRITE_BELOW: u16 = Self::PROBE_STRIDE;
+
+    /// Whether this write should probe the tail block for reclaimable entries.
+    ///
+    /// True when the block has filled — the last moment it can be repaired inline, since
+    /// the next new document rotates it away — and periodically before then.
+    ///
+    /// The periodic case is what reaches short posting lists. A list that never fills a
+    /// block is *entirely* tail, so the fork GC never repairs it either: it discards any
+    /// delta touching the last block. Waiting for a full block would leave every such term
+    /// reclaimed by neither path, and in a natural-language index those terms are most of
+    /// the vocabulary.
+    ///
+    /// The cadence is self-limiting in the same way the full-block check was. A repair that
+    /// reclaims `k` entries moves the block `k` entries back down, so the next probe is `k`
+    /// writes further away; a clean block simply pays the decode.
+    fn should_probe_tail_block(&self) -> bool {
+        self.blocks.last().is_some_and(|b| {
+            b.num_entries >= E::RECOMMENDED_BLOCK_ENTRIES
+                || (b.num_entries > 0
+                    && (b.num_entries < Self::PROBE_EVERY_WRITE_BELOW
+                        || b.num_entries % Self::PROBE_STRIDE == 0))
+        })
     }
 
-    /// [`repair_tail_block`](Self::repair_tail_block), but only at the moment the tail
-    /// block has filled. This is the form the write path should call.
-    ///
-    /// A writer can only ever repair the tail, and a block stops being the tail as soon as
-    /// the next new document arrives — so the instant it fills is both the last chance to
-    /// repair it inline and the point at which it holds the most garbage it will ever hold
-    /// while still reachable. Checking here rather than on a write counter also needs no
-    /// per-index state: there is one `InvertedIndex` per term, so a counter field would
-    /// cost memory on every term in the index to answer a question the block length
-    /// already answers.
-    ///
-    /// The cadence this produces is self-limiting. A clean block is checked exactly once
-    /// and then rotates. A block that reclaims `k` entries drops back below capacity and
-    /// is checked again only after `k` more writes refill it — so checks scale with how
-    /// much garbage is actually being produced, and a clean index settles at one check per
-    /// block.
+    /// [`repair_tail_block`](Self::repair_tail_block), gated on
+    /// [`should_probe_tail_block`](Self::should_probe_tail_block). This is the form the
+    /// write path should call.
     ///
     /// # Errors
     ///
     /// See [`repair_tail_block`](Self::repair_tail_block).
-    pub fn repair_full_tail_block(
+    pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
-        if !self.tail_block_is_full() {
+        if !self.should_probe_tail_block() {
             return Ok(None);
         }
 

--- a/src/redisearch_rs/inverted_index/src/index/opaque.rs
+++ b/src/redisearch_rs/inverted_index/src/index/opaque.rs
@@ -165,9 +165,16 @@ impl InvertedIndex {
     pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
+        probe_stride: u16,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<crate::GcApplyInfo>> {
-        ii_dispatch!(self, maybe_repair_tail_block, min_reclaim_pct, doc_exist)
+        ii_dispatch!(
+            self,
+            maybe_repair_tail_block,
+            min_reclaim_pct,
+            probe_stride,
+            doc_exist
+        )
     }
 
     /// Return the number of unique documents in the index.

--- a/src/redisearch_rs/inverted_index/src/index/opaque.rs
+++ b/src/redisearch_rs/inverted_index/src/index/opaque.rs
@@ -158,6 +158,18 @@ impl InvertedIndex {
         ii_dispatch!(self, apply_gc, delta)
     }
 
+    /// Reclaim deleted documents from the tail block, if it has just filled.
+    ///
+    /// This is a dispatch wrapper around the typed
+    /// [`InvertedIndex::repair_full_tail_block`].
+    pub fn repair_full_tail_block(
+        &mut self,
+        min_reclaim_pct: u8,
+        doc_exist: impl Fn(DocId) -> bool,
+    ) -> std::io::Result<Option<crate::GcApplyInfo>> {
+        ii_dispatch!(self, repair_full_tail_block, min_reclaim_pct, doc_exist)
+    }
+
     /// Return the number of unique documents in the index.
     ///
     /// This is a dispatch wrapper around the typed `InvertedIndex::unique_docs`.

--- a/src/redisearch_rs/inverted_index/src/index/opaque.rs
+++ b/src/redisearch_rs/inverted_index/src/index/opaque.rs
@@ -161,13 +161,13 @@ impl InvertedIndex {
     /// Reclaim deleted documents from the tail block, if it has just filled.
     ///
     /// This is a dispatch wrapper around the typed
-    /// [`InvertedIndex::repair_full_tail_block`].
-    pub fn repair_full_tail_block(
+    /// [`InvertedIndex::maybe_repair_tail_block`].
+    pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<crate::GcApplyInfo>> {
-        ii_dispatch!(self, repair_full_tail_block, min_reclaim_pct, doc_exist)
+        ii_dispatch!(self, maybe_repair_tail_block, min_reclaim_pct, doc_exist)
     }
 
     /// Return the number of unique documents in the index.

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -158,6 +158,29 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
 
         info
     }
+
+    /// Reclaim deleted documents from the tail block, if it has just filled. See
+    /// [`InvertedIndex::repair_full_tail_block`].
+    ///
+    /// Keeps [`number_of_entries`](Self::number_of_entries) in step, exactly as
+    /// [`apply_gc`](Self::apply_gc) does — the inline and fork paths must not disagree
+    /// about how many entries this index holds.
+    pub fn repair_full_tail_block(
+        &mut self,
+        min_reclaim_pct: u8,
+        doc_exist: impl Fn(DocId) -> bool,
+    ) -> std::io::Result<Option<GcApplyInfo>> {
+        let Some(info) = self
+            .index
+            .repair_full_tail_block(min_reclaim_pct, doc_exist)?
+        else {
+            return Ok(None);
+        };
+
+        self.number_of_entries -= info.entries_removed;
+
+        Ok(Some(info))
+    }
 }
 
 impl<E: NumericEncoder> EntriesTrackingIndex<E> {

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -168,11 +168,12 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
     pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
+        probe_stride: u16,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
-        let Some(info) = self
-            .index
-            .maybe_repair_tail_block(min_reclaim_pct, doc_exist)?
+        let Some(info) =
+            self.index
+                .maybe_repair_tail_block(min_reclaim_pct, probe_stride, doc_exist)?
         else {
             return Ok(None);
         };

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -160,19 +160,19 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
     }
 
     /// Reclaim deleted documents from the tail block, if it has just filled. See
-    /// [`InvertedIndex::repair_full_tail_block`].
+    /// [`InvertedIndex::maybe_repair_tail_block`].
     ///
     /// Keeps [`number_of_entries`](Self::number_of_entries) in step, exactly as
     /// [`apply_gc`](Self::apply_gc) does — the inline and fork paths must not disagree
     /// about how many entries this index holds.
-    pub fn repair_full_tail_block(
+    pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
         let Some(info) = self
             .index
-            .repair_full_tail_block(min_reclaim_pct, doc_exist)?
+            .maybe_repair_tail_block(min_reclaim_pct, doc_exist)?
         else {
             return Ok(None);
         };

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -149,17 +149,17 @@ impl<E: Encoder + DecodedBy> FieldMaskTrackingIndex<E> {
     }
 
     /// Reclaim deleted documents from the tail block, if it has just filled. See
-    /// [`InvertedIndex::repair_full_tail_block`].
+    /// [`InvertedIndex::maybe_repair_tail_block`].
     ///
     /// The tracked field mask is a union over every entry ever added and is never narrowed
     /// by a removal, so — as with [`apply_gc`](Self::apply_gc) — there is nothing to adjust
     /// here beyond forwarding.
-    pub fn repair_full_tail_block(
+    pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
         self.index
-            .repair_full_tail_block(min_reclaim_pct, doc_exist)
+            .maybe_repair_tail_block(min_reclaim_pct, doc_exist)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -147,4 +147,19 @@ impl<E: Encoder + DecodedBy> FieldMaskTrackingIndex<E> {
     pub fn apply_gc(&mut self, delta: GcScanDelta) -> GcApplyInfo {
         self.index.apply_gc(delta)
     }
+
+    /// Reclaim deleted documents from the tail block, if it has just filled. See
+    /// [`InvertedIndex::repair_full_tail_block`].
+    ///
+    /// The tracked field mask is a union over every entry ever added and is never narrowed
+    /// by a removal, so — as with [`apply_gc`](Self::apply_gc) — there is nothing to adjust
+    /// here beyond forwarding.
+    pub fn repair_full_tail_block(
+        &mut self,
+        min_reclaim_pct: u8,
+        doc_exist: impl Fn(DocId) -> bool,
+    ) -> std::io::Result<Option<GcApplyInfo>> {
+        self.index
+            .repair_full_tail_block(min_reclaim_pct, doc_exist)
+    }
 }

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -157,9 +157,10 @@ impl<E: Encoder + DecodedBy> FieldMaskTrackingIndex<E> {
     pub fn maybe_repair_tail_block(
         &mut self,
         min_reclaim_pct: u8,
+        probe_stride: u16,
         doc_exist: impl Fn(DocId) -> bool,
     ) -> std::io::Result<Option<GcApplyInfo>> {
         self.index
-            .maybe_repair_tail_block(min_reclaim_pct, doc_exist)
+            .maybe_repair_tail_block(min_reclaim_pct, probe_stride, doc_exist)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests/expiration_bit.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/expiration_bit.rs
@@ -239,3 +239,43 @@ fn expiration_bit_survives_gc() {
     }
     assert!(!reader.next_record(&mut result).unwrap());
 }
+
+#[test]
+fn expiration_bit_survives_prefix_replay() {
+    // Like `expiration_bit_survives_gc`, but the first entry survives, so the
+    // repair replays a non-empty prefix from the buffer. The bits live in a side
+    // bitset addressed by ordinal rather than in the encoding, so an off-by-one
+    // in the replay's ordinal shifts every bit in the prefix.
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    let entries: &[(DocId, bool)] = &[(10, true), (11, false), (12, false), (13, true)];
+    for &(doc_id, has_exp) in entries {
+        let rec = RSIndexResult::build_virt()
+            .doc_id(doc_id)
+            .has_field_expiration(has_exp)
+            .build();
+        ii.add_record(&rec).unwrap();
+    }
+
+    // Drop only doc 12, so 10 and 11 are read and dropped before the repair
+    // discovers the block changes.
+    let delta = ii
+        .scan_gc(
+            |doc_id| doc_id != 12,
+            None::<fn(&RSIndexResult, &RepairContext<'_>)>,
+        )
+        .expect("scan_gc ok")
+        .expect("scan_gc found entries to remove");
+    ii.apply_gc(delta);
+
+    let mut reader = ii.reader();
+    let mut result = RSIndexResult::build_virt().build();
+    for &(doc_id, has_exp) in &[(10u64, true), (11, false), (13, true)] {
+        assert!(reader.next_record(&mut result).unwrap());
+        assert_eq!(result.doc_id, doc_id);
+        assert_eq!(
+            result.has_field_expiration, has_exp,
+            "the prefix replay must preserve the expiration bit for doc {doc_id}"
+        );
+    }
+    assert!(!reader.next_record(&mut result).unwrap());
+}

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -14,7 +14,7 @@ use std::{
 
 use crate::{
     Decoder, Encoder, EntriesTrackingIndex, GcApplyInfo, GcScanDelta, IdDelta, IndexBlock,
-    InvertedIndex, gc::BlockGcScanResult, gc::RepairType,
+    IndexReader, InvertedIndex, gc::BlockGcScanResult, gc::RepairType,
 };
 use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
@@ -121,6 +121,122 @@ fn index_block_repair_some_deletions() {
             n_unique_docs_removed: 2
         })
     );
+}
+
+#[test]
+fn index_block_repair_replays_surviving_prefix() {
+    // Entries that survive *before* the first dead one are decoded and dropped
+    // before the repair knows the block will change, so they have to be replayed
+    // from the buffer. Every other repair test kills the first entry, which
+    // leaves that replay with nothing to do.
+    let block = IndexBlock {
+        buffer: encode_ids!(Dummy, 10, 11, 12, 13),
+        num_entries: 4,
+        first_doc_id: 10,
+        last_doc_id: 13,
+        expiration_bits: Default::default(),
+    };
+
+    fn cb(doc_id: DocId) -> bool {
+        doc_id != 12
+    }
+
+    let repair_status = block
+        .repair(
+            0,
+            cb,
+            None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
+            PhantomData::<Dummy>,
+        )
+        .unwrap();
+
+    assert_eq!(
+        repair_status,
+        Some(RepairType::Replace {
+            blocks: smallvec![IndexBlock {
+                first_doc_id: 10,
+                last_doc_id: 13,
+                num_entries: 3,
+                buffer: encode_ids!(Dummy, 10, 11, 13),
+                expiration_bits: Default::default(),
+            }],
+            n_unique_docs_removed: 1
+        })
+    );
+}
+
+#[test]
+fn index_block_repair_replays_prefix_with_duplicate_doc_ids() {
+    // `unique_write` is seeded by the prefix replay, and duplicates must not
+    // inflate it — otherwise `n_unique_docs_removed` is wrong and `apply_gc`
+    // corrupts the index's unique-document count.
+    let block = IndexBlock {
+        buffer: encode_ids!(Dummy, 10, 10, 11, 12),
+        num_entries: 4,
+        first_doc_id: 10,
+        last_doc_id: 12,
+        expiration_bits: Default::default(),
+    };
+
+    fn cb(doc_id: DocId) -> bool {
+        doc_id != 12
+    }
+
+    let repair_status = block
+        .repair(
+            0,
+            cb,
+            None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
+            PhantomData::<Dummy>,
+        )
+        .unwrap();
+
+    // Three unique docs read (10, 11, 12), two written (10, 11), so exactly one
+    // unique doc was removed — the repeated 10 must not be counted twice.
+    //
+    // The replayed block holds two entries, not three: `Dummy` sets
+    // `ALLOW_DUPLICATES = false`, so `add_record` drops the repeat on re-encode.
+    // That is pre-existing behavior of re-encoding through `add_record`, asserted
+    // here so the prefix replay is pinned to it rather than diverging.
+    assert_eq!(
+        repair_status,
+        Some(RepairType::Replace {
+            blocks: smallvec![IndexBlock {
+                first_doc_id: 10,
+                last_doc_id: 11,
+                num_entries: 2,
+                buffer: encode_ids!(Dummy, 10, 11),
+                expiration_bits: Default::default(),
+            }],
+            n_unique_docs_removed: 1
+        })
+    );
+}
+
+#[test]
+fn index_block_repair_invokes_callback_once_per_survivor() {
+    // The prefix replay re-decodes records the callback has already seen. It must
+    // not hand them to the callback a second time: `fork_gc`'s numeric collector
+    // folds every survivor into an HLL, and a double count corrupts the estimate.
+    let block = IndexBlock {
+        buffer: encode_ids!(Dummy, 10, 11, 12, 13),
+        num_entries: 4,
+        first_doc_id: 10,
+        last_doc_id: 13,
+        expiration_bits: Default::default(),
+    };
+
+    let mut seen = Vec::new();
+    block
+        .repair(
+            0,
+            |doc_id: DocId| doc_id != 12,
+            Some(|res: &RSIndexResult, _: &crate::RepairContext<'_>| seen.push(res.doc_id)),
+            PhantomData::<Dummy>,
+        )
+        .unwrap();
+
+    assert_eq!(seen, vec![10, 11, 13]);
 }
 
 #[test]
@@ -887,4 +1003,205 @@ fn test_refresh_buffer_pointers_after_reallocation() {
     // Should have read all 990 documents (10, 11, 12..999)
     assert_eq!(doc_count, 990);
     assert_eq!(expected_doc_id, 1000);
+}
+
+/// `Dummy`, but two entries fill a block — enough to build a multi-block index in a
+/// test without writing hundreds of records.
+#[derive(Clone)]
+struct TinyBlocks;
+
+impl Encoder for TinyBlocks {
+    type Delta = u32;
+
+    const RECOMMENDED_BLOCK_ENTRIES: u16 = 2;
+
+    fn encode<W: std::io::Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        Dummy::encode(writer, delta, record)
+    }
+}
+
+impl Decoder for TinyBlocks {
+    fn decode<'index>(
+        cursor: &mut Cursor<&'index [u8]>,
+        base: DocId,
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
+        Dummy::decode(cursor, base, result)
+    }
+
+    fn base_result<'index>() -> RSIndexResult<'index> {
+        Dummy::base_result()
+    }
+}
+
+/// An index of `doc_ids`, laid out two entries per block.
+fn tiny_block_index(doc_ids: impl IntoIterator<Item = DocId>) -> InvertedIndex<TinyBlocks> {
+    let mut ii = InvertedIndex::<TinyBlocks>::new(IndexFlags_Index_DocIdsOnly);
+    for doc_id in doc_ids {
+        ii.add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
+            .unwrap();
+    }
+    ii
+}
+
+fn doc_ids_in(ii: &InvertedIndex<TinyBlocks>) -> Vec<DocId> {
+    let mut reader = ii.reader();
+    let mut result = RSIndexResult::build_virt().build();
+    let mut ids = Vec::new();
+    while reader.next_record(&mut result).unwrap() {
+        ids.push(result.doc_id);
+    }
+    ids
+}
+
+#[test]
+fn repair_tail_block_on_empty_index_is_a_noop() {
+    let mut ii = InvertedIndex::<TinyBlocks>::new(IndexFlags_Index_DocIdsOnly);
+    let marker = ii.gc_marker();
+
+    assert_eq!(ii.repair_tail_block(0, |_| true).unwrap(), None);
+    assert_eq!(ii.gc_marker(), marker);
+}
+
+#[test]
+fn repair_tail_block_leaves_a_clean_block_alone() {
+    let mut ii = tiny_block_index([10, 11, 12, 13]);
+    let marker = ii.gc_marker();
+
+    assert_eq!(ii.repair_tail_block(0, |_| true).unwrap(), None);
+    // A reader positioned in the block must not be forced to revalidate for nothing.
+    assert_eq!(ii.gc_marker(), marker);
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 12, 13]);
+}
+
+#[test]
+fn repair_tail_block_reclaims_from_the_tail_only() {
+    // Blocks are [10, 11], [12, 13], [14, 15]. Doc 10 and doc 14 are both dead, but
+    // only 14 is in the tail: the write path must not widen its cost to other blocks,
+    // and doc 10 stays for the fork GC.
+    let mut ii = tiny_block_index([10, 11, 12, 13, 14, 15]);
+    let marker = ii.gc_marker();
+    let docs_before = ii.unique_docs();
+
+    let info = ii
+        .repair_tail_block(0, |doc_id| doc_id != 10 && doc_id != 14)
+        .unwrap()
+        .expect("the tail block holds a dead entry");
+
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 12, 13, 15]);
+    assert_eq!(ii.unique_docs(), docs_before - 1);
+    assert_eq!(ii.gc_marker(), marker + 1);
+    // No snapshot was taken, so there is no stale last block to skip.
+    assert!(!info.ignored_last_block);
+}
+
+#[test]
+fn repair_tail_block_removes_a_wholly_dead_tail() {
+    let mut ii = tiny_block_index([10, 11, 12, 13]);
+    let blocks_before = ii.number_of_blocks();
+
+    let info = ii
+        .repair_tail_block(0, |doc_id| doc_id < 12)
+        .unwrap()
+        .expect("the whole tail block is dead");
+
+    assert_eq!(doc_ids_in(&ii), vec![10, 11]);
+    assert_eq!(ii.number_of_blocks(), blocks_before - 1);
+    assert_eq!(info.block_count_delta, -1);
+}
+
+#[test]
+fn repair_tail_block_honours_the_minimum_reclaim() {
+    // One of two entries dies: a 50% reclaim, which a 100% threshold must reject.
+    let mut ii = tiny_block_index([10, 11, 12, 13]);
+    let marker = ii.gc_marker();
+
+    assert_eq!(
+        ii.repair_tail_block(100, |doc_id| doc_id != 12).unwrap(),
+        None
+    );
+    assert_eq!(ii.gc_marker(), marker);
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 12, 13]);
+
+    // The same reclaim is accepted once the threshold is at or below what it achieves.
+    assert!(
+        ii.repair_tail_block(50, |doc_id| doc_id != 12)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 13]);
+}
+
+#[test]
+fn repair_full_tail_block_waits_for_the_block_to_fill() {
+    // Blocks hold two entries. With one entry in the tail there is nothing to do yet,
+    // even though that entry is dead — repairing a half-filled block would let the
+    // write path pay for the same block many times over as it fills.
+    let mut ii = tiny_block_index([10, 11, 12]);
+    let marker = ii.gc_marker();
+
+    assert_eq!(
+        ii.repair_full_tail_block(0, |doc_id| doc_id != 12).unwrap(),
+        None
+    );
+    assert_eq!(ii.gc_marker(), marker);
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 12]);
+
+    // The block fills, and now the same dead entry is reclaimed.
+    ii.add_record(&RSIndexResult::build_virt().doc_id(13).build())
+        .unwrap();
+    assert!(
+        ii.repair_full_tail_block(0, |doc_id| doc_id != 12)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(doc_ids_in(&ii), vec![10, 11, 13]);
+}
+
+#[test]
+fn repair_full_tail_block_checks_a_clean_block_once_per_rotation() {
+    // A clean full block is checked, found clean, and left alone; the next write
+    // rotates it away so it is never checked again. This is the worst case for cost,
+    // and it must stay at one check per block rather than one per write.
+    let mut ii = tiny_block_index([10, 11]);
+
+    assert_eq!(ii.repair_full_tail_block(0, |_| true).unwrap(), None);
+
+    // Rotation: the full block is frozen and a new tail starts.
+    let blocks_before = ii.number_of_blocks();
+    ii.add_record(&RSIndexResult::build_virt().doc_id(12).build())
+        .unwrap();
+    assert_eq!(ii.number_of_blocks(), blocks_before + 1);
+
+    // The new tail is not full, so no further check happens.
+    assert_eq!(ii.repair_full_tail_block(0, |_| true).unwrap(), None);
+}
+
+#[test]
+fn repair_tail_block_agrees_with_the_fork_gc_path() {
+    // The inline path and the scan/apply path share their accounting helpers; this
+    // pins them to the same observable result on an index the fork GC can fully
+    // repair (single block, so no last-block skip applies).
+    let dead = |doc_id: DocId| doc_id != 11;
+
+    let mut inline = tiny_block_index([10, 11]);
+    inline
+        .repair_tail_block(0, dead)
+        .unwrap()
+        .expect("doc 11 is dead");
+
+    let mut forked = tiny_block_index([10, 11]);
+    let delta = forked
+        .scan_gc(dead, None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>)
+        .unwrap()
+        .expect("doc 11 is dead");
+    forked.apply_gc(delta);
+
+    assert_eq!(doc_ids_in(&inline), doc_ids_in(&forked));
+    assert_eq!(inline.unique_docs(), forked.unique_docs());
+    assert_eq!(inline.number_of_blocks(), forked.number_of_blocks());
 }

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -1143,7 +1143,7 @@ fn maybe_repair_tail_block_repairs_a_full_block() {
     let mut ii = tiny_block_index([10, 11, 12, 13]);
 
     assert!(
-        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 12)
+        ii.maybe_repair_tail_block(0, 8, |doc_id| doc_id != 12)
             .unwrap()
             .is_some()
     );
@@ -1158,7 +1158,7 @@ fn maybe_repair_tail_block_leaves_a_clean_block_alone() {
     let mut ii = tiny_block_index([10, 11]);
     let marker = ii.gc_marker();
 
-    assert_eq!(ii.maybe_repair_tail_block(0, |_| true).unwrap(), None);
+    assert_eq!(ii.maybe_repair_tail_block(0, 8, |_| true).unwrap(), None);
     assert_eq!(ii.gc_marker(), marker);
     assert_eq!(doc_ids_in(&ii), vec![10, 11]);
 }
@@ -1223,7 +1223,7 @@ fn maybe_repair_tail_block_reaches_a_posting_list_shorter_than_a_block() {
     let mut ii = roomy_block_index([10, 11, 12]);
 
     assert!(
-        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 11)
+        ii.maybe_repair_tail_block(0, 8, |doc_id| doc_id != 11)
             .unwrap()
             .is_some()
     );
@@ -1238,7 +1238,8 @@ fn maybe_repair_tail_block_probes_on_a_stride_once_past_the_first_entries() {
     let mut ii = roomy_block_index(1..=9);
 
     assert_eq!(
-        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 5).unwrap(),
+        ii.maybe_repair_tail_block(0, 8, |doc_id| doc_id != 5)
+            .unwrap(),
         None,
         "9 is neither below the every-write bound nor on a stride boundary"
     );
@@ -1250,7 +1251,7 @@ fn maybe_repair_tail_block_probes_on_a_stride_once_past_the_first_entries() {
     }
 
     assert!(
-        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 5)
+        ii.maybe_repair_tail_block(0, 8, |doc_id| doc_id != 5)
             .unwrap()
             .is_some(),
         "16 is on a stride boundary"
@@ -1260,13 +1261,73 @@ fn maybe_repair_tail_block_probes_on_a_stride_once_past_the_first_entries() {
 }
 
 #[test]
+fn maybe_repair_tail_block_with_stride_zero_waits_for_a_full_block() {
+    // Stride 0 is the cheap end of the dial: no periodic probe, so an unfilled block is
+    // left alone however much of it is dead. This is the trigger the change originally
+    // shipped with, kept reachable for operators who want its ~5% write cost instead of
+    // the default's reclaim.
+    let mut ii = roomy_block_index(1..=16);
+
+    assert_eq!(
+        ii.maybe_repair_tail_block(0, 0, |doc_id| doc_id != 5)
+            .unwrap(),
+        None
+    );
+    assert_eq!(roomy_doc_ids_in(&ii), (1..=16).collect::<Vec<_>>());
+
+    // A block that has filled is still repaired, since that check is independent of stride.
+    let mut full = tiny_block_index([10, 11, 12, 13]);
+    assert!(
+        full.maybe_repair_tail_block(0, 0, |doc_id| doc_id != 12)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(doc_ids_in(&full), vec![10, 11, 13]);
+}
+
+#[test]
+fn maybe_repair_tail_block_stride_sets_the_probe_cadence() {
+    // The dial's whole purpose: a wider stride probes less often, so the same dead entry
+    // survives longer. At 9 entries neither 8 nor 16 divides it, but 3 does.
+    let mut ii = roomy_block_index(1..=9);
+    assert_eq!(
+        ii.maybe_repair_tail_block(0, 16, |doc_id| doc_id != 5)
+            .unwrap(),
+        None
+    );
+    assert!(
+        ii.maybe_repair_tail_block(0, 3, |doc_id| doc_id != 5)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn maybe_repair_tail_block_stride_is_monotonic() {
+    // Raising the stride must never probe *more*. It would if the every-append bound were
+    // derived from the stride rather than held constant: a large stride would put every
+    // short block in the probe-always region and make the dial's cheap end its expensive
+    // one. Nine entries is above the constant bound, so no stride that fails to divide it
+    // may fire.
+    for stride in [10, 16, 64, 1024] {
+        let mut ii = roomy_block_index(1..=9);
+        assert_eq!(
+            ii.maybe_repair_tail_block(0, stride, |doc_id| doc_id != 5)
+                .unwrap(),
+            None,
+            "stride {stride} probed a 9-entry block"
+        );
+    }
+}
+
+#[test]
 fn maybe_repair_tail_block_still_honours_the_threshold_on_a_short_block() {
     // The threshold is a proportion of the block, so on a short block a single dead entry
     // is already a large fraction. Ten entries with one dead is 10%, below a 20% bar.
     let mut ii = roomy_block_index(1..=16);
 
     assert_eq!(
-        ii.maybe_repair_tail_block(20, |doc_id| doc_id != 5)
+        ii.maybe_repair_tail_block(20, 8, |doc_id| doc_id != 5)
             .unwrap(),
         None
     );
@@ -1274,7 +1335,7 @@ fn maybe_repair_tail_block_still_honours_the_threshold_on_a_short_block() {
 
     // Four dead of sixteen clears the same bar.
     assert!(
-        ii.maybe_repair_tail_block(20, |doc_id| !(5..=8).contains(&doc_id))
+        ii.maybe_repair_tail_block(20, 8, |doc_id| !(5..=8).contains(&doc_id))
             .unwrap()
             .is_some()
     );

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -1137,25 +1137,13 @@ fn repair_tail_block_honours_the_minimum_reclaim() {
 }
 
 #[test]
-fn repair_full_tail_block_waits_for_the_block_to_fill() {
-    // Blocks hold two entries. With one entry in the tail there is nothing to do yet,
-    // even though that entry is dead — repairing a half-filled block would let the
-    // write path pay for the same block many times over as it fills.
-    let mut ii = tiny_block_index([10, 11, 12]);
-    let marker = ii.gc_marker();
+fn maybe_repair_tail_block_repairs_a_full_block() {
+    // Blocks hold two entries. A full tail block with a dead entry is the last moment
+    // that block can be repaired inline — the next new document rotates it away.
+    let mut ii = tiny_block_index([10, 11, 12, 13]);
 
-    assert_eq!(
-        ii.repair_full_tail_block(0, |doc_id| doc_id != 12).unwrap(),
-        None
-    );
-    assert_eq!(ii.gc_marker(), marker);
-    assert_eq!(doc_ids_in(&ii), vec![10, 11, 12]);
-
-    // The block fills, and now the same dead entry is reclaimed.
-    ii.add_record(&RSIndexResult::build_virt().doc_id(13).build())
-        .unwrap();
     assert!(
-        ii.repair_full_tail_block(0, |doc_id| doc_id != 12)
+        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 12)
             .unwrap()
             .is_some()
     );
@@ -1163,22 +1151,135 @@ fn repair_full_tail_block_waits_for_the_block_to_fill() {
 }
 
 #[test]
-fn repair_full_tail_block_checks_a_clean_block_once_per_rotation() {
-    // A clean full block is checked, found clean, and left alone; the next write
-    // rotates it away so it is never checked again. This is the worst case for cost,
-    // and it must stay at one check per block rather than one per write.
+fn maybe_repair_tail_block_leaves_a_clean_block_alone() {
+    // Probing a clean block costs a decode and must change nothing observable — in
+    // particular the GC marker must not move, or every reader would revalidate for
+    // nothing.
     let mut ii = tiny_block_index([10, 11]);
+    let marker = ii.gc_marker();
 
-    assert_eq!(ii.repair_full_tail_block(0, |_| true).unwrap(), None);
+    assert_eq!(ii.maybe_repair_tail_block(0, |_| true).unwrap(), None);
+    assert_eq!(ii.gc_marker(), marker);
+    assert_eq!(doc_ids_in(&ii), vec![10, 11]);
+}
 
-    // Rotation: the full block is frozen and a new tail starts.
-    let blocks_before = ii.number_of_blocks();
-    ii.add_record(&RSIndexResult::build_virt().doc_id(12).build())
-        .unwrap();
-    assert_eq!(ii.number_of_blocks(), blocks_before + 1);
+/// `Dummy`, but with a realistic block capacity, so a short posting list never fills its
+/// only block — the case the probe stride exists to reach.
+#[derive(Clone)]
+struct RoomyBlocks;
 
-    // The new tail is not full, so no further check happens.
-    assert_eq!(ii.repair_full_tail_block(0, |_| true).unwrap(), None);
+impl Encoder for RoomyBlocks {
+    type Delta = u32;
+
+    const RECOMMENDED_BLOCK_ENTRIES: u16 = 100;
+
+    fn encode<W: std::io::Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        Dummy::encode(writer, delta, record)
+    }
+}
+
+impl Decoder for RoomyBlocks {
+    fn decode<'index>(
+        cursor: &mut Cursor<&'index [u8]>,
+        base: DocId,
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
+        Dummy::decode(cursor, base, result)
+    }
+
+    fn base_result<'index>() -> RSIndexResult<'index> {
+        Dummy::base_result()
+    }
+}
+
+fn roomy_block_index(doc_ids: impl IntoIterator<Item = DocId>) -> InvertedIndex<RoomyBlocks> {
+    let mut ii = InvertedIndex::<RoomyBlocks>::new(IndexFlags_Index_DocIdsOnly);
+    for doc_id in doc_ids {
+        ii.add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
+            .unwrap();
+    }
+    ii
+}
+
+fn roomy_doc_ids_in(ii: &InvertedIndex<RoomyBlocks>) -> Vec<DocId> {
+    let mut reader = ii.reader();
+    let mut result = RSIndexResult::build_virt().build();
+    let mut ids = Vec::new();
+    while reader.next_record(&mut result).unwrap() {
+        ids.push(result.doc_id);
+    }
+    ids
+}
+
+#[test]
+fn maybe_repair_tail_block_reaches_a_posting_list_shorter_than_a_block() {
+    // Three entries in a block that holds a hundred. This list is entirely tail, so the
+    // fork GC will never repair it — it discards deltas touching the last block. If the
+    // write path waited for a full block, nothing would ever reclaim this.
+    let mut ii = roomy_block_index([10, 11, 12]);
+
+    assert!(
+        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 11)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(roomy_doc_ids_in(&ii), vec![10, 12]);
+}
+
+#[test]
+fn maybe_repair_tail_block_probes_on_a_stride_once_past_the_first_entries() {
+    // Past PROBE_EVERY_WRITE_BELOW the block is probed every PROBE_STRIDE appends, which
+    // is what bounds the added decode rate. At 9 entries no probe happens even though one
+    // is dead; the next stride boundary reclaims it.
+    let mut ii = roomy_block_index(1..=9);
+
+    assert_eq!(
+        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 5).unwrap(),
+        None,
+        "9 is neither below the every-write bound nor on a stride boundary"
+    );
+    assert_eq!(roomy_doc_ids_in(&ii), (1..=9).collect::<Vec<_>>());
+
+    for doc_id in 10..=16 {
+        ii.add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
+            .unwrap();
+    }
+
+    assert!(
+        ii.maybe_repair_tail_block(0, |doc_id| doc_id != 5)
+            .unwrap()
+            .is_some(),
+        "16 is on a stride boundary"
+    );
+    let expected: Vec<DocId> = (1..=16).filter(|d| *d != 5).collect();
+    assert_eq!(roomy_doc_ids_in(&ii), expected);
+}
+
+#[test]
+fn maybe_repair_tail_block_still_honours_the_threshold_on_a_short_block() {
+    // The threshold is a proportion of the block, so on a short block a single dead entry
+    // is already a large fraction. Ten entries with one dead is 10%, below a 20% bar.
+    let mut ii = roomy_block_index(1..=16);
+
+    assert_eq!(
+        ii.maybe_repair_tail_block(20, |doc_id| doc_id != 5)
+            .unwrap(),
+        None
+    );
+    assert_eq!(roomy_doc_ids_in(&ii), (1..=16).collect::<Vec<_>>());
+
+    // Four dead of sixteen clears the same bar.
+    assert!(
+        ii.maybe_repair_tail_block(20, |doc_id| !(5..=8).contains(&doc_id))
+            .unwrap()
+            .is_some()
+    );
+    let expected: Vec<DocId> = (1..=16).filter(|d| !(5..=8).contains(d)).collect();
+    assert_eq!(roomy_doc_ids_in(&ii), expected);
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -24,6 +24,10 @@ harness = false
 name = "add_record"
 harness = false
 
+[[bench]]
+name = "tail_block_repair"
+harness = false
+
 [dependencies]
 buffer.workspace = true
 criterion.workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/benches/tail_block_repair.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/tail_block_repair.rs
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Feasibility bench for inline repair of an inverted index's tail block on the
+//! write path — the gate for `openspec/changes/inline-block-repair-on-write`.
+//!
+//! The question it answers: how does repairing one full block compare to the
+//! `add_record` that would trigger it? Inline repair is only viable if the
+//! repair, amortized over a stride of writes, disappears into the write cost.
+//!
+//! The existing `garbage_collection` bench measures a scan over a whole index,
+//! which conflates per-block cost with block count, and `add_record` measures
+//! bulk insertion. Neither gives the per-block-versus-per-write ratio.
+//!
+//! `IndexBlock::repair` is crate-private, so the measurement goes through
+//! `InvertedIndex::scan_gc` on an index built to hold exactly one block: the
+//! scan is then one `repair` call plus negligible loop overhead. Each bench
+//! asserts the single-block precondition, so a future change to
+//! `RECOMMENDED_BLOCK_ENTRIES` or the block-splitting rule fails the bench
+//! rather than silently measuring something else.
+//!
+//! Two `doc_exist` predicates bracket the real cost. The production predicate
+//! is `DocTable_Exists`, a C call this crate cannot link (the bencher stubs it
+//! with `panic!`), so:
+//!
+//! - `arith` — an arithmetic hash, inlined and branch-predictable. A floor:
+//!   it measures decode cost with the liveness check all but free.
+//! - `hashset` — a `HashSet` probe, which pays a hash and a likely cache miss
+//!   per entry, as a doc-table lookup does. Closer, still not the real thing.
+//!
+//! Read the gap between them as the range the real predicate falls in, and
+//! treat neither as a substitute for measuring the wired-up write path.
+
+use std::collections::HashSet;
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::{
+    IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreByteOffsets,
+    IndexFlags_Index_StoreFieldFlags, IndexFlags_Index_StoreFreqs,
+    IndexFlags_Index_StoreTermOffsets,
+};
+use index_result::{RSIndexResult, RSOffsetSlice};
+use inverted_index::{
+    Encoder, InvertedIndex, RepairContext, doc_ids_only::DocIdsOnly, full::Full, numeric::Numeric,
+};
+use query_term::RSQueryTerm;
+
+/// Flags for a full-text index carrying frequencies, field masks, and offsets —
+/// what the [`Full`] encoder expects, and what an `FT.CREATE` TEXT field produces.
+const FULL_FLAGS: IndexFlags = IndexFlags_Index_StoreFreqs
+    | IndexFlags_Index_StoreTermOffsets
+    | IndexFlags_Index_StoreFieldFlags
+    | IndexFlags_Index_StoreByteOffsets;
+
+/// Deletion arrangements to measure, ordered cheapest-looking to most punishing
+/// for the lazy re-encode in `IndexBlock::repair`.
+///
+/// `Prefix(0)` — a wholly clean block — is the case any triggering heuristic hits
+/// most often, and the one whose cost is pure waste.
+const PATTERNS: [DeadPattern; 6] = [
+    DeadPattern::Prefix(0),
+    DeadPattern::Prefix(5),
+    DeadPattern::Prefix(25),
+    DeadPattern::Prefix(50),
+    DeadPattern::EveryNth(10),
+    DeadPattern::LastOnly,
+];
+
+/// Type-annotated `None` for `scan_gc`'s optional repair callback.
+fn no_repair_cb() -> Option<fn(&RSIndexResult, &RepairContext<'_>)> {
+    None
+}
+
+/// Which documents in a block of `n` entries (doc IDs `1..=n`) are deleted.
+///
+/// The position of the *first* dead entry, not just how many are dead, drives
+/// the cost: `IndexBlock::repair` only starts re-encoding once it sees one, and
+/// replays the surviving prefix from the buffer at that point. So a block whose
+/// first entry is dead has no prefix to replay, and one whose last entry is dead
+/// replays everything.
+#[derive(Clone, Copy)]
+enum DeadPattern {
+    /// The first `pct`% of doc IDs. Survivors stay contiguous and the prefix
+    /// replay has nothing to do — the cheapest arrangement.
+    Prefix(u64),
+    /// Only the final entry. Worst case for the replay: every other entry is
+    /// decoded twice.
+    LastOnly,
+    /// Every `k`-th entry. The first dead entry appears early, but survivors are
+    /// interleaved, which is what a real update workload produces.
+    EveryNth(u64),
+}
+
+impl DeadPattern {
+    fn label(self) -> String {
+        match self {
+            Self::Prefix(pct) => format!("prefix-{pct}%"),
+            Self::LastOnly => "last-only".to_string(),
+            Self::EveryNth(k) => format!("every-{k}th"),
+        }
+    }
+
+    /// Whether `doc_id` (in `1..=n`) is still live.
+    const fn is_live(self, doc_id: u64, n: u64) -> bool {
+        match self {
+            Self::Prefix(pct) => doc_id > n * pct / 100,
+            Self::LastOnly => doc_id != n,
+            Self::EveryNth(k) => !doc_id.is_multiple_of(k),
+        }
+    }
+}
+
+/// Append one record for `doc_id`, in whichever shape the encoder accepts.
+///
+/// Each encoder validates the record variant it is handed — the [`Numeric`]
+/// encoder panics on a term record — so the record shape is bound to the
+/// encoding here rather than at the call sites.
+fn add_full(ii: &mut InvertedIndex<Full>, doc_id: u64) {
+    ii.add_record(
+        &RSIndexResult::build_term()
+            .borrowed_record(
+                Some(RSQueryTerm::new("bench", 1, 0)),
+                RSOffsetSlice::from_slice(&[1, 2, 3, 4]),
+            )
+            .doc_id(doc_id)
+            .field_mask(1u128)
+            .frequency(1)
+            .build(),
+    )
+    .unwrap();
+}
+
+fn add_docids(ii: &mut InvertedIndex<DocIdsOnly>, doc_id: u64) {
+    ii.add_record(&RSIndexResult::build_term().doc_id(doc_id).build())
+        .unwrap();
+}
+
+fn add_numeric(ii: &mut InvertedIndex<Numeric>, doc_id: u64) {
+    ii.add_record(
+        &RSIndexResult::build_numeric(doc_id as f64 / 10.0)
+            .doc_id(doc_id)
+            .build(),
+    )
+    .unwrap();
+}
+
+/// Measure a full-block repair for one encoding, across dead-entry proportions
+/// and both liveness predicates.
+///
+/// `new_index` supplies an empty index with the flags the encoding needs, and
+/// `add_one` appends a record the encoder accepts. Blocks are filled to
+/// [`Encoder::RECOMMENDED_BLOCK_ENTRIES`], the count that fills one block
+/// without starting a second.
+fn bench_repair<E, N, A>(c: &mut Criterion, encoding: &str, new_index: N, add_one: A)
+where
+    E: Encoder + inverted_index::DecodedBy,
+    N: Fn() -> InvertedIndex<E>,
+    A: Fn(&mut InvertedIndex<E>, u64),
+{
+    let n = u64::from(E::RECOMMENDED_BLOCK_ENTRIES);
+    let build = |count: u64| {
+        let mut ii = new_index();
+        for doc_id in 1..=count {
+            add_one(&mut ii, doc_id);
+        }
+        ii
+    };
+
+    let mut group = c.benchmark_group(format!("tail_block_repair/{encoding}"));
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(800));
+
+    for pattern in PATTERNS {
+        let label = pattern.label();
+        let ii = build(n);
+        assert_eq!(
+            ii.number_of_blocks(),
+            1,
+            "{encoding}: {n} records must occupy exactly one block for this bench to measure a \
+             single block repair — RECOMMENDED_BLOCK_ENTRIES or the block-splitting rule changed"
+        );
+
+        // Floor: liveness check is a couple of ALU ops.
+        group.bench_function(BenchmarkId::new("arith", &label), |b| {
+            b.iter(|| {
+                black_box(
+                    ii.scan_gc(|doc_id: u64| pattern.is_live(doc_id, n), no_repair_cb())
+                        .unwrap(),
+                )
+            })
+        });
+
+        // Closer to `DocTable_Exists`: hash plus a probable cache miss per entry.
+        let live: HashSet<u64> = (1..=n).filter(|&id| pattern.is_live(id, n)).collect();
+        group.bench_function(BenchmarkId::new("hashset", &label), |b| {
+            b.iter(|| {
+                black_box(
+                    ii.scan_gc(|doc_id: u64| live.contains(&doc_id), no_repair_cb())
+                        .unwrap(),
+                )
+            })
+        });
+    }
+
+    // The comparison the gate turns on: one `add_record` onto an almost-full
+    // tail block — the write that would carry an inline repair. Setup builds
+    // `n - 1` records and is excluded from the measurement by `iter_batched`.
+    group.bench_function(BenchmarkId::new("add_record", "1 record"), |b| {
+        b.iter_batched(
+            || build(n - 1),
+            |mut ii| add_one(&mut ii, n),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+fn benchmark_tail_block_repair(c: &mut Criterion) {
+    bench_repair::<Full, _, _>(
+        c,
+        "Full",
+        || InvertedIndex::<Full>::new(FULL_FLAGS),
+        add_full,
+    );
+    bench_repair::<DocIdsOnly, _, _>(
+        c,
+        "DocIdsOnly",
+        || InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+        add_docids,
+    );
+    bench_repair::<Numeric, _, _>(
+        c,
+        "Numeric",
+        || InvertedIndex::<Numeric>::new(IndexFlags_Index_DocIdsOnly),
+        add_numeric,
+    );
+}
+
+criterion_group!(benches, benchmark_tail_block_repair);
+criterion_main!(benches);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2831,6 +2831,8 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   RedisModule_InfoEndDictField(ctx);
 
   RedisModule_InfoAddFieldULongLong(ctx, "total_inverted_index_blocks", sp->stats.totalInvertedIndexBlocks);
+  RedisModule_InfoAddFieldULongLong(ctx, "inline_gc_repairs", sp->stats.inlineRepairs);
+  RedisModule_InfoAddFieldLongLong(ctx, "inline_gc_bytes_collected", sp->stats.inlineBytesCollected);
 
   RedisModule_InfoBeginDictField(ctx, "index_properties_averages");
   RedisModule_InfoAddFieldDouble(ctx, "records_per_doc_avg",(float)num_records / (float)sp->stats.scoring.numDocuments);

--- a/src/spec.h
+++ b/src/spec.h
@@ -151,6 +151,15 @@ typedef struct {
   // `total_inverted_index_blocks`. Writes must go through `IndexStats_BlockCountAdd` (signed
   // delta, atomic). Reads must use `__atomic_load_n`.
   size_t totalInvertedIndexBlocks;
+  // Number of inline tail-block repairs performed on the write path, and the net bytes they
+  // reclaimed. Both stay 0 unless INLINE_GC_BLOCK_REPAIR_THRESHOLD is set. Separate from the
+  // fork GC's `bytes_collected` so the two reclaim paths can be compared rather than summed.
+  //
+  // `inlineBytesCollected` is signed for the same reason as `InfoGCStats.totalCollectedBytes`:
+  // re-encoding a repaired block can allocate more than it frees, so the net is not
+  // necessarily positive and unsigned arithmetic would wrap.
+  size_t inlineRepairs;
+  ssize_t inlineBytesCollected;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;
   uint32_t activeQueries;

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -590,6 +590,9 @@ numericConfigs = [
     ('search-fork-gc-sleep-before-exit', 'FORKGC_SLEEP_BEFORE_EXIT', 0, 0, LLONG_MAX, False, False),
     ('search-gc-scan-size', 'GCSCANSIZE', 100, 1, LLONG_MAX, True, False),
     ('search-index-cursor-limit', 'INDEX_CURSOR_LIMIT', 128, 0, LLONG_MAX, False, False),
+    # Capped at a stride wider than any block, past which it cannot fire before the
+    # block-full check does. 0 leaves only that check.
+    ('search-inline-gc-block-repair-stride', 'INLINE_GC_BLOCK_REPAIR_STRIDE', 8, 0, 1024, False, False),
     # A percentage, so the maximum is 100 rather than a type bound. 0 disables inline repair.
     ('search-inline-gc-block-repair-threshold', 'INLINE_GC_BLOCK_REPAIR_THRESHOLD', 0, 0, 100, False, False),
     ('search-max-aggregate-groups', 'MAX_AGGREGATE_GROUPS', DEFAULT_MAX_AGGREGATE_GROUPS, 1, MAX_AGGREGATE_GROUPS, False, False),

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -590,6 +590,8 @@ numericConfigs = [
     ('search-fork-gc-sleep-before-exit', 'FORKGC_SLEEP_BEFORE_EXIT', 0, 0, LLONG_MAX, False, False),
     ('search-gc-scan-size', 'GCSCANSIZE', 100, 1, LLONG_MAX, True, False),
     ('search-index-cursor-limit', 'INDEX_CURSOR_LIMIT', 128, 0, LLONG_MAX, False, False),
+    # A percentage, so the maximum is 100 rather than a type bound. 0 disables inline repair.
+    ('search-inline-gc-block-repair-threshold', 'INLINE_GC_BLOCK_REPAIR_THRESHOLD', 0, 0, 100, False, False),
     ('search-max-aggregate-groups', 'MAX_AGGREGATE_GROUPS', DEFAULT_MAX_AGGREGATE_GROUPS, 1, MAX_AGGREGATE_GROUPS, False, False),
     ('search-max-aggregate-results', 'MAXAGGREGATERESULTS', DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS, 0, MAX_AGGREGATE_REQUEST_RESULTS, False, False),
     ('search-max-doctablesize', 'MAXDOCTABLESIZE', 1_000_000, 1, 100_000_000, True, False),


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: deleting or updating a document only flags it — its inverted-index postings stay encoded until a fork GC reclaims them. That GC forks while the write spike that produced the garbage is still running, and by design never repairs an index's last block, so the tail of an actively-written term accumulates dead entries across cycles.
2. Change: two new runtime configs, both inert by default. `INLINE_GC_BLOCK_REPAIR_THRESHOLD` (percent, `0` = off, the default) makes a writer reclaim dead entries from its index's tail block in place; `INLINE_GC_BLOCK_REPAIR_STRIDE` sets how often it inspects a tail block that has not yet filled. `FT.INFO` gains `inline_gc_repairs` and `inline_gc_bytes_collected`.
3. Outcome: operators who enable it trade write throughput for residency and smaller GC cycles. On a 200k-document enwiki index under continuous updates, the default stride leaves 7.5 M index records instead of 88.5 M, lowers peak RSS 25–35%, and cuts total fork-GC time 19–36%, for ~26% write throughput. Nothing changes for anyone who does not set the threshold.

#### Which additional issues this PR fixes

1. N/A — no ticket was opened for this change.

#### Main objects this PR modified

1. `InvertedIndex::maybe_repair_tail_block` / `repair_tail_block` (`inverted_index/src/gc.rs`) — the write-path repair and the trigger deciding when it runs, plus lazy re-encode in `IndexBlock::repair` so a clean block no longer pays to rebuild itself.
2. `src/indexer.c` — `maybeRepairTailBlock` on the write path, with the spec-stat accounting mirroring the fork GC's.
3. `src/config.c` / `config.h` — the threshold and the stride, at both the `FT.CONFIG` and `search-*` module-config entry points.
4. `FT.INFO` (`src/info/info_command.c`, `src/spec.c`) — the two new counters.
5. `openspec/changes/inline-block-repair-on-write/` — proposal, design, spec delta, and four rounds of benchmarks behind the numbers above.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Notes for reviewers, beyond what the diff shows:

- **The write cost is large enough to be a deliberate choice, which is why there is a dial.** `proposal.md` criterion 3 set a 5% write-latency budget. The default stride costs ~26% (p50 0.121 → 0.171 ms); `INLINE_GC_BLOCK_REPAIR_STRIDE = 0` restricts repair to filled blocks and costs ~5%, reclaiming much less (68 M residual records against 7.5 M). Both endpoints are measured, the curve between them is not. What is left for maintainers is which end the *default* stride should sit at — it only bites once the threshold default moves off `0`.
- **The stride's every-append bound is deliberately a constant, not a function of the stride.** Deriving it inverts the dial: a large stride would put every short block in the probe-always region, so raising it to cut cost would raise cost instead. `maybe_repair_tail_block_stride_is_monotonic` pins this.
- **Success criterion 2 is marked not met.** Under forced GC, `gc_blocks_denied` was unchanged (408k vs 406k) — a denial fires whenever a writer touched the last block since the fork, which this does not change. Under automatic scheduling (round 4) denials do roughly halve, as a second-order effect of there being less garbage. Both measurements are in the write-up; the criterion as worded is still the wrong test for this mechanism.
- **`repair_tail_block` rejects a repair that would split the block into more than one**, because dropping an entry can widen a doc-ID delta past what the encoder can represent. Those entries are left to the fork GC, which can afford the split off the write path.
- **This does not replace the fork GC, and cannot.** A writer only reaches the tail block, so even at the most aggressive setting the index sits at ~47% garbage in steady state: inline repair removes ~96% of the garbage *flow*, but cold terms, non-tail blocks, and any idle period after a bulk delete stay the fork GC's. Cycle time halves rather than collapsing, because scanning a clean index still costs a decode pass per block.
- `tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-gc.yml` cannot exercise this feature: its dataset keys are `doc:<uuid>:<id>` while its memtier arguments generate `doc:<N>`, so every "update" is an insert and no garbage is produced. Benchmarks here used a purpose-built harness; fixing that file is listed as a follow-up.
- Verification beyond the usual: four rounds of benchmarks, the last two on a fixed write count with automatic GC scheduling so arms are comparable — method, numbers, and caveats in `benchmarks.md`.
