### PR TITLE
[EXPERIMENAL] Proof of concept: using ghcr mirror on self-hosted runners

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -63,7 +63,7 @@ jobs:
   # ------------------------------------------------------------------
 
   basic-test:
-    name: basic-test / ubuntu:latest (x86_64)
+    name: basic-test ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -82,7 +82,7 @@ jobs:
       rejson-branch: master
 
   coverage:
-    name: coverage / ubuntu:latest (x86_64)
+    name: coverage ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -101,7 +101,7 @@ jobs:
       rejson-branch: master
 
   sanitize:
-    name: sanitize / ubuntu:latest (x86_64)
+    name: sanitize ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -125,7 +125,7 @@ jobs:
   # ------------------------------------------------------------------
 
   miri:
-    name: miri / ubuntu:latest (x86_64) (${{ matrix.shard }}/3)
+    name: miri ubuntu:latest (x86_64) (${{ matrix.shard }}/3)
     needs: [check-what-changed, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     # Split MIRI across 3 nextest partitions. Each shard is self-contained

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -63,6 +63,7 @@ jobs:
   # ------------------------------------------------------------------
 
   basic-test:
+    name: basic-test / ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -81,6 +82,7 @@ jobs:
       rejson-branch: master
 
   coverage:
+    name: coverage / ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -99,6 +101,7 @@ jobs:
       rejson-branch: master
 
   sanitize:
+    name: sanitize / ubuntu:latest (x86_64)
     needs: [check-what-changed, get-latest-redis-tag, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     permissions:
@@ -122,7 +125,7 @@ jobs:
   # ------------------------------------------------------------------
 
   miri:
-    name: miri (${{ matrix.shard }}/3)
+    name: miri / ubuntu:latest (x86_64) (${{ matrix.shard }}/3)
     needs: [check-what-changed, spellcheck]
     if: ${{ ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     # Split MIRI across 3 nextest partitions. Each shard is self-contained

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -76,7 +76,7 @@ jobs:
       san: ${{ inputs.job-type == 'sanitize' && 'address' || 'none' }}
 
   build:
-    name: Build / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
+    name: Build ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # build-image is skipped for non-container platforms; without this guard a
     # skipped need would skip this job (and the whole pipeline) instead of
@@ -115,7 +115,7 @@ jobs:
   # independent of the module build, so they run concurrently with it rather than
   # inside it; both are cache-restored on the common path.
   build-redis:
-    name: Redis / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
+    name: Redis ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # Same build-image guard as `build` above.
     if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
@@ -141,7 +141,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   build-rejson:
-    name: RedisJSON / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
+    name: RedisJSON ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # Same build-image guard as `build` above.
     if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
@@ -168,7 +168,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-unit:
-    name: Unit / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
+    name: Unit ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image, build]
     if: ${{ !cancelled() && needs.build.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     permissions:
@@ -202,7 +202,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-standalone:
-    name: Standalone / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
+    name: Standalone ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image, build, build-redis, build-rejson]
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     permissions:
@@ -241,7 +241,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-coordinator:
-    name: Coordinator / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }}) (${{ matrix.shard }}/${{ strategy.job-total }})
+    name: Coordinator ${{ inputs.job-type }} ${{ inputs.platform }} (${{ inputs.architecture }}) (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [get-config, build-image, build, build-redis, build-rejson]
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     # Coordinator tests are the slowest flow suite (cluster setup, inter-shard

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -69,6 +69,7 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
+    secrets: inherit
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env }}
@@ -106,6 +107,7 @@ jobs:
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       enable-lto: ${{ inputs.enable-lto != '' && inputs.enable-lto || needs.get-config.outputs.enable_lto }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   # redis-server and RedisJSON are external to this repo but must be built with
@@ -121,6 +123,7 @@ jobs:
       contents: read
       packages: read
     uses: ./.github/workflows/task-build-redis.yml
+    secrets: inherit
     with:
       redis-ref: ${{ inputs.redis-ref }}
       coverage: ${{ inputs.job-type == 'coverage' }}
@@ -134,6 +137,7 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   build-rejson:
@@ -145,6 +149,7 @@ jobs:
       contents: read
       packages: read
     uses: ./.github/workflows/task-build-rejson.yml
+    secrets: inherit
     with:
       platform: ${{ inputs.platform }}
       coverage: ${{ inputs.job-type == 'coverage' }}
@@ -159,6 +164,7 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-unit:
@@ -192,6 +198,7 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-standalone:
@@ -230,6 +237,7 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-coordinator:
@@ -280,4 +288,5 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
+      image-is-mirror: ${{ needs.build-image.outputs.image-is-mirror }}
       image-built: ${{ needs.build-image.outputs.succeeded }}

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -76,7 +76,7 @@ jobs:
       san: ${{ inputs.job-type == 'sanitize' && 'address' || 'none' }}
 
   build:
-    name: Build (${{ inputs.job-type }})
+    name: Build / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # build-image is skipped for non-container platforms; without this guard a
     # skipped need would skip this job (and the whole pipeline) instead of
@@ -115,7 +115,7 @@ jobs:
   # independent of the module build, so they run concurrently with it rather than
   # inside it; both are cache-restored on the common path.
   build-redis:
-    name: Build Redis (${{ inputs.job-type }})
+    name: Redis / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # Same build-image guard as `build` above.
     if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
@@ -141,7 +141,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   build-rejson:
-    name: Build RedisJSON (${{ inputs.job-type }})
+    name: RedisJSON / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image]
     # Same build-image guard as `build` above.
     if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
