### PR TITLE
[8.6] doc: Rust: bring rustdoc lint to parity with master (#8656)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ endef
 lint:
 	@echo "Running linters..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items
 
 fmt:
 ifeq ($(CHECK),1)

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -67,6 +67,8 @@ pub unsafe extern "C" fn RLookup_AddKeysFrom<'a>(
 ///     1. The entire memory range of this cstr must be contained within a single allocation!
 ///     2. `name` must be non-null even for a zero-length cstr.
 /// 4. The nul terminator must be within `isize::MAX` from `name`
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_FindFieldInSpecCache(
     lookup: *const RLookup<'_>,

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -211,6 +211,8 @@ void RLookup_AddKeysFrom(const struct RLookup *src,
  *     1. The entire memory range of this cstr must be contained within a single allocation!
  *     2. `name` must be non-null even for a zero-length cstr.
  * 4. The nul terminator must be within `isize::MAX` from `name`
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const FieldSpec *RLookup_FindFieldInSpecCache(const struct RLookup *lookup, const char *name);
 

--- a/src/redisearch_rs/inverted_index/src/controlled_cursor.rs
+++ b/src/redisearch_rs/inverted_index/src/controlled_cursor.rs
@@ -58,7 +58,7 @@ unsafe fn vec_write_all_unchecked(pos: usize, vec: &mut Vec<u8>, buf: &[u8]) -> 
     pos + buf.len()
 }
 
-/// Resizing `write_all` implementation for [`Cursor`].
+/// Resizing `write_all` implementation for [`ControlledCursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]
@@ -92,7 +92,7 @@ fn vec_write_all(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> std::io::R
     Ok(buf_len)
 }
 
-/// Resizing `write_all_vectored` implementation for [`Cursor`].
+/// Resizing `write_all_vectored` implementation for [`ControlledCursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -203,7 +203,7 @@ impl Upstream<'_> {
 /// For intrusive data types like this we need to tell the compiler "don't move this please I have pointers to it" which is called
 /// pinning in Rust.
 ///
-/// We wrap a reference in the Pin<T> type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
+/// We wrap a reference in the `Pin<T>` type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
 /// Crucially though, the way Pin disallows is not magic, it simply doesn't implement any methods and traits that would
 /// allow a caller to move the value. Unfortunately this means banning all mutable access to the value T (you cannot get a
 /// &mut T from a Pin<&mut T> for example) since with a &mut T you can always move the value very easily (via mem::replace for example).

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -12,9 +12,9 @@
 //!
 //! It also contains wrappers for some RedisModule types, using new-type pattern to ensure proper memory/lock management.
 //!
-//! - [RedisString]: A wrapper around `RedisModuleString` that ensures proper memory management.
-//! - [RedisKey]: A wrapper around `RedisModuleKey` that ensures proper resource management (open/close)
-//! - [RedisScanCursor]: A wrapper around `RedisModuleScanCursor` that ensures proper resource management (create/destroy).
+//! - `RedisString`: A wrapper around `RedisModuleString` that ensures proper memory management.
+//! - `RedisKey`: A wrapper around `RedisModuleKey` that ensures proper resource management (open/close)
+//! - `RedisScanCursor`: A wrapper around `RedisModuleScanCursor` that ensures proper resource management (create/destroy).
 
 use core::slice;
 use enumflags2::{BitFlags, bitflags};
@@ -28,7 +28,7 @@ use std::{
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, strum::FromRepr)]
 pub enum RLookupLoadMode {
-    /// Use keylist to load a number of [RLookupLoadOptions::n_keys] from [RLookupLoadOptions::keys]
+    /// Use keylist to load a number of `RLookupLoadOptions::n_keys` from `RLookupLoadOptions::keys`
     KeyList = 0,
 
     /// Load only cached keys from the [sorting_vector::RSSortingVector] and do not load from [crate::row::RLookupRow]

--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -86,7 +86,7 @@ pub type RLookupKeyFlags = BitFlags<RLookupKeyFlag>;
 pub const GET_KEY_FLAGS: RLookupKeyFlags =
     make_bitflags!(RLookupKeyFlag::{Override | Hidden | ExplicitReturn | ForceLoad});
 
-/// Flags do not persist to the key, they are just options to [`RLookup::get_key_read`], [`RLookup::get_key_write`], or [`RLookup::get_key_load`].
+/// Flags do not persist to the key, they are just options to [`super::RLookup::get_key_read`], [`super::RLookup::get_key_write`], or [`super::RLookup::get_key_load`].
 pub const TRANSIENT_FLAGS: RLookupKeyFlags =
     make_bitflags!(RLookupKeyFlag::{Override | ForceLoad | NameAlloc});
 
@@ -285,7 +285,7 @@ impl<'a> RLookupKey<'a> {
     /// Constructs a `Pin<Box<RLookupKey>>` from a raw pointer.
     ///
     /// The returned `Box` will own the raw pointer, in particular dropping the `Box`
-    /// will deallocate the `RLookupKey`. This function should only be used by [`RLookup::drop`].
+    /// will deallocate the `RLookupKey`. This function should only be used by [`super::key_list::KeyList`]'s `drop` implementation.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -45,7 +45,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
 
     /// Get the current iterator offset—i.e. its position in the list of IDs.
     ///
-    /// This is used by [`MetricIterator`](crate::metric::MetricIterator) to iterate over the corresponding list
+    /// This is used by [`Metric`](crate::metric::Metric) to iterate over the corresponding list
     /// of metric data in lockstep.
     #[inline(always)]
     pub(super) const fn offset(&self) -> usize {

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -178,7 +178,7 @@ impl<T: RSValueTrait> RSSortingVector<T> {
         sz
     }
 
-    /// Returns `Ok(())` if the index is in bounds, [`Error::OutOfBounds`] otherwise.
+    /// Returns `Ok(())` if the index is in bounds, [`IndexOutOfBounds`] otherwise.
     fn in_bounds(&self, idx: usize) -> Result<(), IndexOutOfBounds> {
         if idx < self.values.len() {
             Ok(())

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -9,7 +9,7 @@
 
 //! Primitives to manage the expected memory layout of the heap-allocated buffer for each [`Node`].
 //!
-//! Check out [`NodeLayout`]'s documentation for more details.
+//! Check out [`PtrMetadata`]'s documentation for more details.
 use crate::node::Node;
 use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
@@ -17,7 +17,7 @@ use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 #[derive(Clone, Copy, Debug)]
 /// The first field in the allocated buffer for a [`Node`].
 ///
-/// [`NodeHeader::layout`] can be used to compute the layout of
+/// [`NodeHeader::metadata`] can be used to compute the layout of
 /// the buffer allocated for a [`Node`].
 pub(super) struct NodeHeader {
     /// The length of the label associated with this node.
@@ -106,7 +106,7 @@ impl NodeHeader {
 /// to align our type.
 ///
 /// We have optimized, in particular, for `Data=NonNull<*mut c_void>`, the scenario we have in
-/// [`crate::ffi`]. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
+/// the FFI layer. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
 /// located between the end of the array of children first bytes and the start of the
 /// array of children pointers.
 ///
@@ -357,7 +357,7 @@ impl<Data> PtrMetadata<Data> {
     /// a. `ptr` must point to an allocation with the same alignment and size of [`Self::layout`].
     /// b. `ptr` must have been allocated via the global allocator.
     /// c. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// d. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// d. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, ptr: NonNull<NodeHeader>, options: DeallocOptions) {
@@ -519,7 +519,7 @@ impl<Data> PtrWithMetadata<Data> {
     ///
     /// a. The layout of the allocation behind [`Self::ptr`] matches *exactly* the layout it was allocated with.
     /// b. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// c. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// c. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, options: DeallocOptions) {

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::is_prefix`].
+/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::all::is_prefix`].
 #[inline(always)]
 pub(crate) fn strip_prefix<'a>(haystack: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
     if !memchr::arch::all::is_prefix(haystack, prefix) {


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `make lint`'s `cargo doc` check on this branch does not pass `--document-private-items`, so private-item rustdoc warnings that would fail on `master` since #8656 go undetected here.
2. Change: cherry-picked #8656, adapted to this branch — added `--document-private-items` to the branch's single `cargo doc` line (8.6, unlike master, has no separate release-mode doc invocation, so none is added), dropped hunks touching code that doesn't exist on this branch, and fixed the branch-specific rustdoc warnings that flag then surfaced (broken intra-doc links to renamed/removed types).
3. Outcome: internal-only — `make lint` on this branch now enforces the same private-item rustdoc coverage as `master`, closing the gap left by 8.6 being cut (2026-01-17) before #8656 merged (2026-03-11).

#### Which additional issues this PR fixes

1. N/A
2. Cherry-picks/backports #8656

#### Main objects this PR modified

1. `Makefile` — added `--document-private-items` to the existing `cargo doc` lint line.
2. `src/redisearch_rs/rqe_iterators/src/id_list.rs` — fixed a broken intra-doc link to a since-renamed type (`MetricIterator` → `Metric`).
3. `src/redisearch_rs/rlookup/src/bindings.rs` — module doc referenced types that don't exist on this branch (`RedisString`/`RedisKey`/`RedisScanCursor`/`RLookupLoadOptions`); converted to plain text.
4. `src/redisearch_rs/result_processor/src/lib.rs` — restored a doc link to `ffi::SearchResult_Clear` (the crate has no dependency on `search_result`, so a link to it can't resolve here).
5. `src/redisearch_rs/sorting_vector/src/lib.rs` — fixed a doc link referencing a nonexistent `Error::OutOfBounds` to the real `IndexOutOfBounds` type.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
