### PR TITLE
[MOD-18075] Support FT.DEBUG DUMP_HNSW for disk indexes

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1755,6 +1755,11 @@ void replyDumpHNSW(RedisModuleCtx *ctx, VecSimIndex *index, t_docId doc_id) {
     RedisModule_EndReply(&reply);
     return;
   }
+  if (res != VecSimDebugCommandCode_OK) {
+    RedisModule_Reply_Error(&reply, "Unable to read HNSW graph data");
+    RedisModule_EndReply(&reply);
+    return;
+  }
   START_POSTPONED_LEN_ARRAY(response);
   REPLY_WITH_LONG_LONG("Doc id", (long long)doc_id, ARRAY_LEN_VAR(response));
 
@@ -1783,9 +1788,6 @@ DEBUG_COMMAND(dumpHNSWData) {
   }
   if (argc < 4 || argc > 5) { // it should be 4 or 5 (allowing specifying a certain doc)
     return RedisModule_WrongArity(ctx);
-  }
-  if (SearchDisk_IsEnabled()) {
-    return RedisModule_ReplyWithError(ctx, "Command not supported in disk mode");
   }
   GET_SEARCH_CTX(argv[2])
 
@@ -1825,7 +1827,27 @@ DEBUG_COMMAND(dumpHNSWData) {
   }
   // Otherwise, dump neighbors for every document in the index.
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-  DOCTABLE_FOREACH((&sctx->spec->docs), {replyDumpHNSW(ctx, vecsimIndex, dmd->id); len_num_docs++;})
+  if (sctx->spec->diskSpec) {
+    t_docId max_doc_id = SearchDisk_GetMaxDocId(sctx->spec->diskSpec);
+    for (t_docId doc_id = 1; doc_id <= max_doc_id; doc_id++) {
+      RSDocumentMetadata *dmd = rm_calloc(1, sizeof(*dmd));
+      dmd->sortVector = RSSortingVector_Empty();
+      dmd->ref_count = 1;
+      bool found = !SearchDisk_DocIdDeleted(sctx->spec->diskSpec, doc_id) &&
+                   SearchDisk_GetDocumentMetadata(sctx->spec->diskSpec, sctx, doc_id, dmd, NULL);
+      DMD_Return(dmd);
+      if (!found) {
+        continue;
+      }
+      replyDumpHNSW(ctx, vecsimIndex, doc_id);
+      len_num_docs++;
+    }
+  } else {
+    DOCTABLE_FOREACH((&sctx->spec->docs), {
+      replyDumpHNSW(ctx, vecsimIndex, dmd->id);
+      len_num_docs++;
+    })
+  }
   RedisModule_ReplySetArrayLength(ctx, len_num_docs);
 
   cleanup:

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -353,6 +353,7 @@ class TestDebugCommands(object):
 
 @skip(cluster=True, no_json=True)
 def testDumpHNSW(env):
+    """DUMP_HNSW supports individual and full graph inspection for live documents."""
     # Note that this test has its own env as it relies on the specific doc ids in the index created.
     # Had we used this test in the TestDebugCommands env, a background indexing would have been triggered, and
     # with high probability, some documents would be indexed BEFORE the background scan would end, and it will be
@@ -387,6 +388,12 @@ def testDumpHNSW(env):
     env.expect(debug_cmd(), 'DUMP_HNSW', 'temp-idx', 'v_HNSW').\
         equal([['Doc id', 1, ['Neighbors in level 0', 2]], ['Doc id', 2, ['Neighbors in level 0', 1]],
                "Doc id 3 doesn't contain the given field"])
+
+    # Full dumps enumerate the live document table, so deleted documents that never had this
+    # vector field must not produce a "doesn't contain the given field" entry.
+    env.expect('JSON.DEL', '_doc3').equal(1)
+    env.expect(debug_cmd(), 'DUMP_HNSW', 'temp-idx', 'v_HNSW').\
+        equal([['Doc id', 1, ['Neighbors in level 0', 2]], ['Doc id', 2, ['Neighbors in level 0', 1]]])
 
 @skip(cluster=False)
 def testCoordDebug(env: Env):


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.DEBUG DUMP_HNSW` rejects disk mode, so disk HNSW graph connectivity cannot be inspected through the existing debug command.
2. Change: Allow disk-backed vector indexes to serve the existing command, enumerate live disk documents for full dumps, and fail cleanly when a backend cannot expose graph data. This depends on [VectorSimilarity #1024](https://github.com/RedisAI/VectorSimilarity/pull/1024).
3. Outcome: Operators and developers can inspect one document or the full HNSW graph for disk indexes using the same reply shape as RAM indexes; deleted documents are excluded.

#### Which additional issues this PR fixes

1. [MOD-18075](https://redislabs.atlassian.net/browse/MOD-18075)
2. [VectorSimilarity #1024](https://github.com/RedisAI/VectorSimilarity/pull/1024)

#### Main objects this PR modified

1. `FT.DEBUG DUMP_HNSW` — disk-mode support and backend error handling
2. Disk document table traversal — live-document enumeration
3. VectorSimilarity dependency — polymorphic HNSW debug dispatch
4. Debug flow coverage — deleted-document behavior

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


[MOD-18075]: https://redislabs.atlassian.net/browse/MOD-18075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