@@ -168,7 +168,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-unit:
-    name: ${{ inputs.job-type }} (Unit)
+    name: Unit / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image, build]
     if: ${{ !cancelled() && needs.build.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     permissions:
@@ -202,7 +202,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-standalone:
-    name: ${{ inputs.job-type }} (Standalone)
+    name: Standalone / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }})
     needs: [get-config, build-image, build, build-redis, build-rejson]
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     permissions:
@@ -241,7 +241,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-coordinator:
-    name: ${{ inputs.job-type }} (Coordinator ${{ matrix.shard }}/${{ strategy.job-total }})
+    name: Coordinator / ${{ inputs.job-type }} / ${{ inputs.platform }} (${{ inputs.architecture }}) (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [get-config, build-image, build, build-redis, build-rejson]
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     # Coordinator tests are the slowest flow suite (cluster setup, inter-shard

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -105,7 +105,6 @@ jobs:
         done
         [ $SUCCESS -eq 1 ] || exit 1
     steps: &build_steps
-      # Setup
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -52,7 +52,8 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build cached container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
-    secrets: inherit
+    secrets:
+      GHCR_MIRROR_PASSWORD: ${{ secrets.GHCR_MIRROR_PASSWORD }}
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -84,7 +84,7 @@ jobs:
 
     env: &build_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-      VERBOSE: 1 # For logging
+      VERBOSE: 1
       RELEASE: 0
       LTO: ${{ needs.get-config.outputs.enable_lto }}
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -52,35 +52,36 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build cached container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
+    secrets: inherit
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
-  build:
+  build-ghcr:
     name: Build ${{ needs.get-config.outputs.name }}
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
-      needs.get-config.result == 'success'
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror != 'true'
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
-    permissions:
+    permissions: &build_permissions
       id-token: write # Required for OIDC role assumption during upload
       contents: read  # Required for actions/checkout
       packages: read  # Required for GHCR read
-    defaults:
+    defaults: &build_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    container: ${{
-      needs.get-config.outputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1}"}}',
-            needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '')
-        )
-      || null }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: &build_container_options >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
 
-    env:
+    env: &build_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
@@ -103,7 +104,7 @@ jobs:
           fi
         done
         [ $SUCCESS -eq 1 ] || exit 1
-    steps:
+    steps: &build_steps
       # Setup
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
@@ -224,3 +225,56 @@ jobs:
           BETA_VERSION: ${{ steps.set-versions.outputs.BETA_VERSION }}
           VERSION_SUFFIX: ${{ steps.set-versions.outputs.VERSION_SUFFIX }}
         run: make upload-artifacts
+
+  build-mirror:
+    name: Build ${{ needs.get-config.outputs.name }}
+    needs: [get-config, build-image]
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror == 'true'
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *build_permissions
+    defaults: *build_defaults
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    env: *build_env
+    steps: *build_steps
+
+  build-raw:
+    name: Build ${{ needs.get-config.outputs.name }}
+    needs: [get-config, build-image]
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded != 'true'
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *build_permissions
+    defaults: *build_defaults
+    container:
+      image: ${{ needs.get-config.outputs.container }}
+      options: *build_container_options
+    env: *build_env
+    steps: *build_steps
+
+  build-host:
+    name: Build ${{ needs.get-config.outputs.name }}
+    needs: [get-config, build-image]
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container == ''
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *build_permissions
+    defaults: *build_defaults
+    env: *build_env
+    steps: *build_steps

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -59,7 +59,7 @@ jobs:
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
   build-ghcr:
-    name: Build ${{ needs.get-config.outputs.name }}
+    name: Build artifacts / ghcr
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -227,7 +227,7 @@ jobs:
         run: make upload-artifacts
 
   build-mirror:
-    name: Build ${{ needs.get-config.outputs.name }}
+    name: Build artifacts / mirror
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -250,7 +250,7 @@ jobs:
     steps: *build_steps
 
   build-raw:
-    name: Build ${{ needs.get-config.outputs.name }}
+    name: Build artifacts / raw
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -267,7 +267,7 @@ jobs:
     steps: *build_steps
 
   build-host:
-    name: Build ${{ needs.get-config.outputs.name }}
+    name: Build artifacts / host
     needs: [get-config, build-image]
     if: |
       !cancelled() &&

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -105,6 +105,7 @@ jobs:
         done
         [ $SUCCESS -eq 1 ] || exit 1
     steps: &build_steps
+      # Setup
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -84,7 +84,7 @@ jobs:
 
     env: &build_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-      VERBOSE: 1
+      VERBOSE: 1 # For logging
       RELEASE: 0
       LTO: ${{ needs.get-config.outputs.enable_lto }}
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -69,9 +69,9 @@ jobs:
       needs.build-image.outputs.image-is-mirror != 'true'
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions: &build_permissions
-      id-token: write # Required for OIDC role assumption during upload
-      contents: read  # Required for actions/checkout
-      packages: read  # Required for GHCR read
+      id-token: write
+      contents: read
+      packages: read
     defaults: &build_defaults
       run:
         shell: bash -l -eo pipefail {0}
@@ -83,10 +83,9 @@ jobs:
 
     env: &build_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-      VERBOSE: 1 # For logging
-      RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
+      VERBOSE: 1
+      RELEASE: 0
       LTO: ${{ needs.get-config.outputs.enable_lto }}
-      # Build command
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
       GITHUB_REPOSITORY: ${{ github.repository }}
       SETUP_RETRY_LOOP: |
@@ -105,7 +104,6 @@ jobs:
         done
         [ $SUCCESS -eq 1 ] || exit 1
     steps: &build_steps
-      # Setup
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -114,7 +112,6 @@ jobs:
         if: ${{ needs.build-image.outputs.succeeded == 'true' && needs.get-config.outputs.container }}
         shell: bash
         run: |
-          # Issue [HOME is overridden for containers](https://github.com/actions/runner/issues/863)
           h=$(getent passwd "$(id -un)" | cut -d: -f6)
           if [ "$h" = "$HOME" ]; then
             echo "HOME fine: $HOME"
@@ -134,7 +131,7 @@ jobs:
         run: ${{ needs.get-config.outputs.post_setup_script }}
 
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive
@@ -159,8 +156,6 @@ jobs:
           command: ./install_aws.sh ${{ needs.get-config.outputs.install_mode }}
           working_directory: .install
       - name: Setup test dependencies
-        # github_token (scoped to this step) lets cargo-binstall, invoked via
-        # common_installations.sh, use authenticated GitHub API calls
         uses: ./.github/actions/retry-command
         with:
           command: .install/test_deps/common_installations.sh ${{ needs.get-config.outputs.install_mode }}
