### PR TITLE
[8.4] Commit the regenerated Cargo.lock and module_init.h [MOD-13507]

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "build_utils",
  "cbindgen",
+ "chrono",
  "ffi",
  "tracing",
  "tracing_redismodule",

--- a/src/redisearch_rs/headers/module_init.h
+++ b/src/redisearch_rs/headers/module_init.h
@@ -17,15 +17,20 @@ extern "C" {
 void TracingRedisModule_Init(RedisModuleCtx *ctx);
 
 /**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ * Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
  *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
+ * Panic messages will be logged through `tracing` at the `ERROR` level, and
+ * stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+ * the crash report.
  */
 void RustPanicHook_Init(void);
 
 /**
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
+ *
+ * When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+ * in the same section, ahead of the backtrace.
  *
  * # Safety
  *


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `8.4` is red on CI's "Generated files" step. #11157 (the #11091 backport) hand-wrote two generated files instead of running the tools: `chrono` was inserted at the top of `module_init_ffi`'s dependency list in `Cargo.lock`, and `headers/module_init.h` was never regenerated at all.
2. **Change:** Both files replaced with the output of `make lint`, which is exactly what that CI step diffs against. No source changes.
3. **Outcome:** Internal only, no user-visible effect. Unblocks the "Generated files" check on `8.4`.

Cargo keeps each package's dependency list sorted, so `chrono` ahead of `build_utils` is rewritten on the next cargo run. The header is produced by cbindgen from `module_init_ffi`'s build script and had not picked up the doc comments the backport changed (the `replaacing` typo fix and the two new paragraphs).

Same defect landed on `8.6-rse` (lock only) and is fixed in a sibling PR; the still-open `8.8` and `8.6` backports were fixed in place.

#### Which additional issues this PR fixes

1. MOD-13507
2. #11157

#### Main objects this PR modified

1. `src/redisearch_rs/Cargo.lock` — `chrono` sorted into `module_init_ffi`'s dependency list.
2. `src/redisearch_rs/headers/module_init.h` — regenerated from the current Rust doc comments.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

### Note on verification

`make lint` does not reach a clean exit on this branch, for a pre-existing reason this PR does not touch: `8.4` has no `--document-private-items` on its `cargo doc` line, so the `[`PANIC_STASH`]` links #11157 added to public items fail `rustdoc::private_intra_doc_links`. Clippy passes and both generated files above are byte-identical to what `make lint` writes before that step fails. A separate PR brings `8.4`'s lint invocation to parity with #8656.
