### PR TITLE
Top K : pytest: pin scorer interaction for Top K

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1385,6 +1385,42 @@ def test_hybrid_query_scorer_slop():
                               message=[scorer, hybrid])
 
 
+@skip(cluster=True)
+def test_hybrid_query_scorer_slop_ranking():
+    """The ranking a filtered KNN query replies with: a boosted document whose
+    matched terms are far apart outranks a tighter, unboosted one, because under
+    a KNN the distance between the terms is not charged against it. The same
+    prefilter on its own ranks the two the other way round."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCORE_FIELD', 'boost', 'SCHEMA', 't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn.execute_command('HSET', 'tight', 'boost', 1, 't', 'hello world',
+                         'v', np.float32([1, 1]).tobytes())
+    conn.execute_command('HSET', 'boosted', 'boost', 2, 't', 'hello big wide world',
+                         'v', np.float32([2, 2]).tobytes())
+
+    query_vec = np.float32([0, 0]).tobytes()
+
+    # No SORTBY, so both replies are ordered by relevance score. TFIDF is one of
+    # the scorers that divides by the slop; the default one does not.
+    env.expect('FT.SEARCH', 'idx', '@t:(hello world)', 'SCORER', 'TFIDF',
+               'NOCONTENT').equal([2, 'tight', 'boosted'])
+    env.expect('FT.SEARCH', 'idx', '(@t:(hello world))=>[KNN 2 @v $vec_param]',
+               'SCORER', 'TFIDF', 'NOCONTENT',
+               'PARAMS', 2, 'vec_param', query_vec).equal([2, 'boosted', 'tight'])
+    env.expect('FT.SEARCH', 'idx', '(@t:(hello world))=>[KNN 2 @v $vec_param]',
+               'SCORER', 'TFIDF', 'NOCONTENT', 'LIMIT', 0, 1,
+               'PARAMS', 2, 'vec_param', query_vec).equal([2, 'boosted'])
+    # `k` selects candidates by vector distance before any scoring, so the
+    # nearest vector is the answer whatever the relevance ranking says.
+    env.expect('FT.SEARCH', 'idx', '(@t:(hello world))=>[KNN 1 @v $vec_param]',
+               'SCORER', 'TFIDF', 'NOCONTENT',
+               'PARAMS', 2, 'vec_param', query_vec).equal([1, 'tight'])
+
+
 @skip(cluster=False)
 def test_single_entry():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1339,6 +1339,45 @@ def test_hybrid_query_non_vector_score():
                 'PARAMS', 2, 'vec_param', query_data.tobytes(),
                 'RETURN', 2, 't', '__v_score', 'LIMIT', 0, 100).equal(expected_res_6)
 
+@skip(cluster=True)
+def test_hybrid_query_scorer_slop():
+    """A filtered KNN query scores its text prefilter exactly as that prefilter
+    scores on its own: the scorer receives the prefilter's intersection, so the
+    slop divisor is the terms' real offset distance."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    # Each doc carries both terms once, so they share TF, IDF and max term
+    # frequency; the gap between the terms is the only input that differs.
+    conn.execute_command('HSET', 'adjacent', 't', 'hello world',
+                         'v', np.float32([1, 1]).tobytes())
+    conn.execute_command('HSET', 'separated', 't', 'hello big wide world',
+                         'v', np.float32([2, 2]).tobytes())
+
+    query_vec = np.float32([0, 0]).tobytes()
+
+    def scores(query, scorer):
+        res = env.cmd('FT.SEARCH', 'idx', query, 'SCORER', scorer, 'WITHSCORES',
+                      'NOCONTENT', 'PARAMS', 2, 'vec_param', query_vec)
+        return {res[i]: float(res[i + 1]) for i in range(1, len(res), 2)}
+
+    for scorer in ('TFIDF', 'BM25'):
+        text_only = scores('@t:(hello world)', scorer)
+        hybrid = scores('(@t:(hello world))=>[KNN 2 @v $vec_param]', scorer)
+
+        env.assertEqual(sorted(hybrid.keys()), ['adjacent', 'separated'],
+                        message=[scorer, hybrid])
+        # Slop is the minimal offset distance between the two terms.
+        env.assertAlmostEqual(text_only['adjacent'] / text_only['separated'], 3.0, 0.01,
+                              message=[scorer, text_only])
+        for doc, score in text_only.items():
+            env.assertAlmostEqual(hybrid[doc], score, 0.01,
+                                  message=[scorer, doc, hybrid, text_only])
+
+
 @skip(cluster=False)
 def test_single_entry():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1341,9 +1341,10 @@ def test_hybrid_query_non_vector_score():
 
 @skip(cluster=True)
 def test_hybrid_query_scorer_slop():
-    """A filtered KNN query scores its text prefilter exactly as that prefilter
-    scores on its own: the scorer receives the prefilter's intersection, so the
-    slop divisor is the terms' real offset distance."""
+    """A filtered KNN query scores its text prefilter as if the matched terms
+    were adjacent: the scorer receives the prefilter alongside the distance
+    metric, and the slop walk pairs only top-level siblings, so the terms' real
+    offset distance never reaches the divisor."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -1370,12 +1371,18 @@ def test_hybrid_query_scorer_slop():
 
         env.assertEqual(sorted(hybrid.keys()), ['adjacent', 'separated'],
                         message=[scorer, hybrid])
-        # Slop is the minimal offset distance between the two terms.
-        env.assertAlmostEqual(text_only['adjacent'] / text_only['separated'], 3.0, 0.01,
+
+        # Adjacent terms are a distance of one apart, so `adjacent` is scored
+        # undivided and any score read against it recovers its own divisor.
+        undivided = text_only['adjacent']
+        env.assertAlmostEqual(undivided / text_only['separated'], 3.0, 0.01,
                               message=[scorer, text_only])
-        for doc, score in text_only.items():
-            env.assertAlmostEqual(hybrid[doc], score, 0.01,
-                                  message=[scorer, doc, hybrid, text_only])
+        env.assertAlmostEqual(undivided / hybrid['adjacent'], 1.0, 0.01,
+                              message=[scorer, hybrid])
+        # Under a KNN the gap between the terms is invisible, so the divisor
+        # falls back to a distance of one rather than the distance they are at.
+        env.assertAlmostEqual(undivided / hybrid['separated'], 1.0, 0.01,
+                              message=[scorer, hybrid])
 
 
 @skip(cluster=False)


### PR DESCRIPTION
- follow up to https://github.com/RediSearch/RediSearch/pull/11167#discussion_r3860861556

This is about a KNN query fed to a scorer, then limited, I think it falls on quite an edge case, but I'd appreciate feedbacks.

My goal with this PR is to pin the current behaviour, to better understand the impact when swapping, where we will update the test.

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