@@ -177,7 +172,6 @@ jobs:
           build_tls: 'false'
           cache_platform_id: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
 
-      # Build & Pack
       - name: Build and Pack RediSearch OSS
         env:
             COORD: oss
@@ -190,7 +184,6 @@ jobs:
         if: runner.os == 'Linux' && inputs.platform != 'ubuntu:focal'
         uses: ./.github/actions/validate-glibc-version
 
-      # Upload
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure-aws-credentials
         with:
@@ -207,14 +200,11 @@ jobs:
         run: |
           VERSION_SUFFIX="$INPUT_VERSION_SUFFIX"
           echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_OUTPUT
-          # Use the pre-generated beta version if provided (master branch builds)
-          # Otherwise generate regular version from version.h (non-master branch builds)
           if [[ -n "$INPUT_BETA_VERSION" ]]; then
             BETA_VERSION="$INPUT_BETA_VERSION"
             echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
             echo "Using pre-generated beta version: $BETA_VERSION"
           else
-            # Generate regular version from version.h for non-master branches
             MAJOR=$(grep '#define REDISEARCH_VERSION_MAJOR' src/version.h | awk '{print $3}')
             MINOR=$(grep '#define REDISEARCH_VERSION_MINOR' src/version.h | awk '{print $3}')
             PATCH=$(grep '#define REDISEARCH_VERSION_PATCH' src/version.h | awk '{print $3}')

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -60,7 +60,7 @@ jobs:
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
   build-ghcr:
-    name: Build artifacts / ghcr
+    name: Build artifacts ghcr
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -219,7 +219,7 @@ jobs:
         run: make upload-artifacts
 
   build-mirror:
-    name: Build artifacts / mirror
+    name: Build artifacts mirror
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -242,7 +242,7 @@ jobs:
     steps: *build_steps
 
   build-raw:
-    name: Build artifacts / raw
+    name: Build artifacts raw
     needs: [get-config, build-image]
     if: |
       !cancelled() &&
@@ -259,7 +259,7 @@ jobs:
     steps: *build_steps
 
   build-host:
-    name: Build artifacts / host
+    name: Build artifacts host
     needs: [get-config, build-image]
     if: |
       !cancelled() &&

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
           ref: ${{ env.REF }}
       - name: Setup sccache

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -29,6 +29,10 @@ on:
       succeeded:
         description: "Whether image build completed successfully"
         value: ${{ jobs.build-image.outputs.succeeded }}
+    secrets:
+      GHCR_MIRROR_PASSWORD:
+        description: "Password for authenticating to GHCR_MIRROR_HOST"
+        required: false
 
 jobs:
   build-image:

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -21,8 +21,11 @@ on:
         default: ""
     outputs:
       image:
-        description: "Built image tag for this run"
+        description: "Image tag to use for job containers"
         value: ${{ jobs.build-image.outputs.image }}
+      image-is-mirror:
+        description: "Whether image points at GHCR_MIRROR_HOST"
+        value: ${{ jobs.build-image.outputs.image-is-mirror }}
       succeeded:
         description: "Whether image build completed successfully"
         value: ${{ jobs.build-image.outputs.succeeded }}
@@ -35,7 +38,8 @@ jobs:
       contents: read
       packages: write # required for GHCR push
     outputs:
-      image: ${{ steps.meta.outputs.image }}
+      image: ${{ steps.select-pull-image.outputs.image }}
+      image-is-mirror: ${{ steps.select-pull-image.outputs.image-is-mirror }}
       succeeded: ${{ steps.mark-status.outputs.succeeded }}
     steps:
       - name: Checkout
@@ -62,12 +66,15 @@ jobs:
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')
-          IMAGE_TAG="${IMAGE_NAME}:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-${RUN_ID}"
+          IMAGE_PATH="${OWNER_LC}/redisearch-ci:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-${RUN_ID}"
+          GHCR_IMAGE_TAG="ghcr.io/${IMAGE_PATH}"
           CACHE_REF="${IMAGE_NAME}:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-cache"
 
-          echo "image=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image-path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
+          echo "ghcr-image=$GHCR_IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "cache=$CACHE_REF" >> "$GITHUB_OUTPUT"
-          echo "Using image tag: $IMAGE_TAG"
+          echo "Using image path: $IMAGE_PATH"
+          echo "Using GHCR image tag: $GHCR_IMAGE_TAG"
           echo "Using cache ref: $CACHE_REF"
           if [[ "$IS_FORK_PR" == "true" ]]; then
             echo "can_push=false" >> "$GITHUB_OUTPUT"
@@ -101,9 +108,43 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ github.token }}
           file: Dockerfile
-          tags: ${{ steps.meta.outputs.image }}
+          tags: ${{ steps.meta.outputs.ghcr-image }}
           cache-to: ${{ steps.meta.outputs.can_push == 'true' && format('type=registry,ref={0},mode=max,compression=zstd', steps.meta.outputs.cache) || '' }}
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache }}
+
+      - name: Select pull image
+        if: always()
+        id: select-pull-image
+        env:
+          GHCR_IMAGE: ${{ steps.meta.outputs.ghcr-image }}
+          IMAGE_PATH: ${{ steps.meta.outputs.image-path }}
+          BUILD_OUTCOME: ${{ steps.build-and-push.outcome }}
+          GHCR_MIRROR_USERNAME: ${{ vars.GHCR_MIRROR_USERNAME }}
+          GHCR_MIRROR_PASSWORD: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+        run: |
+          image="$GHCR_IMAGE"
+          image_is_mirror=false
+
+          if [[ "$BUILD_OUTCOME" == "success" && -n "${GHCR_MIRROR_HOST:-}" ]]; then
+            mirror_image="${GHCR_MIRROR_HOST%/}/${IMAGE_PATH}"
+            echo "Checking mirror manifest: $mirror_image"
+            if [[ -n "$GHCR_MIRROR_USERNAME" && -n "$GHCR_MIRROR_PASSWORD" ]]; then
+              echo "$GHCR_MIRROR_PASSWORD" | docker login "$GHCR_MIRROR_HOST" --username "$GHCR_MIRROR_USERNAME" --password-stdin >/dev/null 2>&1 || true
+            fi
+            if docker manifest inspect "$mirror_image" >/dev/null 2>&1; then
+              image="$mirror_image"
+              image_is_mirror=true
+              echo "Mirror image is available."
+            else
+              echo "Mirror image is not available; using GHCR image."
+            fi
+          else
+            echo "Mirror host is unavailable or image build did not succeed; using GHCR image."
+          fi
+
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "image-is-mirror=$image_is_mirror" >> "$GITHUB_OUTPUT"
+          echo "Using pull image tag: $image"
 
       - name: Mark build status
         if: always()

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -96,7 +96,7 @@ env:
 jobs:
   build-redis-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Redis / ghcr
