### PR TITLE
[8.6-rse] Commit the regenerated Cargo.lock, and fix spellcheck's diff base [MOD-13507]

### DIFF
--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -12,9 +12,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Fetch master
-        run: git fetch origin master
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -28,4 +25,4 @@ jobs:
           pip install -r ./.codespell/requirements.txt
 
       - name: Run codespell on diffs
-        run: git diff --name-only origin/master --diff-filter=AM | xargs -r codespell --config .codespell/.codespellrc
+        run: git diff --name-only origin/8.6-rse --diff-filter=AM | xargs -r codespell --config .codespell/.codespellrc

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "build_utils",
  "cbindgen",
+ "chrono",
  "ffi",
  "tracing",
  "tracing_redismodule",


### PR DESCRIPTION
## Describe the changes in the pull request

Two independent CI fixes for `8.6-rse`, both blocking any PR to this branch.

1. **Generated files.** #11156 (the #11091 backport) hand-inserted `chrono` at the top of `module_init_ffi`'s dependency list in `Cargo.lock`. Cargo keeps those lists sorted, so it is rewritten on the next cargo run and CI's "Generated files" step reports a dirty tree. Replaced with the output of `make lint`, which is what that step diffs against. The generated header on this branch was already correct, unlike on `8.4`/`8.8`/`8.6`.

2. **Spellcheck.** codespell ran over `git diff --name-only origin/master`, which on a release branch is the entire divergence from master — hundreds of files nobody in the PR touched. It trips on a pre-existing `altough` in `tests/pytests/test_stemmer.py`, so every PR to this branch fails spellcheck regardless of its contents. Now compares against `origin/8.6-rse`, the same change `8.6` and `8.4` already took in #8303 and #8304.

`master` no longer carries this workflow code at all — it delegates to the shared `redisearch-ci-common` spellcheck workflow, which resolves the base ref from the PR target. Migrating these branches to that is the better long-term fix and is deliberately left out of scope here.

`make lint` passes on this branch with the change applied, and the tree stays clean afterwards.

#### Which additional issues this PR fixes

1. MOD-13507
2. #11156

#### Main objects this PR modified

1. `src/redisearch_rs/Cargo.lock` — `chrono` sorted into `module_init_ffi`'s dependency list.
2. `.github/workflows/task-spellcheck.yml` — diff base changed from `origin/master` to `origin/8.6-rse`; the now-unused `Fetch master` step dropped.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes