### PR TITLE
[MOD-17877] Fix crash when Redis lacks RedisModule_AddPostNotificationJobForKey

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -186,7 +186,14 @@ int KeySpaceNotificationCallback(RedisModuleCtx *ctx, int type, const char *even
   // RedisModuleKey handles it held during notification emission are closed. Defer all handled
   // non-loaded notifications except rename_from, which only stores an owned source-key copy for
   // the following rename_to job.
-  if (ShouldDeferKeyspaceNotification(redisCommand)) {
+  //
+  // RedisModule_AddPostNotificationJobForKey is not exported by every Redis build the module
+  // loads into (it postdates some released enterprise runtimes). When it is absent, RedisModule_Init
+  // left the pointer NULL; handle inline there rather than call through a NULL pointer. This
+  // re-opens the pre-deferral re-entrancy window on those runtimes, but only where the deferred
+  // path was never available.
+  if (RedisModule_AddPostNotificationJobForKey != NULL &&
+      ShouldDeferKeyspaceNotification(redisCommand)) {
     int rc = RedisModule_AddPostNotificationJobForKey(ctx, HandlePerKeyJobFunc, key,
                                                      (void *)(uintptr_t)redisCommand, NULL);
     RS_LOG_ASSERT(rc == REDISMODULE_OK, "Failed to add post-notification job for key");


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: MOD-17109 made `KeySpaceNotificationCallback` defer every non-loaded notification through `RedisModule_AddPostNotificationJobForKey`, in both disk and in-memory modes. That symbol postdates some Redis runtimes the module still loads into (e.g. enterprise `rl_8.6`). `REDISMODULE_GET_API` leaves the function pointer NULL when the host does not export it, and module load still succeeds — so the first write notification calls through a NULL pointer and the server SIGSEGVs.
2. Change: the deferral is now gated on `RedisModule_AddPostNotificationJobForKey != NULL`. Where the API is missing, the notification is handled inline (the pre-MOD-17109 path) instead of being deferred.
3. Outcome: the module no longer crashes on Redis runtimes that lack `RedisModule_AddPostNotificationJobForKey`; runtimes that export it keep the deferred behavior. This is what the RediSearchEnterprise RoR suite (pinned to `rl_8.6`) hits.

#### Which additional issues this PR fixes

1. MOD-17877

#### Main objects this PR modified

1. `src/notifications.c` — `KeySpaceNotificationCallback` NULL-guards the post-notification deferral and falls back to inline handling.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