+    name: Redis ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -189,7 +189,7 @@ jobs:
 
   build-redis-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Redis / mirror
+    name: Redis mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -207,7 +207,7 @@ jobs:
 
   build-redis-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Redis / raw
+    name: Redis raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -220,7 +220,7 @@ jobs:
 
   build-redis-host:
     if: ${{ inputs.container == '' }}
-    name: Redis / host
+    name: Redis host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -56,6 +56,9 @@ on:
       image:
         type: string
         default: ''
+      image-is-mirror:
+        type: string
+        default: 'false'
       image-built:
         description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
         type: string
@@ -65,7 +68,13 @@ on:
         description: 'Name of the uploaded Redis artifact.'
         # Reusable-workflow outputs must map from a job output, not directly
         # from inputs — otherwise validation can reject it / it evaluates empty.
-        value: ${{ jobs.build-redis.outputs.artifact-name }}
+        value: >-
+          ${{
+            jobs.build-redis-ghcr.outputs.artifact-name ||
+            jobs.build-redis-mirror.outputs.artifact-name ||
+            jobs.build-redis-raw.outputs.artifact-name ||
+            jobs.build-redis-host.outputs.artifact-name
+          }}
 
 env:
   SETUP_RETRY_LOOP: |
@@ -85,28 +94,26 @@ env:
     [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
-  build-redis:
+  build-redis-ghcr:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
     name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
-    container: ${{
-      inputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1}"}}',
-            inputs.image-built == 'true' && inputs.image || inputs.container,
-            startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '')
-        )
-      || null }}
+    container:
+      image: ${{ inputs.image }}
+      options: &build_redis_container_options >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
 
-    permissions:
+    permissions: &build_redis_permissions
       contents: read  # actions/checkout
       packages: read  # pull container image from GHCR
 
-    defaults:
+    defaults: &build_redis_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &build_redis_steps
       - name: Install bash
         if: startsWith(inputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -177,3 +184,44 @@ jobs:
           path: redis-install.tar.gz
           if-no-files-found: error
           retention-days: 1
+
+  build-redis-mirror:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
+    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *build_redis_permissions
+    defaults: *build_redis_defaults
+    steps: *build_redis_steps
+
+  build-redis-raw:
+    if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
+    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.container }}
+      options: *build_redis_container_options
+    permissions: *build_redis_permissions
+    defaults: *build_redis_defaults
+    steps: *build_redis_steps
+
+  build-redis-host:
+    if: ${{ inputs.container == '' }}
+    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *build_redis_permissions
+    defaults: *build_redis_defaults
+    steps: *build_redis_steps

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -96,7 +96,7 @@ env:
 jobs:
   build-redis-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    name: Redis / ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -187,7 +187,7 @@ jobs:
 
   build-redis-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    name: Redis / mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -205,7 +205,7 @@ jobs:
 
   build-redis-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    name: Redis / raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -218,7 +218,7 @@ jobs:
 
   build-redis-host:
     if: ${{ inputs.container == '' }}
-    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    name: Redis / host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -151,6 +151,8 @@ jobs:
         # Shallow, submodule-free: this job only needs the install scripts and
         # the two local actions below. Redis itself is cloned by build-redis.
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -147,6 +147,8 @@ jobs:
         # .rust-nightly and tests/deps/setup_rejson.sh. RedisJSON and its own
         # submodules are cloned by that script.
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       # On a cache miss this job compiles RedisJSON from source (cargo), so it
       # needs real disk headroom — unlike task-build-redis.yml, which restores or

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -100,7 +100,7 @@ env:
 jobs:
   build-rejson-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    name: RedisJSON / ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -218,7 +218,7 @@ jobs:
 
   build-rejson-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    name: RedisJSON / mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -236,7 +236,7 @@ jobs:
 
   build-rejson-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    name: RedisJSON / raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -249,7 +249,7 @@ jobs:
 
   build-rejson-host:
     if: ${{ inputs.container == '' }}
-    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    name: RedisJSON / host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -100,7 +100,7 @@ env:
 jobs:
   build-rejson-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: RedisJSON / ghcr
+    name: RedisJSON ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -220,7 +220,7 @@ jobs:
 
   build-rejson-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: RedisJSON / mirror
+    name: RedisJSON mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -238,7 +238,7 @@ jobs:
 
   build-rejson-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: RedisJSON / raw
+    name: RedisJSON raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -251,7 +251,7 @@ jobs:
 
   build-rejson-host:
     if: ${{ inputs.container == '' }}
-    name: RedisJSON / host
+    name: RedisJSON host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -59,6 +59,9 @@ on:
       image:
         type: string
         default: ''
+      image-is-mirror:
+        type: string
+        default: 'false'
       image-built:
         description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
         type: string
@@ -68,7 +71,13 @@ on:
         description: 'Name of the uploaded RedisJSON artifact.'
         # Reusable-workflow outputs must map from a job output, not directly
         # from inputs — otherwise validation can reject it / it evaluates empty.
-        value: ${{ jobs.build-rejson.outputs.artifact-name }}
+        value: >-
+          ${{
+            jobs.build-rejson-ghcr.outputs.artifact-name ||
+            jobs.build-rejson-mirror.outputs.artifact-name ||
+            jobs.build-rejson-raw.outputs.artifact-name ||
+            jobs.build-rejson-host.outputs.artifact-name
+          }}
 
 env:
   RUST_BACKTRACE: "full"
