### PR TITLE
[8.4] doc: Rust: bring rustdoc lint to parity with master (#8656)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ endef
 lint:
 	@echo "Running linters..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates)
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items
 
 fmt:
 ifeq ($(CHECK),1)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "build_utils",
  "cbindgen",
+ "chrono",
  "ffi",
  "tracing",
  "tracing_redismodule",

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -52,7 +52,7 @@ static PANIC_STASH: OnceLock<StashedPanic> = OnceLock::new();
 /// Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
 ///
 /// Panic messages will be logged through `tracing` at the `ERROR` level, and
-/// stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+/// stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
 /// the crash report.
 #[unsafe(no_mangle)]
 pub extern "C" fn RustPanicHook_Init() {
@@ -124,7 +124,7 @@ fn info_cstring(value: impl Into<Vec<u8>>) -> CString {
 /// Add the current backtrace as a new section to the report printed
 /// by RediSearch's INFO command.
 ///
-/// When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+/// When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
 /// in the same section, ahead of the backtrace.
 ///
 /// # Safety

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -15,7 +15,7 @@ use value::RSValueFFI;
 ///
 /// Safety:
 /// 1. `key` must be a valid pointer to an [`RLookupKey`].
-/// 2. `row` must be a valid pointer to an [`RLookupRow`].
+/// 2. `row` must be a valid pointer to an [`rlookup::RLookupRow`].
 /// 3. `value` must be a valid pointer to an [`ffi::RSValue`].
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RLookup_WriteKey<'a>(
@@ -42,7 +42,7 @@ unsafe extern "C" fn RLookup_WriteKey<'a>(
 ///
 /// Safety:
 /// 1. `key` must be a valid pointer to an [`RLookupKey`].
-/// 2. `row` must be a valid pointer to an [`RLookupRow`].
+/// 2. `row` must be a valid pointer to an [`rlookup::RLookupRow`].
 /// 3. `value` must be a valid pointer to an [`ffi::RSValue`].
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RLookup_WriteOwnKey<'a>(
@@ -65,7 +65,7 @@ unsafe extern "C" fn RLookup_WriteOwnKey<'a>(
 /// Wipes a RLookupRow by decrementing all values and resetting the row.
 ///
 /// Safety:
-/// 1. The pointer must be a valid pointer to an [`RLookupRow`].
+/// 1. The pointer must be a valid pointer to an [`rlookup::RLookupRow`].
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RLookupRow_Wipe<'a>(
     row: Option<NonNull<rlookup::RLookupRow<'a, RSValueFFI>>>,
@@ -80,7 +80,7 @@ unsafe extern "C" fn RLookupRow_Wipe<'a>(
 /// This does not affect the sorting vector.
 ///
 /// Safety:
-/// 1. The pointer must be a valid pointer to an [`RLookupRow`].
+/// 1. The pointer must be a valid pointer to an [`rlookup::RLookupRow`].
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RLookupRow_Reset<'a>(
     row: Option<NonNull<rlookup::RLookupRow<'a, RSValueFFI>>>,

--- a/src/redisearch_rs/headers/module_init.h
+++ b/src/redisearch_rs/headers/module_init.h
@@ -17,15 +17,20 @@ extern "C" {
 void TracingRedisModule_Init(RedisModuleCtx *ctx);
 
 /**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ * Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
  *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
+ * Panic messages will be logged through `tracing` at the `ERROR` level, and
+ * stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
+ * the crash report.
  */
 void RustPanicHook_Init(void);
 
 /**
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
+ *
+ * When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
+ * in the same section, ahead of the backtrace.
  *
  * # Safety
  *

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -370,7 +370,7 @@ void RLookup_Cleanup(struct RLookup *lookup);
  *
  * Safety:
  * 1. `key` must be a valid pointer to an [`RLookupKey`].
- * 2. `row` must be a valid pointer to an [`RLookupRow`].
+ * 2. `row` must be a valid pointer to an [`rlookup::RLookupRow`].
  * 3. `value` must be a valid pointer to an [`ffi::RSValue`].
  */
 void RLookup_WriteKey(const struct RLookupKey *key,
@@ -382,7 +382,7 @@ void RLookup_WriteKey(const struct RLookupKey *key,
  *
  * Safety:
  * 1. `key` must be a valid pointer to an [`RLookupKey`].
- * 2. `row` must be a valid pointer to an [`RLookupRow`].
+ * 2. `row` must be a valid pointer to an [`rlookup::RLookupRow`].
  * 3. `value` must be a valid pointer to an [`ffi::RSValue`].
  */
 void RLookup_WriteOwnKey(const struct RLookupKey *key,
@@ -393,7 +393,7 @@ void RLookup_WriteOwnKey(const struct RLookupKey *key,
  * Wipes a RLookupRow by decrementing all values and resetting the row.
  *
  * Safety:
- * 1. The pointer must be a valid pointer to an [`RLookupRow`].
+ * 1. The pointer must be a valid pointer to an [`rlookup::RLookupRow`].
  */
 void RLookupRow_Wipe(struct RLookupRow *row);
 
@@ -403,7 +403,7 @@ void RLookupRow_Wipe(struct RLookupRow *row);
  * This does not affect the sorting vector.
  *
  * Safety:
- * 1. The pointer must be a valid pointer to an [`RLookupRow`].
+ * 1. The pointer must be a valid pointer to an [`rlookup::RLookupRow`].
  */
 void RLookupRow_Reset(struct RLookupRow *row);
 

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -203,7 +203,7 @@ impl Upstream<'_> {
 /// For intrusive data types like this we need to tell the compiler "don't move this please I have pointers to it" which is called
 /// pinning in Rust.
 ///
-/// We wrap a reference in the Pin<T> type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
+/// We wrap a reference in the `Pin<T>` type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
 /// Crucially though, the way Pin disallows is not magic, it simply doesn't implement any methods and traits that would
 /// allow a caller to move the value. Unfortunately this means banning all mutable access to the value T (you cannot get a
 /// &mut T from a Pin<&mut T> for example) since with a &mut T you can always move the value very easily (via mem::replace for example).

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -67,7 +67,7 @@ pub enum FieldSpecType {
 pub type FieldSpecTypes = BitFlags<FieldSpecType>;
 
 /// KeyMode is a set of flags that can be used when opening a key with `RedisModule_OpenKey`.
-/// See https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#RedisModule_OpenKey
+/// See <https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#RedisModule_OpenKey>
 /// TODO: [MOD-10548] move to unified RedisModule wrapper crate.
 #[bitflags]
 #[repr(u32)] // should be c_unit
@@ -313,7 +313,7 @@ impl RedisString {
         (ptr, len)
     }
 
-    /// Converts a raw `RedisModuleString` pointer to a C-style string reference [`&CStr`].
+    /// Converts a raw `RedisModuleString` pointer to a C-style string reference [`CStr`].
     ///
     /// This is useful at points where the Rust wrapper is not accessible, e.g. callbacks.
     /// If possible prefer [RedisString::try_as_c_str] which is safer and more idiomatic.
@@ -343,7 +343,7 @@ impl RedisString {
         }
     }
 
-    /// Converts the string to a C-style string reference [&CStr], uses the `RedisModule_StringPtrLen` function from the C API.
+    /// Converts the string to a C-style string reference [`CStr`], uses the `RedisModule_StringPtrLen` function from the C API.
     #[inline]
     #[expect(unused, reason = "Used by follow-up PRs")]
     pub fn try_as_c_str(&self) -> Option<&CStr> {
@@ -526,7 +526,7 @@ impl RedisScanCursor {
 
     /// This function uses the [RedisScanCursor] to iterate over each element and call a callback function for each element.
     /// For now the only usage pattern we saw was an extensive while loop as shown in the documentation as an example:
-    /// See https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#redismodule_scankey
+    /// See <https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#redismodule_scankey>
     ///
     /// Safety:
     /// The callback provides by the callee must be safe to call and must not mutate the state of the cursor.

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -397,7 +397,7 @@ impl<'a> RLookupKey<'a> {
     /// Constructs a `Pin<Box<RLookupKey>>` from a raw pointer.
     ///
     /// The returned `Box` will own the raw pointer, in particular dropping the `Box`
-    /// will deallocate the `RLookupKey`. This function should only be used by [`RLookup::drop`].
+    /// will deallocate the `RLookupKey`. This function should only be used by [`KeyList::drop`].
     ///
     /// # Safety
     ///
@@ -410,7 +410,7 @@ impl<'a> RLookupKey<'a> {
         // This function must be kept in sync with `Self::into_ptr` above.
 
         // Safety:
-        // 1 -> This function will only ever be called through `RLookup::drop` below.
+        // 1 -> This function will only ever be called through `KeyList::drop` below.
         //      We therefore know - because push_key creates pointers through `into_ptr` - that the invariant is upheld.
         // 2 -> Has to be upheld by the caller
         let b = unsafe { Box::from_raw(ptr.as_ptr()) };
@@ -586,7 +586,7 @@ impl<'a> KeyList<'a> {
         }
     }
 
-    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::_name]
     /// and return a [`Cursor`] pointing to the key if found.
     // FIXME [MOD-10315] replace with more efficient search
     fn find_by_name(&self, name: &CStr) -> Option<Cursor<'_, 'a>> {
@@ -603,7 +603,7 @@ impl<'a> KeyList<'a> {
         None
     }
 
-    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::_name]
     /// and return a [`CursorMut`] pointing to the key if found.
     // FIXME [MOD-10315] replace with more efficient search
     fn find_by_name_mut(&mut self, name: &CStr) -> Option<CursorMut<'_, 'a>> {

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -178,7 +178,7 @@ impl<T: RSValueTrait> RSSortingVector<T> {
         sz
     }
 
-    /// Returns `Ok(())` if the index is in bounds, [`Error::OutOfBounds`] otherwise.
+    /// Returns `Ok(())` if the index is in bounds, [`IndexOutOfBounds`] otherwise.
     fn in_bounds(&self, idx: usize) -> Result<(), IndexOutOfBounds> {
         if idx < self.values.len() {
             Ok(())

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -9,7 +9,7 @@
 
 //! Primitives to manage the expected memory layout of the heap-allocated buffer for each [`Node`].
 //!
-//! Check out [`NodeLayout`]'s documentation for more details.
+//! Check out [`PtrMetadata`]'s documentation for more details.
 use crate::node::Node;
 use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
@@ -17,7 +17,7 @@ use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 #[derive(Clone, Copy, Debug)]
 /// The first field in the allocated buffer for a [`Node`].
 ///
-/// [`NodeHeader::layout`] can be used to compute the layout of
+/// [`NodeHeader::metadata`] can be used to compute the layout of
 /// the buffer allocated for a [`Node`].
 pub(super) struct NodeHeader {
     /// The length of the label associated with this node.
@@ -106,7 +106,7 @@ impl NodeHeader {
 /// to align our type.
 ///
 /// We have optimized, in particular, for `Data=NonNull<*mut c_void>`, the scenario we have in
-/// [`crate::ffi`]. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
+/// the FFI layer. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
 /// located between the end of the array of children first bytes and the start of the
 /// array of children pointers.
 ///
@@ -357,7 +357,7 @@ impl<Data> PtrMetadata<Data> {
     /// a. `ptr` must point to an allocation with the same alignment and size of [`Self::layout`].
     /// b. `ptr` must have been allocated via the global allocator.
     /// c. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// d. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// d. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, ptr: NonNull<NodeHeader>, options: DeallocOptions) {
@@ -519,7 +519,7 @@ impl<Data> PtrWithMetadata<Data> {
     ///
     /// a. The layout of the allocation behind [`Self::ptr`] matches *exactly* the layout it was allocated with.
     /// b. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// c. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// c. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, options: DeallocOptions) {

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::is_prefix`].
+/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::all::is_prefix`].
 #[inline(always)]
 pub(crate) fn strip_prefix<'a>(haystack: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
     if !memchr::arch::all::is_prefix(haystack, prefix) {

--- a/src/redisearch_rs/value/src/map.rs
+++ b/src/redisearch_rs/value/src/map.rs
@@ -159,7 +159,7 @@ impl RsValueMap {
     }
 
     /// Calculate the [`Layout`] that should be used to allocate space for
-    /// `cap` [`RsValueEntries`] for use in this map.
+    /// `cap` [`RsValueMapEntry`] for use in this map.
     const fn entry_layout(cap: u32) -> Layout {
         let Ok(layout) = Layout::array::<RsValueMapEntry>(cap as usize) else {
             panic!("Capacity too high. Can be at most `isize::MAX / size_of::<RsValueMapEntry>()`");


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `make lint`'s `cargo doc` step on `8.4` runs without `--document-private-items` (unlike `8.6`, which already had parity) and without `--no-deps`, so the workspace's rustdoc lint coverage lags `master` (#8656).
2. Change: Backport of #8656 — add `--document-private-items` and `--no-deps` to the `cargo doc` invocation in `Makefile`, and fix every rustdoc warning that documenting private items and checking workspace crates in isolation then surfaces: broken intra-doc links to renamed/private/nonexistent symbols, malformed link syntax, and bare URLs. One fix (`module_init_ffi`) is new versus the `master`/`8.6` fix set: a public function's doc comment linked to the private `PANIC_STASH` static, which trips `rustdoc::private_intra_doc_links` regardless of `--document-private-items` (verified with an isolated repro) — resolved by de-linking to plain code text rather than making the static public.
3. Outcome: Internal-only. `make lint` now passes cleanly on `8.4`, including `module_init_ffi` and `rlookup_ffi`, which were previously failing. No behavior change.

#### Which additional issues this PR fixes
1. #8656

#### Main objects this PR modified
1. `Makefile` — `cargo doc` flags
2. `src/redisearch_rs/value/src/map.rs` — broken link `RsValueEntries` -> `RsValueMapEntry`
3. `src/redisearch_rs/sorting_vector/src/lib.rs` — broken link `Error::OutOfBounds` -> `IndexOutOfBounds`
4. `src/redisearch_rs/rlookup/src/bindings.rs` — malformed link syntax, bare URLs
5. `src/redisearch_rs/rlookup/src/lookup.rs` — broken links `RLookup::drop` -> `KeyList::drop`, `RLookupKey::name` -> `RLookupKey::_name`
6. `src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs` — unresolved bare-name link `RLookupRow` -> `rlookup::RLookupRow`
7. `src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs` — `private_intra_doc_links` on `PANIC_STASH`, de-linked
8. `src/redisearch_rs/headers/module_init.h`, `src/redisearch_rs/headers/rlookup_rs.h` — cbindgen-regenerated by `make lint` as a side effect of the above; not hand-edited
9. `src/redisearch_rs/Cargo.lock` — shifted by the same `make lint` run

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