@@ -89,7 +98,8 @@ env:
     [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
-  build-rejson:
+  build-rejson-ghcr:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
     name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
@@ -97,24 +107,21 @@ jobs:
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      inputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            inputs.image-built == 'true' && inputs.image || inputs.container,
-            startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ inputs.image }}
+      options: &build_rejson_container_options >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &build_rejson_permissions
       contents: read  # actions/checkout
       packages: read  # pull container image from GHCR
 
-    defaults:
+    defaults: &build_rejson_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &build_rejson_steps
       - name: Install bash
         if: startsWith(inputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -208,3 +215,44 @@ jobs:
           path: rejson.tar.gz
           if-no-files-found: error
           retention-days: 1
+
+  build-rejson-mirror:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
+    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *build_rejson_permissions
+    defaults: *build_rejson_defaults
+    steps: *build_rejson_steps
+
+  build-rejson-raw:
+    if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
+    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.container }}
+      options: *build_rejson_container_options
+    permissions: *build_rejson_permissions
+    defaults: *build_rejson_defaults
+    steps: *build_rejson_steps
+
+  build-rejson-host:
+    if: ${{ inputs.container == '' }}
+    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *build_rejson_permissions
+    defaults: *build_rejson_defaults
+    steps: *build_rejson_steps

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -59,6 +59,9 @@ on:
       image:
         type: string
         default: ''
+      image-is-mirror:
+        type: string
+        default: 'false'
       image-built:
         description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
         type: string
@@ -68,7 +71,13 @@ on:
         description: 'Name of the uploaded build artifact.'
         # Reusable-workflow outputs must map from a job output, not directly
         # from inputs — otherwise validation can reject it / it evaluates empty.
-        value: ${{ jobs.common-flow.outputs.artifact-name }}
+        value: >-
+          ${{
+            jobs.common-flow-ghcr.outputs.artifact-name ||
+            jobs.common-flow-mirror.outputs.artifact-name ||
+            jobs.common-flow-raw.outputs.artifact-name ||
+            jobs.common-flow-host.outputs.artifact-name
+          }}
 
 env:
   COV: ${{ inputs.coverage && 1 || 0 }} # convert the boolean input to numeric
@@ -94,7 +103,8 @@ env:
     [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
-  common-flow:
+  common-flow-ghcr:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
     name: Build ${{ inputs.name }}
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
@@ -102,31 +112,28 @@ jobs:
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      inputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            inputs.image-built == 'true' && inputs.image || inputs.container,
-            startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ inputs.image }}
+      options: &common_flow_container_options >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &common_flow_permissions
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3
       packages: read  # pull container image from GHCR
       actions: write  # Swatinem/rust-cache read/write of GH cache
 
-    env:
+    env: &common_flow_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       # LTO is disabled on coverage and sanitizer tasks
       LTO: ${{ inputs.enable-lto == '1' && inputs.san == '' && !inputs.coverage && 1 || 0 }}
 
-    defaults:
+    defaults: &common_flow_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &common_flow_steps
       - name: Install bash
         if: startsWith(inputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -298,3 +305,47 @@ jobs:
             nextest-archive.tar.zst
           if-no-files-found: error
           retention-days: 1
+
+  common-flow-mirror:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
+    name: Build ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-raw:
+    if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
+    name: Build ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.container }}
+      options: *common_flow_container_options
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-host:
+    if: ${{ inputs.container == '' }}
+    name: Build ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -157,6 +157,7 @@ jobs:
       - name: Full checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Free up disk space

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -105,7 +105,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Build / ghcr
+    name: Build ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -309,7 +309,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Build / mirror
+    name: Build mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -328,7 +328,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Build / raw
+    name: Build raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -342,7 +342,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: Build / host
+    name: Build host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -105,7 +105,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Build ${{ inputs.name }}
+    name: Build / ghcr
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -308,7 +308,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Build ${{ inputs.name }}
+    name: Build / mirror
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -327,7 +327,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Build ${{ inputs.name }}
+    name: Build / raw
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -341,7 +341,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: Build ${{ inputs.name }}
+    name: Build / host
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -21,32 +21,32 @@ jobs:
       packages: write
     name: Build container for lint
     uses: ./.github/workflows/task-build-cached-container.yml
+    secrets: inherit
     with:
       container: ubuntu:noble
       runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
 
-  lint:
+  lint-ghcr:
     name: Linting
     needs: build-image
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror != 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
-    permissions:
+    permissions: &lint_permissions
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3
       packages: read  # pull container image from GHCR
       actions: write  # Swatinem/rust-cache read/write of GH cache
-    defaults:
+    defaults: &lint_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    container: ${{
-      needs.build-image.outputs.succeeded == 'true'
-        && fromJSON(format('{{"image":"{0}","options":"--user root"}}', needs.build-image.outputs.image))
-      || null }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: --user root
 
-    env:
+    env: &lint_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-    steps:
+    steps: &lint_steps
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
@@ -187,3 +187,29 @@ jobs:
           echo "Dependency licenses: ${{ steps.dep-licenses.outcome }}"
           echo "Workspace hack check: ${{ steps.workspace_hack.outcome }}"
           exit 1
+
+  lint-mirror:
+    name: Linting
+    needs: build-image
+    if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror == 'true' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *lint_permissions
+    defaults: *lint_defaults
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: --user root
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    env: *lint_env
+    steps: *lint_steps
+
+  lint-host:
+    name: Linting
+    needs: build-image
+    if: ${{ !cancelled() && needs.build-image.outputs.succeeded != 'true' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *lint_permissions
+    defaults: *lint_defaults
+    env: *lint_env
+    steps: *lint_steps

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Fix HOME Directory
         if: ${{ needs.build-image.outputs.succeeded == 'true' }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -28,7 +28,7 @@ jobs:
       runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
 
   lint-ghcr:
-    name: Lint / ghcr
+    name: Lint ghcr
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror != 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -191,7 +191,7 @@ jobs:
           exit 1
 
   lint-mirror:
-    name: Lint / mirror
+    name: Lint mirror
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror == 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -207,7 +207,7 @@ jobs:
     steps: *lint_steps
 
   lint-host:
-    name: Lint / host
+    name: Lint host
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded != 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -27,7 +27,7 @@ jobs:
       runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
 
   lint-ghcr:
-    name: Linting
+    name: Lint / ghcr
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror != 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -189,7 +189,7 @@ jobs:
           exit 1
 
   lint-mirror:
-    name: Linting
+    name: Lint / mirror
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image-is-mirror == 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -205,7 +205,7 @@ jobs:
     steps: *lint_steps
 
   lint-host:
-    name: Linting
+    name: Lint / host
     needs: build-image
     if: ${{ !cancelled() && needs.build-image.outputs.succeeded != 'true' }}
     runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -21,7 +21,8 @@ jobs:
       packages: write
     name: Build container for lint
     uses: ./.github/workflows/task-build-cached-container.yml
-    secrets: inherit
+    secrets:
+      GHCR_MIRROR_PASSWORD: ${{ secrets.GHCR_MIRROR_PASSWORD }}
     with:
       container: ubuntu:noble
       runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Full checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Free up disk space

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -66,7 +66,8 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
-    secrets: inherit
+    secrets:
+      GHCR_MIRROR_PASSWORD: ${{ secrets.GHCR_MIRROR_PASSWORD }}
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env }}

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -74,7 +74,7 @@ jobs:
 
   common-flow-ghcr:
     needs: [get-config, build-image]
-    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    name: MIRI / ghcr
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -213,7 +213,7 @@ jobs:
 
   common-flow-mirror:
     needs: [get-config, build-image]
-    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    name: MIRI / mirror
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -236,7 +236,7 @@ jobs:
 
   common-flow-raw:
     needs: [get-config, build-image]
-    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    name: MIRI / raw
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -253,7 +253,7 @@ jobs:
 
   common-flow-host:
     needs: [get-config, build-image]
-    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    name: MIRI / host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -66,44 +66,45 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
+    secrets: inherit
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env }}
       san: 'none'
 
-  common-flow:
+  common-flow-ghcr:
     needs: [get-config, build-image]
     name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
     if: |
       !cancelled() &&
-      needs.get-config.result == 'success'
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror != 'true'
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      needs.get-config.outputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: &common_flow_container_options >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &common_flow_permissions
       contents: read
       id-token: write
       packages: read
       actions: write   # Swatinem/rust-cache read/write of GH cache
 
-    env:
+    env: &common_flow_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-    defaults:
+    defaults: &common_flow_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &common_flow_steps
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -209,3 +210,56 @@ jobs:
         run: |
           echo "Rust tests (MIRI): ${{ steps.rust_unit_tests_miri.outcome }}"
           exit 1
+
+  common-flow-mirror:
+    needs: [get-config, build-image]
+    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror == 'true'
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-raw:
+    needs: [get-config, build-image]
+    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded != 'true'
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ needs.get-config.outputs.container }}
+      options: *common_flow_container_options
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-host:
+    needs: [get-config, build-image]
+    name: MIRI${{ inputs.partition && format(' [{0}]', inputs.partition) || '' }} on ${{ needs.get-config.outputs.name }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      needs.get-config.outputs.container == ''
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -75,7 +75,7 @@ jobs:
 
   common-flow-ghcr:
     needs: [get-config, build-image]
-    name: MIRI / ghcr
+    name: MIRI ghcr
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -215,7 +215,7 @@ jobs:
 
   common-flow-mirror:
     needs: [get-config, build-image]
-    name: MIRI / mirror
+    name: MIRI mirror
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -238,7 +238,7 @@ jobs:
 
   common-flow-raw:
     needs: [get-config, build-image]
-    name: MIRI / raw
+    name: MIRI raw
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -255,7 +255,7 @@ jobs:
 
   common-flow-host:
     needs: [get-config, build-image]
-    name: MIRI / host
+    name: MIRI host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -71,32 +71,30 @@ jobs:
       ec2-image-id: ${{ needs.get-config.outputs.ec2_image_id }}
       ec2-instance-type: ${{ needs.get-config.outputs.ec2_instance_type }}
 
-  redis-build-sanity:
+  redis-build-sanity-container:
     needs: [get-config, start-runner]
     name: Redis build sanity on ${{ needs.get-config.outputs.name }}
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
-      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success')
+      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
+      needs.get-config.outputs.container != ''
     runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      needs.get-config.outputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
-    permissions:
+    container:
+      image: ${{ needs.get-config.outputs.container }}
+      options: &redis_build_sanity_container_options >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
+    permissions: &redis_build_sanity_permissions
       contents: read
-    defaults:
+    defaults: &redis_build_sanity_defaults
       run:
         shell: /bin/bash -l -eo pipefail {0}
-    steps:
+    steps: &redis_build_sanity_steps
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -325,10 +323,23 @@ jobs:
                   proc.wait()
           PY
 
+  redis-build-sanity-host:
+    needs: [get-config, start-runner]
+    name: Redis build sanity on ${{ needs.get-config.outputs.name }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
+      needs.get-config.outputs.container == ''
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *redis_build_sanity_permissions
+    defaults: *redis_build_sanity_defaults
+    steps: *redis_build_sanity_steps
+
   stop-runner:
     permissions: {} # AWS access keys, and the runner deregisters with an App token
     name: Stop self-hosted EC2 runner
-    needs: [start-runner, redis-build-sanity]
+    needs: [start-runner, redis-build-sanity-container, redis-build-sanity-host]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}
     uses: ./.github/workflows/task-stop-ec2-runner.yml
     secrets: inherit

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Checkout RediSearch
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Free up disk space
         uses: ./.github/actions/github-hosted-runner-cleanup
@@ -178,6 +180,7 @@ jobs:
       - name: Checkout Redis
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           repository: ${{ inputs.redis-repository }}
           ref: ${{ inputs.redis-ref }}
           path: redis

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -73,7 +73,7 @@ jobs:
 
   redis-build-sanity-container:
     needs: [get-config, start-runner]
-    name: Redis build sanity / container
+    name: Redis build sanity container
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -328,7 +328,7 @@ jobs:
 
   redis-build-sanity-host:
     needs: [get-config, start-runner]
-    name: Redis build sanity / host
+    name: Redis build sanity host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -73,7 +73,7 @@ jobs:
 
   redis-build-sanity-container:
     needs: [get-config, start-runner]
-    name: Redis build sanity on ${{ needs.get-config.outputs.name }}
+    name: Redis build sanity / container
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -325,7 +325,7 @@ jobs:
 
   redis-build-sanity-host:
     needs: [get-config, start-runner]
-    name: Redis build sanity on ${{ needs.get-config.outputs.name }}
+    name: Redis build sanity / host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -132,7 +132,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Flow / ghcr
+    name: Flow ghcr
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
@@ -590,7 +590,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Flow / mirror
+    name: Flow mirror
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.image }}
@@ -607,7 +607,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Flow / raw
+    name: Flow raw
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.container }}
@@ -619,7 +619,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: Flow / host
+    name: Flow host
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions: *common_flow_permissions
     env: *common_flow_env

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -95,6 +95,9 @@ on:
       image:
         type: string
         default: ''
+      image-is-mirror:
+        type: string
+        default: 'false'
       image-built:
         description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
         type: string
@@ -127,35 +130,33 @@ env:
     [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
-  common-flow:
+  common-flow-ghcr:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
     name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      inputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            inputs.image-built == 'true' && inputs.image || inputs.container,
-            startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ inputs.image }}
+      options: &common_flow_container_options >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &common_flow_permissions
       contents: read
       id-token: write
       packages: read
       actions: read  # download artifact from the build job's workflow run
 
-    env:
+    env: &common_flow_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-    defaults:
+    defaults: &common_flow_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &common_flow_steps
       - name: Install bash
         if: startsWith(inputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -585,3 +586,41 @@ jobs:
           flags: flow
           fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  common-flow-mirror:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
+    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-raw:
+    if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
+    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.container }}
+      options: *common_flow_container_options
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-host:
+    if: ${{ inputs.container == '' }}
+    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Full checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Free up disk space

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -132,7 +132,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Flow / ghcr
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
@@ -589,7 +589,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Flow / mirror
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.image }}
@@ -606,7 +606,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Flow / raw
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.container }}
@@ -618,7 +618,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: ${{ inputs.test-mode == 'standalone' && 'Standalone' || 'Coordinator' }} flow tests${{ inputs.shard-total > 1 && format(' [{0}/{1}]', inputs.shard-index, inputs.shard-total) || '' }} on ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Flow / host
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions: *common_flow_permissions
     env: *common_flow_env

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -139,6 +139,7 @@ jobs:
       - name: Full checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Free up disk space

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -94,7 +94,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Unit / ghcr
+    name: Unit ghcr
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
@@ -346,7 +346,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Unit / mirror
+    name: Unit mirror
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.image }}
@@ -363,7 +363,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Unit / raw
+    name: Unit raw
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.container }}
@@ -375,7 +375,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: Unit / host
+    name: Unit host
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions: *common_flow_permissions
     env: *common_flow_env

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -94,7 +94,7 @@ env:
 jobs:
   common-flow-ghcr:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
-    name: Unit tests on ${{ inputs.name }}
+    name: Unit / ghcr
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
@@ -345,7 +345,7 @@ jobs:
 
   common-flow-mirror:
     if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
-    name: Unit tests on ${{ inputs.name }}
+    name: Unit / mirror
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.image }}
@@ -362,7 +362,7 @@ jobs:
 
   common-flow-raw:
     if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
-    name: Unit tests on ${{ inputs.name }}
+    name: Unit / raw
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container:
       image: ${{ inputs.container }}
@@ -374,7 +374,7 @@ jobs:
 
   common-flow-host:
     if: ${{ inputs.container == '' }}
-    name: Unit tests on ${{ inputs.name }}
+    name: Unit / host
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions: *common_flow_permissions
     env: *common_flow_env

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -63,6 +63,9 @@ on:
       image:
         type: string
         default: ''
+      image-is-mirror:
+        type: string
+        default: 'false'
       image-built:
         description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
         type: string
@@ -89,35 +92,33 @@ env:
     [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
-  common-flow:
+  common-flow-ghcr:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror != 'true' }}
     name: Unit tests on ${{ inputs.name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      inputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            inputs.image-built == 'true' && inputs.image || inputs.container,
-            startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ inputs.image }}
+      options: &common_flow_container_options >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && (startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(inputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &common_flow_permissions
       contents: read
       id-token: write
       packages: read
       actions: read   # download artifact from the build job
 
-    env:
+    env: &common_flow_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-    defaults:
+    defaults: &common_flow_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &common_flow_steps
       - name: Install bash
         if: startsWith(inputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -341,3 +342,41 @@ jobs:
           flags: unit
           fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  common-flow-mirror:
+    if: ${{ inputs.container != '' && inputs.image-built == 'true' && inputs.image-is-mirror == 'true' }}
+    name: Unit tests on ${{ inputs.name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(inputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-raw:
+    if: ${{ inputs.container != '' && inputs.image-built != 'true' }}
+    name: Unit tests on ${{ inputs.name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ inputs.container }}
+      options: *common_flow_container_options
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-host:
+    if: ${{ inputs.container == '' }}
+    name: Unit tests on ${{ inputs.name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -120,12 +120,13 @@ jobs:
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform
     uses: ./.github/workflows/task-build-cached-container.yml
+    secrets: inherit
     with:
       container: ${{ needs.get-config.outputs.container }}
       runner-env: ${{ needs.get-config.outputs.env }}
       san: ${{ inputs.san || 'none' }}
 
-  common-flow:
+  common-flow-ghcr:
     needs: [get-config, build-image, start-runner]
     name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
     # Run if get-config succeeded and at least one test type is enabled
@@ -133,36 +134,36 @@ jobs:
       !cancelled() &&
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
-      (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests)
+      (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests) &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror != 'true'
     runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
     # Runner-local env is unavailable while GitHub creates the job container.
     # Use the resolved runner label as the pre-container signal for GitHub-hosted
     # mounts; runner-local env is not available yet.
-    container: ${{
-      needs.get-config.outputs.container
-        && fromJSON(
-          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
-            needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
-            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
-        )
-      || null }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: &common_flow_container_options >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '' }}
+        ${{ startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '' }}
 
-    permissions:
+    permissions: &common_flow_permissions
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3
       packages: read  # pull container image from GHCR
       actions: write  # Swatinem/rust-cache read/write of GH cache
 
-    env:
+    env: &common_flow_env
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       # LTO is disabled on coverage and sanitizer tasks
       LTO: ${{ needs.get-config.outputs.enable_lto == '1' && inputs.san == '' && !inputs.coverage && 1 || 0 }}
 
-    defaults:
+    defaults: &common_flow_defaults
       run:
         shell: bash -l -eo pipefail {0}
-    steps:
+    steps: &common_flow_steps
       - name: Install bash
         if: startsWith(needs.get-config.outputs.container, 'alpine:')
         shell: sh -l -eo pipefail {0}
@@ -638,11 +639,70 @@ jobs:
           fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  common-flow-mirror:
+    needs: [get-config, build-image, start-runner]
+    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
+      (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests) &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded == 'true' &&
+      needs.build-image.outputs.image-is-mirror == 'true'
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ needs.build-image.outputs.image }}
+      options: >-
+        --user root
+        ${{ startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro' || '' }}
+      credentials:
+        username: ${{ vars.GHCR_MIRROR_USERNAME }}
+        password: ${{ secrets.GHCR_MIRROR_PASSWORD }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-raw:
+    needs: [get-config, build-image, start-runner]
+    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
+      (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests) &&
+      needs.get-config.outputs.container != '' &&
+      needs.build-image.outputs.succeeded != 'true'
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    container:
+      image: ${{ needs.get-config.outputs.container }}
+      options: *common_flow_container_options
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
+  common-flow-host:
+    needs: [get-config, build-image, start-runner]
+    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    if: |
+      !cancelled() &&
+      needs.get-config.result == 'success' &&
+      (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
+      (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests) &&
+      needs.get-config.outputs.container == ''
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions: *common_flow_permissions
+    env: *common_flow_env
+    defaults: *common_flow_defaults
+    steps: *common_flow_steps
+
   # Stop EC2 runner for self-hosted platforms (always runs if `start-runner` succeeds, to ensure cleanup)
   stop-runner:
     permissions: {} # AWS access keys, and the runner deregisters with an App token
     name: Stop self-hosted EC2 runner
-    needs: [start-runner, common-flow]
+    needs: [start-runner, common-flow-ghcr, common-flow-mirror, common-flow-raw, common-flow-host]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}
     uses: ./.github/workflows/task-stop-ec2-runner.yml
     secrets: inherit

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -128,7 +128,7 @@ jobs:
 
   common-flow-ghcr:
     needs: [get-config, build-image, start-runner]
-    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Test / ghcr
     # Run if get-config succeeded and at least one test type is enabled
     if: |
       !cancelled() &&
@@ -641,7 +641,7 @@ jobs:
 
   common-flow-mirror:
     needs: [get-config, build-image, start-runner]
-    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Test / mirror
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -666,7 +666,7 @@ jobs:
 
   common-flow-raw:
     needs: [get-config, build-image, start-runner]
-    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Test / raw
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -685,7 +685,7 @@ jobs:
 
   common-flow-host:
     needs: [get-config, build-image, start-runner]
-    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Test / host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -128,7 +128,7 @@ jobs:
 
   common-flow-ghcr:
     needs: [get-config, build-image, start-runner]
-    name: Test / ghcr
+    name: Test ghcr
     # Run if get-config succeeded and at least one test type is enabled
     if: |
       !cancelled() &&
@@ -642,7 +642,7 @@ jobs:
 
   common-flow-mirror:
     needs: [get-config, build-image, start-runner]
-    name: Test / mirror
+    name: Test mirror
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -667,7 +667,7 @@ jobs:
 
   common-flow-raw:
     needs: [get-config, build-image, start-runner]
-    name: Test / raw
+    name: Test raw
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
@@ -686,7 +686,7 @@ jobs:
 
   common-flow-host:
     needs: [get-config, build-image, start-runner]
-    name: Test / host
+    name: Test host
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Full checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Free up disk space


### PR DESCRIPTION
This is built on top of #11075.

Provides a way to pull images for `container` type jobs from the internal GHCR mirror.
The idea is to check mirror availability in the build-image job and put respective URLs to the job output.
This allows to have kinda fallback mechanism in case internal mirror is not available or is under maintenance.

* I have to split `container` jobs using mutually exclusive conditions. The reason is `container` keyword does not support `secrets` context and we need it to provide credentials for the mirror, so we have to use different declarations depending on which registry is used
* YAML anchors were used to avoid huge code duplication 
* Static names were used for jobs as skipped job names looks ugly when using expressions (see the [issue](https://github.com/orgs/community/discussions/13261)). Variable name parts were moved to workflow names where possible
* Comments in the anchored sections were removed because zizmor fails to parse yaml with comments in anchors.

Happy run on self-hosted, using mirror and static names: https://github.com/RediSearch/RediSearch/actions/runs/32980630672/job/98217612504
Manual build Alpine/arm (known to be problematic because of workarounds): https://github.com/RediSearch/RediSearch/actions/runs/32982088766

Run with fallback to github-hosted runners: https://github.com/RediSearch/RediSearch/actions/runs/32980630672/job/98247240802?pr=11191 (`RUNS_ON...` vars renamed)
Run alpine/arm with fallbak to github-hosted runners: https://github.com/RediSearch/RediSearch/actions/runs/32982088766/job/98266435511

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->

## Describe the changes in the pull request

<!--
1-3 sentences each. No file-by-file walkthrough, no restating what the code does.

- Current: the behavior or limitation today, and why it is worth changing now
- Change: what is different, in user- or API-visible terms
- Outcome: what a user, operator, or caller can observe that they could not before

For internal-only work (refactor, CI, test, dependency), say so plainly in
"Outcome" and state what it enables or unblocks instead of inventing user impact.
-->

1. Current:
2. Change:
3. Outcome:

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
