### PR TITLE
[MOD-17688] Relabel an unchanged vector instead of re-adding it on update

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 #----------------------------------------------------------------------------------------------
 # Add subdirectories for src/ components
 add_subdirectory(geometry)
+add_subdirectory(vector_compare)
 add_subdirectory(buffer)
 add_subdirectory(iterators)
 add_subdirectory(index_result)
@@ -148,6 +149,7 @@ set_target_properties(redisearch_c PROPERTIES LINKER_LANGUAGE CXX)
 # Declare dependencies for transitive linking
 target_link_libraries(redisearch_c
     redisearch-geometry
+    redisearch-vector-compare
     redisearch-hash
     VectorSimilarity
     redisearch-coord

--- a/src/config.c
+++ b/src/config.c
@@ -1260,11 +1260,17 @@ CONFIG_GETTER(getGcPolicy) {
   return sdsnew(GCPolicy_ToString(config->gcConfigParams.gcPolicy));
 }
 
-// PARTIAL_INDEXED_DOCS
+// PARTIAL_INDEXED_DOCS -- retained as a no-op, see the field's comment in config.h.
 CONFIG_SETTER(setFilterCommand) {
   int filterCommands;
   int acrc = AC_GetInt(ac, &filterCommands, AC_F_GE0);
   config->filterCommands = (bool)filterCommands;
+  if (config->filterCommands) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "PARTIAL_INDEXED_DOCS is deprecated and has no effect. Hash field-change "
+                    "detection now comes from subkey notifications when the server supports "
+                    "them, and is unavailable otherwise.");
+  }
   RETURN_STATUS(acrc);
 }
 
@@ -1797,7 +1803,8 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = getNoMemPools,
          .flags = RSCONFIGVAR_F_FLAG | RSCONFIGVAR_F_IMMUTABLE},
         {.name = "PARTIAL_INDEXED_DOCS",
-         .helpText = "Enable commands filter which optimize indexing on partial hash updates",
+         .helpText = "Deprecated, has no effect. Partial hash updates are now optimized via "
+                     "subkey notifications, with no configuration",
          .setValue = setFilterCommand,
          .getValue = getFilterCommand,
          .flags = RSCONFIGVAR_F_IMMUTABLE},

--- a/src/config.h
+++ b/src/config.h
@@ -159,6 +159,17 @@ typedef struct {
 
   bool noMemPool;
 
+  /** Deprecated, read by nothing.
+   *
+   * Once gated a command filter that captured hash field names before execution,
+   * which subkey notifications replaced -- they deliver the same information from
+   * Redis directly, so there is nothing left to switch on.
+   *
+   * Retained only so the surface it is bound to keeps working: `PARTIAL_INDEXED_DOCS`
+   * and, more importantly, the `search-partial-indexed-docs` module config. Dropping
+   * the latter's registration makes a server whose config file sets it refuse to
+   * start ("Module Configuration detected without loadmodule directive"), so it can
+   * only be removed at a major version. */
   bool filterCommands;
 
   // free resource on shutdown

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -38,6 +38,7 @@
 #include "cursor.h"
 #include "aggregate/aggregate_debug.h"
 #include "hybrid/hybrid_debug.h"
+#include "notifications.h"
 #include "hybrid/hybrid_exec.h"
 #include "reply.h"
 #include "info/info_command.h"
@@ -2587,6 +2588,13 @@ DEBUG_COMMAND(getHideUserDataFromLogs) {
   return RedisModule_ReplyWithLongLong(ctx, value);
 }
 
+DEBUG_COMMAND(hashSubkeyNotifications) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  return RedisModule_ReplyWithBool(ctx, HashSubkeyNotificationsSupported());
+}
+
 // Global counter for tracking yield calls
 typedef struct {
   size_t yieldOnLoadCounter;
@@ -3762,6 +3770,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"INDEXES", ListIndexesSwitch},
                                {"INFO", IndexObfuscatedInfo},
                                {"GET_HIDE_USER_DATA_FROM_LOGS", getHideUserDataFromLogs},
+                               {"HASH_SUBKEY_NOTIFICATIONS", hashSubkeyNotifications},
                                {"YIELDS_COUNTER", YieldCounter},
                                {"GC_TIMER_ARMS", GCTimerArms},
                                {"INDEXER_SLEEP_BEFORE_YIELD_MICROS", IndexerSleepBeforeYieldMicros},

--- a/src/disk_indexer.c
+++ b/src/disk_indexer.c
@@ -66,7 +66,7 @@ void DiskIndexer_StageDocument(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   // TODO: Consider calling this from SearchDisk_PutDocument
   uint64_t oldDocId = 0;
   actxDocIdMetaGet(aCtx, ctx, &oldDocId);
-  aCtx->disk.oldDocId = oldDocId;
+  aCtx->oldDocId = oldDocId;
 
   // Open a per-document write batch that doc-table / inverted-index / tag-index writes
   // will be staged into. The batch is committed (or aborted on error) by
@@ -221,20 +221,14 @@ static void applyDocTable(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   // memory mode, which gates `Indexer_RemoveOldDocStats` on whether an old DMD
   // existed, not on its length. `oldDocLen` is still the right value to subtract
   // from `totalDocsLen` (0 for a zero-length old doc is a correct no-op subtraction).
-  const bool replaced = aCtx->disk.oldDocId != 0;
+  const bool replaced = aCtx->oldDocId != 0;
   if (replaced) {
-    Indexer_RemoveReplacedDocVectorAndGeometry(spec, aCtx->disk.oldDocId);
+    Indexer_HandleReplacedDocVectorAndGeometry(spec, aCtx->oldDocId, aCtx);
     Indexer_RemoveOldDocStats(spec, aCtx->disk.oldDocLen);
   }
   Indexer_AddNewDocStats(spec, aCtx->fwIdx->totalFreq);
 
-  if (spec->gc) {
-    if (replaced) {
-      GCContext_OnUpdate(spec->gc);
-    } else {
-      GCContext_OnWrite(spec->gc);
-    }
-  }
+  handle_gc(spec, replaced);
 }
 
 /**
@@ -266,7 +260,7 @@ static void applyTextIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
 
 /**
  * Disk-mode apply step for non-fulltext fields: runs the per-field-type
- * appliers (`tagApplier`, `vectorApplier`, …) defined in
+ * appliers (`tagApplier`, `numericApplier`, …) defined in
  * [document.c](document.c) once per indexed field. Called from
  * `DiskIndexer_IndexDocument` after `commitDocument` reports success. Infallible.
  */
@@ -305,11 +299,18 @@ static void applyVectorInserts(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
     // the next RDB save would persist that divergence. Match the post-commit
     // policy used by `applyDocTable` for `DocIdMeta_Set` failure.
     RS_LOG_ASSERT_ALWAYS(vecsim, "openVectorIndex returned NULL after a successful disk commit");
-    const char *curr_vec = (const char *)fdata->vector;
+    // Safe here and not before `commitDocument`: the batch is durable, so the
+    // vector index cannot end up pointing at an unpersisted doc-id.
+    if (AddDocumentCtx_ShouldRelabelField(aCtx, fs->index) &&
+        VectorIndex_RelabelField(vecsim, aCtx->oldDocId, aCtx->doc->docId)) {
+      continue;
+    }
+    const char *curr_vec = fdata->vector;
     for (size_t i = 0; i < fdata->numVec; i++) {
       VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
       curr_vec += fdata->vecLen;
     }
+    FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_VECTOR, 1);
   }
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -21,6 +21,7 @@
 #include "tokenize.h"
 #include "rmalloc.h"
 #include "indexer.h"
+#include "indexer_internal.h"
 #include "tag_index.h"
 #include "geometry/geometry_api.h"
 #include "aggregate/expr/expression.h"
@@ -69,6 +70,7 @@ static void freeDocumentContext(void *p) {
 
   rm_free(aCtx->fspecs);
   rm_free(aCtx->fdatas);
+  rm_free(aCtx->fieldChanges);
   if (aCtx->specName) {
     HiddenString_Free(aCtx->specName, true);
   }
@@ -188,6 +190,12 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp) {
   return 0;
 }
 
+// Contract documented on the declaration in document.h.
+bool AddDocumentCtx_ShouldRelabelField(const RSAddDocumentCtx *aCtx, t_fieldIndex f_idx) {
+  // The mark is checked first so a NULL aCtx never reaches the dereference.
+  return AddDocumentCtx_FieldChange(aCtx, f_idx) == ChangedField_VerifiedNo && aCtx->oldDocId != 0;
+}
+
 RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *status) {
 
   if (!actxPool_g) {
@@ -208,9 +216,10 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   aCtx->specFlags = sp->flags;
   aCtx->spec = sp;
   aCtx->disk.batch = NULL;
-  aCtx->disk.oldDocId = 0;
+  aCtx->oldDocId = 0;
   aCtx->disk.oldDocLen = 0;
   aCtx->disk.openKey = NULL;
+  aCtx->fieldChanges = NULL;
   if (aCtx->specFlags & Index_Async) {
     HiddenString_Clone(sp->specName, &aCtx->specName);
   }
@@ -344,6 +353,9 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx) {
       }
     }
   }
+
+  rm_free(aCtx->fieldChanges);
+  aCtx->fieldChanges = NULL;
 
   // Destroy the common fields:
   if (!(aCtx->stateFlags & ACTX_F_NOFREEDOC)) {
@@ -697,6 +709,16 @@ FIELD_PREPROCESSOR(vectorPreprocessor) {
     fdata->numVec = field->blobArrLen;
   } else if (field->unionType == FLD_VAR_T_NULL) {
     fdata->isNull = 1;
+    // No value means no insert site for this field, so a relabel mark placed before
+    // preprocessing would never be consumed -- and
+    // `Indexer_HandleReplacedDocVectorAndGeometry`, which honours the mark, would leave the
+    // old entry stranded under a doc-id no document owns.
+    // Clearing it here hands the field back to the ordinary delete path. Reachable
+    // for JSON, whose vector path is marked without knowing whether the new document
+    // still has the field.
+    if (aCtx->fieldChanges) {
+      aCtx->fieldChanges[fs->index] = ChangedField_VerifiedYes;
+    }
     return 0; // Skipping indexing missing vector
   }
   if (fdata->vecLen != fs->vectorOpts.expBlobSize) {
@@ -716,11 +738,16 @@ FIELD_BULK_INDEXER(vectorIndexer) {
     QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open vector for indexing");
     return -1;
   }
-  char *curr_vec = (char *)fdata->vector;
+  if (AddDocumentCtx_ShouldRelabelField(aCtx, fs->index) &&
+      VectorIndex_RelabelField(vecsim, aCtx->oldDocId, aCtx->doc->docId)) {
+    return 0;
+  }
+  const char *curr_vec = (char *)fdata->vector;
   for (size_t i = 0; i < fdata->numVec; i++) {
     VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
     curr_vec += fdata->vecLen;
   }
+  FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_VECTOR, 1);
   return 0;
 }
 
@@ -881,13 +908,6 @@ FIELD_BULK_APPLIER(tagApplier) {
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_TAG, 1);
 }
 
-FIELD_BULK_APPLIER(vectorApplier) {
-  // The VecSim insert itself runs in `applyVectorInserts` for disk mode
-  // (after the batch commits) and inline in `vectorIndexer` for memory mode.
-  // The applier only handles the global-stats bump, which is mode-independent.
-  FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_VECTOR, 1);
-}
-
 FIELD_BULK_APPLIER(numericApplier) {
   // Per-spec numeric stats are bumped by `numericIndexer` in both modes.
   // The applier only handles the global field-docs counter.
@@ -970,7 +990,8 @@ void IndexerBulkApply(RSAddDocumentCtx *aCtx, const DocumentField *field,
       case IXFLDPOS_TAG:      tagApplier(aCtx, field, fs, fdata);      break;
       case IXFLDPOS_NUMERIC:  numericApplier(aCtx, field, fs, fdata);  break;
       case IXFLDPOS_GEO:      geoApplier(aCtx, field, fs, fdata);      break;
-      case IXFLDPOS_VECTOR:   vectorApplier(aCtx, field, fs, fdata);   break;
+      // No vector applier: an entry that moved can be an indexing or relabeling op, and only the insert
+      // sites know which happened. They keep both counters instead.
       case IXFLDPOS_GEOMETRY: geometryApplier(aCtx, field, fs, fdata); break;
       case IXFLDPOS_FULLTEXT: break;
     }

--- a/src/document.c
+++ b/src/document.c
@@ -742,7 +742,7 @@ FIELD_BULK_INDEXER(vectorIndexer) {
       VectorIndex_RelabelField(vecsim, aCtx->oldDocId, aCtx->doc->docId)) {
     return 0;
   }
-  const char *curr_vec = (char *)fdata->vector;
+  const char *curr_vec = (const char *)fdata->vector;
   for (size_t i = 0; i < fdata->numVec; i++) {
     VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
     curr_vec += fdata->vecLen;

--- a/src/document.h
+++ b/src/document.h
@@ -128,6 +128,30 @@ typedef struct Document {
 #define UNDERSCORE_PAYLOAD "__payload"
 #define UNDERSCORE_LANGUAGE "__language"
 
+/**
+ * Whether a VECTOR field's value was changed by this update, which is what decides whether its
+ * existing index entry may move onto the document's new doc-id instead of being deleted and
+ * re-added.
+ *
+ * The two verified states are separate from the unverified one because the sources of an answer
+ * cost different things. A hash subkey notification names the fields the command wrote, so it
+ * settles every field for free. Everything else -- JSON (RedisJSON's API cannot report a change
+ * set), a background scan, or a hash on a server without subkey notifications -- has to be
+ * settled by looking at what the index is holding.
+ */
+typedef enum {
+  // Changed: the value was written. Reindex as before, dropping the old entry and adding the new
+  // blob. Must stay zero, because it doubles as the answer for a field with no mark at all: the
+  // per-field array is `rm_calloc`'d, and a field nothing was recorded for has no basis for a
+  // move.
+  ChangedField_VerifiedYes = 0,
+  // Not known either way.
+  ChangedField_Unverified,
+  // Unchanged: a change set named the fields this command wrote and this was not among them, or
+  // the comparison found the index already holding this value. The entry moves.
+  ChangedField_VerifiedNo,
+} ChangedField;
+
 struct RSAddDocumentCtx;
 
 typedef void (*DocumentAddCompleted)(struct RSAddDocumentCtx *, RedisModuleCtx *, void *);
@@ -319,6 +343,23 @@ typedef struct RSAddDocumentCtx {
 
   // Scratch space used by per-type field preprocessors (see the source)
   struct FieldIndexerData *fdatas;
+
+  /** Whether each VECTOR field's value was changed by this update, indexed by
+   *  *schema* field (`FieldSpec.index`) and sized `spec->numFields`.
+   *
+   *  Schema-indexed rather than living in `fdatas` because
+   *  `Indexer_HandleReplacedDocVectorAndGeometry` walks the schema, not the document: a
+   *  vector field absent from this version of the document still has an old entry to
+   *  drop, and would not be reachable through a document-field-indexed array.
+   *
+   *  NULL unless something was actually marked, so a document with no movable vector -- every
+   *  document, with the feature gated off -- allocates nothing. */
+  ChangedField *fieldChanges;
+
+  /** The doc-id this key mapped to before this update, or 0 if it was not
+   *  indexed. Both modes need it at the vector-insert sites, to move an unchanged
+   *  entry off it instead of re-adding the blob. */
+  t_docId oldDocId;
   QueryError status;     // Error message is placed here if there is an error during processing
   uint32_t totalTokens;  // Number of tokens, used for offset vector
   uint32_t specFlags;    // Cached index flags
@@ -331,7 +372,6 @@ typedef struct RSAddDocumentCtx {
   // are unused there.
   struct {
     SearchDiskWriteBatchHandle *batch;
-    t_docId oldDocId;
     uint32_t oldDocLen;
     // Optional already-open key handle for the document, supplied by the caller
     // (e.g. the async scan key callback, where the engine hands us an open,
@@ -341,6 +381,26 @@ typedef struct RSAddDocumentCtx {
     RedisModuleKey *openKey;
   } disk;
 } RSAddDocumentCtx;
+
+// Whether schema field `f_idx`'s value was changed by this update. A NULL aCtx or an unmarked
+// update reads as `ChangedField_VerifiedYes`: no mark means no basis for a move. That default is
+// why every consumer can call this unconditionally.
+static inline ChangedField AddDocumentCtx_FieldChange(const RSAddDocumentCtx *aCtx,
+                                                      t_fieldIndex f_idx) {
+  if (!aCtx || !aCtx->fieldChanges) return ChangedField_VerifiedYes;
+  return aCtx->fieldChanges[f_idx];
+}
+
+/**
+ * Whether field `f_idx`'s existing vector entry is to be moved onto this update's new doc-id,
+ * rather than re-added.
+ *
+ * True only once both halves hold: the field is marked — `VectorIndex_CheckRemoveId` left its
+ * entry in place on that basis — and there is an old doc-id to move it off. A field can be
+ * marked on a key that was not indexed before this update, where nothing says the vector was
+ * written but there is no entry to move either.
+ */
+bool AddDocumentCtx_ShouldRelabelField(const RSAddDocumentCtx *aCtx, t_fieldIndex f_idx);
 
 /**
  * Creates a new context used for adding documents. Once created, call

--- a/src/document.h
+++ b/src/document.h
@@ -128,27 +128,14 @@ typedef struct Document {
 #define UNDERSCORE_PAYLOAD "__payload"
 #define UNDERSCORE_LANGUAGE "__language"
 
-/**
- * Whether a VECTOR field's value was changed by this update, which is what decides whether its
- * existing index entry may move onto the document's new doc-id instead of being deleted and
- * re-added.
- *
- * The two verified states are separate from the unverified one because the sources of an answer
- * cost different things. A hash subkey notification names the fields the command wrote, so it
- * settles every field for free. Everything else -- JSON (RedisJSON's API cannot report a change
- * set), a background scan, or a hash on a server without subkey notifications -- has to be
- * settled by looking at what the index is holding.
- */
+// What this update knows about whether a field's value was changed.
 typedef enum {
-  // Changed: the value was written. Reindex as before, dropping the old entry and adding the new
-  // blob. Must stay zero, because it doubles as the answer for a field with no mark at all: the
-  // per-field array is `rm_calloc`'d, and a field nothing was recorded for has no basis for a
-  // move.
+  // Changed. Must stay zero: the per-field array is `rm_calloc`'d, so this is also what a field
+  // nothing was recorded for reads as.
   ChangedField_VerifiedYes = 0,
   // Not known either way.
   ChangedField_Unverified,
-  // Unchanged: a change set named the fields this command wrote and this was not among them, or
-  // the comparison found the index already holding this value. The entry moves.
+  // Unchanged.
   ChangedField_VerifiedNo,
 } ChangedField;
 

--- a/src/field_spec.c
+++ b/src/field_spec.c
@@ -94,6 +94,22 @@ const char *FieldSpec_GetTypeNames(int idx) {
   }
 }
 
+// Contract documented on the declaration in field_spec.h.
+bool FieldSpec_IsInChangeSet(const FieldSpec *fs, RedisModuleString **changedFields,
+                             size_t numChangedFields) {
+  if (!changedFields) {
+    return false;
+  }
+  for (size_t i = 0; i < numChangedFields; ++i) {
+    size_t length = 0;
+    const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
+    if (FieldSpec_PathEquals(fs, field, length)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void FieldSpec_AddError(FieldSpec *fs, ConstErrorMessage withoutUserData, ConstErrorMessage withUserData, RedisModuleString *key) {
   IndexError_AddError(&fs->indexError, withoutUserData, withUserData, key);
   FieldsGlobalStats_UpdateIndexError(fs->types, 1);

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -173,6 +173,36 @@ const char *FieldSpec_GetTypeNames(int idx);
 char *FieldSpec_FormatName(const FieldSpec *fs, bool obfuscate);
 char *FieldSpec_FormatPath(const FieldSpec *fs, bool obfuscate);
 
+/**
+ * True iff `name` is the document field this FieldSpec is fed from.
+ *
+ * Compares against `fieldPath`, not `fieldName`: a changed field is the hash field the command
+ * wrote, which is the path. `fieldName` is the `AS` alias, so comparing that would find no
+ * match on an aliased schema. `IndexSpec_CreateField` points `fieldPath` at `fieldName` when
+ * `AS` is absent, so unaliased schemas are unaffected.
+ *
+ * This is the one place that rule lives. Callers walking a change set should hoist
+ * `RedisModule_StringPtrLen` out of their innermost loop and call this per candidate field,
+ * rather than re-fetching the name for every field they test.
+ */
+static inline bool FieldSpec_PathEquals(const FieldSpec *fs, const char *name, size_t len) {
+  return HiddenString_CompareC(fs->fieldPath, name, len) == 0;
+}
+
+/**
+ * True iff `changedFields` names the document field `fs` is fed from.
+ *
+ * For the single-field question, where there is nothing to hoist. To ask it of many fields,
+ * loop the change set on the outside and use `FieldSpec_PathEquals` -- the change set is
+ * normally one or two names, so it is the shorter loop of the two.
+ *
+ * An absent change set names nothing, and answers false for every field. That is not the same
+ * as "this field did not change" -- a caller that reads "not named" as a positive statement
+ * about the field has to establish that a change set exists first.
+ */
+bool FieldSpec_IsInChangeSet(const FieldSpec *fs, RedisModuleString **changedFields,
+                             size_t numChangedFields);
+
 /**Adds an error message to the IndexError of the FieldSpec.
  * This function also updates the global field's type index error counter.
  */

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -16,6 +16,7 @@
 #include "inverted_index_ffi.h"
 #include "sorting_vector_ffi.h"
 #include "vector_index.h"
+#include "vector_compare/vector_compare.h"
 #include "redis_index.h"
 #include "suffix.h"
 #include "config.h"
@@ -175,18 +176,100 @@ static void indexText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_FULLTEXT, spec->stats.scoring.numTerms - prevNumTerms);
 }
 
-// Contract documented on the declaration in indexer_internal.h.
-void Indexer_RemoveReplacedDocVectorAndGeometry(IndexSpec *spec, t_docId oldDocId) {
-  if (spec->flags & Index_HasVecSim) {
-    for (int i = 0; i < spec->numFields; ++i) {
-      if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-        // ctx is NULL because we don't create the index here
-        VecSimIndex *vecsim = openVectorIndex(NULL, &spec->fields[i], DONT_CREATE_INDEX);
-        if (!vecsim) continue;
-        VecSimIndex_DeleteVector(vecsim, oldDocId);
-        // TODO: use VecSimReplace instead and if successful, do not insert and remove from doc
-      }
+/**
+ * This update's value for schema field `f_idx`, or NULL when this version of the document
+ * carries none.
+ *
+ * `VectorIndex_CheckRemoveId` walks the schema while the preprocessed values are indexed by
+ * document field, so the mapping is resolved here. Document fields the schema does not know are
+ * zeroed whole, `index` included, so `fieldName` is what distinguishes a real field 0 from a
+ * skipped one.
+ */
+static const FieldIndexerData *replacedFieldValue(const RSAddDocumentCtx *aCtx,
+                                                  const t_fieldIndex f_idx) {
+  const Document *doc = aCtx->doc;
+  for (size_t ii = 0; ii < doc->numFields; ++ii) {
+    const FieldSpec *fs = aCtx->fspecs + ii;
+    if (!fs->fieldName || fs->index != f_idx) continue;
+    const FieldIndexerData *fdata = aCtx->fdatas + ii;
+    return fdata->isNull ? NULL : fdata;
+  }
+  return NULL;
+}
+
+/**
+ * Whether field `fs`'s existing entry is left in place for the vector-insert site to move,
+ * rather than deleted here — and, for a mark that is not yet settled, the point where it is.
+ *
+ * An unverified mark (no change set: JSON, a background scan, a server without subkey
+ * notifications) is resolved by asking the index whether it already holds the value about to
+ * be written. `VectorIndex_HoldsVectors` compares the stored bytes and answers false when it
+ * cannot tell, so an inconclusive comparison costs a reindex rather than risking a stale
+ * vector. Deciding it here rather than at the insert site keeps the delete in the step that
+ * owns it: a changed vector's entry goes now, so nothing downstream has to remember to drop
+ * it, and nothing is stranded if the insert never runs.
+ *
+ * A field with no value in this version of the document cannot be moved however confident the
+ * mark is — there will be no insert site to move it — so the entry goes now too. The reachable
+ * form of that is a JSON document setting the path to `null`: the field is still loaded (as
+ * `FLD_VAR_T_NULL`) and so still marked, but `vectorPreprocessor` indexes nothing for it. A
+ * path removed outright never becomes a document field, so it is never marked in the first
+ * place and takes the ordinary delete below.
+ */
+static bool keepsReplacedVector(const RSAddDocumentCtx *aCtx, const FieldSpec *fs, VecSimIndex *vecsim,
+                                t_docId oldDocId) {
+  const ChangedField mark = AddDocumentCtx_FieldChange(aCtx, fs->index);
+  if (mark == ChangedField_VerifiedYes) {
+    return false;
+  }
+
+  const FieldIndexerData *fdata = replacedFieldValue(aCtx, fs->index);
+  if (fdata &&
+      (mark == ChangedField_VerifiedNo ||
+       VectorIndex_HoldsVectors(vecsim, oldDocId, fdata->vector, fdata->numVec))) {
+    aCtx->fieldChanges[fs->index] = ChangedField_VerifiedNo;
+    return true;
+  }
+  aCtx->fieldChanges[fs->index] = ChangedField_VerifiedYes;
+  return false;
+}
+
+/**
+ * Drop the replaced document's entry from every VECTOR field of `spec`, except a field whose
+ * entry is to be moved onto the document's new doc-id — which is left in place for the
+ * vector-insert site, `VectorIndex_RelabelField`.
+ *
+ * This is where a relabel mark is settled. A change set makes the decision for free; without
+ * one, the field's new value is compared against what the index holds. Either way the answer is
+ * reached before anything is deleted, so a field that turns out to have changed loses its old
+ * entry here and the insert site is left with a straight yes or no.
+ *
+ * `aCtx` may be NULL, in which case nothing is marked and every entry is dropped.
+ * `VecSimIndex_DeleteVector` no-ops on an unknown doc-id, so this is safe even if the replaced
+ * document had no vector data.
+ */
+static void VectorIndex_CheckRemoveId(const IndexSpec *spec, t_docId oldDocId,
+                                      const RSAddDocumentCtx *aCtx) {
+  for (int i = 0; i < spec->numFields; ++i) {
+    FieldSpec *fs = &spec->fields[i];
+    if (fs->types != INDEXFLD_T_VECTOR) continue;
+    // ctx is NULL because we don't create the index here
+    VecSimIndex *vecsim = openVectorIndex(NULL, fs, DONT_CREATE_INDEX);
+    if (!vecsim) {
+      // No index yet, so no entry to drop and none to move either, whatever the mark said.
+      if (aCtx && aCtx->fieldChanges) aCtx->fieldChanges[fs->index] = ChangedField_VerifiedYes;
+      continue;
     }
+    if (keepsReplacedVector(aCtx, fs, vecsim, oldDocId)) continue;
+    VecSimIndex_DeleteVector(vecsim, oldDocId);
+  }
+}
+
+// Contract documented on the declaration in indexer_internal.h.
+void Indexer_HandleReplacedDocVectorAndGeometry(IndexSpec *spec, t_docId oldDocId,
+                                                RSAddDocumentCtx *aCtx) {
+  if (spec->flags & Index_HasVecSim) {
+    VectorIndex_CheckRemoveId(spec, oldDocId, aCtx);
   }
   if (spec->flags & Index_HasGeometry) {
     GeometryIndex_RemoveId(spec, oldDocId);
@@ -228,7 +311,7 @@ static int actxDocIdMetaSet(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx, uint64_
 /** Assigns a document ID to a single document. Handles only the RAM index.
  *  The key -> docId mapping is stored on the Redis key via DocIdMeta (unified
  *  with disk mode); the in-memory DocTable only maps docId -> DMD. */
-static RSDocumentMetadata *makeDocumentId(RedisSearchCtx *sctx, RSAddDocumentCtx *aCtx,
+static RSDocumentMetadata *newDocumentId(RedisSearchCtx *sctx, RSAddDocumentCtx *aCtx,
                                           int replace, bool *updated) {
   IndexSpec *spec = sctx->spec;
   DocTable *table = &spec->docs;
@@ -238,22 +321,23 @@ static RSDocumentMetadata *makeDocumentId(RedisSearchCtx *sctx, RSAddDocumentCtx
   // lookup in doAssignIds).
   uint64_t oldDocId = 0;
   actxDocIdMetaGet(aCtx, sctx, &oldDocId);
+  aCtx->oldDocId = oldDocId;
 
   if (oldDocId) {
     if (replace) {
       // Drop the previous version + its stats/aux indexes; the mapping is
       // overwritten by the actxDocIdMetaSet below.
-      RSDocumentMetadata *old = DocTable_DeleteById(table, (t_docId)oldDocId);
+      RSDocumentMetadata *old = DocTable_DeleteById(table, oldDocId);
       if (old) {
         Indexer_RemoveOldDocStats(spec, old->docLen);
-        Indexer_RemoveReplacedDocVectorAndGeometry(spec, old->id);
+        Indexer_HandleReplacedDocVectorAndGeometry(spec, old->id, aCtx);
         *updated = true;
         DMD_Return(old);
       }
     } else {
       // Already indexed, not a REPLACE: return the existing DMD (former
       // DocTable_Put dedup). Fall through only if the mapping is stale.
-      RSDocumentMetadata *existing = (RSDocumentMetadata *)DocTable_Borrow(table, (t_docId)oldDocId);
+      RSDocumentMetadata *existing = (RSDocumentMetadata *)DocTable_Borrow(table, oldDocId);
       if (existing) {
         doc->docId = existing->id;
         return existing;
@@ -298,7 +382,7 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
     } else {
       RS_LOG_ASSERT(!cur->doc->docId, "docId must be 0");
       bool updated = false;
-      RSDocumentMetadata *md = makeDocumentId(ctx, cur,
+      RSDocumentMetadata *md = newDocumentId(ctx, cur,
                                               cur->options & DOCUMENT_ADD_REPLACE, &updated);
       if (!md) {
         cur->stateFlags |= ACTX_F_ERRORED;
@@ -327,13 +411,7 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       }
       DMD_Return(md);
 
-      if (spec->gc) {
-        if (updated) {
-          GCContext_OnUpdate(spec->gc);
-        } else {
-          GCContext_OnWrite(spec->gc);
-        }
-      }
+      handle_gc(spec, updated);
     }
   }
 }

--- a/src/indexer_internal.h
+++ b/src/indexer_internal.h
@@ -31,20 +31,28 @@ extern "C" {
 #endif
 
 /**
- * Drop the replaced document's VecSim and Geometry entries.
+ * Dispose of the replaced document's VecSim and Geometry entries: drop each one, except a
+ * vector field whose entry is to be moved onto the new doc-id, which is left for the
+ * vector-insert site.
+ *
+ * This is where a relabel mark is settled. A change set makes the decision for free; without
+ * one, the field's new value is compared against what the index holds. Either way the answer
+ * is reached before anything is deleted, so a field that turns out to have changed loses its
+ * old entry here and the insert site is left with a straight yes or no.
  *
  * These two index types live in memory in both memory mode and disk mode (the
  * inverted-index / tag / doc-table cleanup is handled by `SearchDisk_PutDocument`
  * in disk mode and by `DocTable_DeleteById` in memory mode — neither covers VecSim or
  * Geometry, hence this dedicated step). Memory mode calls this inline from
- * `makeDocumentId` before the new DMD is allocated; disk mode calls it from
+ * `newDocumentId` before the new DMD is allocated; disk mode calls it from
  * `applyDocTable` after the disk batch commits.
  *
  * `VecSimIndex_DeleteVector` and `GeometryIndex_RemoveId` no-op on unknown
  * doc-ids, so this is safe even if the replaced doc had no vector / geometry
  * data, and safe to call defensively on stale key-meta in disk mode.
  */
-void Indexer_RemoveReplacedDocVectorAndGeometry(IndexSpec *spec, t_docId oldDocId);
+void Indexer_HandleReplacedDocVectorAndGeometry(IndexSpec *spec, t_docId oldDocId,
+                                                RSAddDocumentCtx *aCtx);
 
 /**
  * Remove the old document's contributions from the spec's scoring stats on
@@ -68,6 +76,16 @@ static inline bool entryWantsSuffixTrie(const IndexSpec *spec, const ForwardInde
       && entry->term[0] != PHONETIC_PREFIX
       && entry->term[0] != SYNONYM_PREFIX_CHAR
       && strlen(entry->term) != 0;
+}
+
+static void handle_gc(const IndexSpec *spec, bool updated) {
+  if (spec->gc) {
+    if (updated) {
+      GCContext_OnUpdate(spec->gc);
+    } else {
+      GCContext_OnWrite(spec->gc);
+    }
+  }
 }
 
 #ifdef __cplusplus

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -598,6 +598,68 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   return res;
 }
 
+/**
+ * True when `changedFields` proves this update cannot change anything `spec` holds for the
+ * document, so the reindex can be skipped. False whenever that cannot be established --
+ * including when there is no change set to reason from.
+ *
+ * "No schema field was named" is not enough on its own, in three ways:
+ *
+ * - A hash matching the rule's prefix is a document whether or not it carries an indexed
+ *   field, so `*`, result counts and `ismissing()` all depend on it being registered. A
+ *   document the index does not hold yet must be indexed whatever the change set says,
+ *   which is what the doc-table lookup below establishes.
+ * - A rule FILTER may test a field the schema never mentions, and its verdict flips when
+ *   that field changes, so a spec carrying one can never skip.
+ * - The rule's language, score and payload fields are read from the document without being
+ *   part of the schema.
+ *
+ * Conservative for a disk-backed spec, whose document bookkeeping does not run through
+ * this doc table.
+ */
+static bool changeSetAllowsSkippingReindex(IndexSpec *spec, RedisModuleCtx *ctx,
+                                           RedisModuleString *key,
+                                           RedisModuleString **changedFields,
+                                           size_t numChangedFields) {
+  if (!changedFields || spec->diskSpec || spec->rule->filter_exp) {
+    return false;
+  }
+
+  // TODO: improve implementation to avoid O(n^2)
+  for (size_t i = 0; i < numChangedFields; ++i) {
+    size_t length = 0;
+    const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
+    for (size_t j = 0; j < spec->numFields; ++j) {
+      // Match on the path, not the name: a changed field is the hash field the command
+      // wrote, which is `fieldPath`. `fieldName` is the `AS` alias, so comparing it would
+      // find no match on an aliased schema and skip a reindex the document needed.
+      // `IndexSpec_CreateField` points `fieldPath` at `fieldName` when `AS` is absent, so
+      // unaliased schemas are unaffected.
+      if (!HiddenString_CompareC(spec->fields[j].fieldPath, field, length)) {
+        return false;
+      }
+    }
+    if ((spec->rule->lang_field && !strcmp(field, spec->rule->lang_field)) ||
+        (spec->rule->score_field && !strcmp(field, spec->rule->score_field)) ||
+        (spec->rule->payload_field && !strcmp(field, spec->rule->payload_field))) {
+      return false;
+    }
+  }
+
+  // Last, because it is the only check that takes a lock. Same locking rationale as
+  // Indexes_UpdateMatchingDocExpiration: read lock suffices for a DMD chain traversal and
+  // refcount, and notification callbacks are serialized on the main thread.
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
+  RedisSearchCtx_LockSpecRead(&sctx);
+  const RSDocumentMetadata *dmd = IndexSpec_BorrowDocByKeyR(spec, ctx, key);
+  const bool alreadyIndexed = dmd != NULL;
+  if (dmd) {
+    DMD_Return(dmd);
+  }
+  RedisSearchCtx_UnlockSpec(&sctx);
+  return alreadyIndexed;
+}
+
 void Indexes_SpecOpsIndexingCtxFree(SpecOpIndexingCtx *specs) {
   dictRelease(specs->specs);
   array_free(specs->specsOps);
@@ -619,6 +681,10 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
     SpecOpCtx *specOp = specs->specsOps + i;
 
     if (specOp->op == SpecOp_Add) {
+      if (changeSetAllowsSkippingReindex(specOp->spec, ctx, key, changedFields,
+                                         numChangedFields)) {
+        continue;
+      }
       IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL, changedFields,
                           numChangedFields);
     } else {

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -598,17 +598,23 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   return res;
 }
 
-static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **hashFields) {
-  if (hashFields == NULL) {
+static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **changedFields,
+                             size_t numChangedFields) {
+  if (changedFields == NULL) {
     return true;
   }
 
   // TODO: improve implementation to avoid O(n^2)
-  for (size_t i = 0; hashFields[i] != NULL; ++i) {
+  for (size_t i = 0; i < numChangedFields; ++i) {
     size_t length = 0;
-    const char *field = RedisModule_StringPtrLen(hashFields[i], &length);
+    const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
     for (size_t j = 0; j < spec->numFields; ++j) {
-      if (!HiddenString_CompareC(spec->fields[j].fieldName, field, length)) {
+      // Match on the path, not the name: a changed field is the hash field the
+      // command wrote, which is `fieldPath`. `fieldName` is the `AS` alias, so
+      // comparing it would find no match on an aliased schema and skip a
+      // reindex the document needed. `IndexSpec_CreateField` points `fieldPath`
+      // at `fieldName` when `AS` is absent, so unaliased schemas are unaffected.
+      if (!HiddenString_CompareC(spec->fields[j].fieldPath, field, length)) {
         return true;
       }
     }
@@ -629,10 +635,11 @@ void Indexes_SpecOpsIndexingCtxFree(SpecOpIndexingCtx *specs) {
 }
 
 void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type,
-                                           RedisModuleString **hashFields) {
+                                           RedisModuleString **changedFields,
+                                           size_t numChangedFields) {
   if (type == DocumentType_Unsupported) {
     // COPY could overwrite a hash/json with other types so we must try and remove old doc.
-    Indexes_DeleteMatchingWithSchemaRules(ctx, key, type, hashFields);
+    Indexes_DeleteMatchingWithSchemaRules(ctx, key, type, changedFields, numChangedFields);
     return;
   }
 
@@ -641,9 +648,10 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
 
-    if (hashFieldChanged(specOp->spec, hashFields)) {
+    if (hashFieldChanged(specOp->spec, changedFields, numChangedFields)) {
       if (specOp->op == SpecOp_Add) {
-        IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL);
+        IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL, changedFields,
+                            numChangedFields);
       } else {
         // specOp->op is SpecOp_Del when the key matches the index prefix but
         // the filter expression fails (e.g. a field value changed so the filter
@@ -729,12 +737,13 @@ void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString 
 
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
                                            DocumentType type,
-                                           RedisModuleString **hashFields) {
+                                           RedisModuleString **changedFields,
+                                           size_t numChangedFields) {
   SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, type, false, NULL);
 
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
-    if (hashFieldChanged(specOp->spec, hashFields)) {
+    if (hashFieldChanged(specOp->spec, changedFields, numChangedFields)) {
       IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
     }
   }
@@ -787,7 +796,7 @@ static void reindexDocAfterFieldExpirationAdded(RedisModuleCtx *ctx, IndexSpec *
   // instead — otherwise the stale entry (with a clear inline bit) keeps being
   // returned. Mirrors the INDEXMISSING path and the slow path's SpecOp_Del.
   if (SchemaRule_ShouldIndex(spec, key, type, openKey)) {
-    IndexSpec_UpdateDoc(spec, ctx, key, type, openKey);
+    IndexSpec_UpdateDoc(spec, ctx, key, type, openKey, NULL, 0);
   } else {
     IndexSpec_DeleteDoc(spec, ctx, key, openKey);
   }
@@ -855,7 +864,7 @@ void Indexes_UpdateMatchingHashFieldExpiration(RedisModuleCtx *ctx, RedisModuleS
     // produces in Indexes_UpdateMatchingWithSchemaRules.
     if (specHasIndexMissing(spec)) {
       if (SchemaRule_ShouldIndex(spec, key, type, k)) {
-        IndexSpec_UpdateDoc(spec, ctx, key, type, k);
+        IndexSpec_UpdateDoc(spec, ctx, key, type, k, NULL, 0);
       } else {
         IndexSpec_DeleteDoc(spec, ctx, key, k);
       }
@@ -993,7 +1002,7 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       // on the spec from section.
       continue;
     }
-    IndexSpec_UpdateDoc(specOp->spec, ctx, to_key, type, NULL);
+    IndexSpec_UpdateDoc(specOp->spec, ctx, to_key, type, NULL, NULL, 0);
   }
   Indexes_SpecOpsIndexingCtxFree(from_specs);
   Indexes_SpecOpsIndexingCtxFree(to_specs);

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -598,36 +598,6 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   return res;
 }
 
-static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **changedFields,
-                             size_t numChangedFields) {
-  if (changedFields == NULL) {
-    return true;
-  }
-
-  // TODO: improve implementation to avoid O(n^2)
-  for (size_t i = 0; i < numChangedFields; ++i) {
-    size_t length = 0;
-    const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
-    for (size_t j = 0; j < spec->numFields; ++j) {
-      // Match on the path, not the name: a changed field is the hash field the
-      // command wrote, which is `fieldPath`. `fieldName` is the `AS` alias, so
-      // comparing it would find no match on an aliased schema and skip a
-      // reindex the document needed. `IndexSpec_CreateField` points `fieldPath`
-      // at `fieldName` when `AS` is absent, so unaliased schemas are unaffected.
-      if (!HiddenString_CompareC(spec->fields[j].fieldPath, field, length)) {
-        return true;
-      }
-    }
-    // optimize. change of score and payload fields just require an update of the doc table
-    if ((spec->rule->lang_field && !strcmp(field, spec->rule->lang_field)) ||
-        (spec->rule->score_field && !strcmp(field, spec->rule->score_field)) ||
-        (spec->rule->payload_field && !strcmp(field, spec->rule->payload_field))) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void Indexes_SpecOpsIndexingCtxFree(SpecOpIndexingCtx *specs) {
   dictRelease(specs->specs);
   array_free(specs->specsOps);
@@ -639,7 +609,7 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
                                            size_t numChangedFields) {
   if (type == DocumentType_Unsupported) {
     // COPY could overwrite a hash/json with other types so we must try and remove old doc.
-    Indexes_DeleteMatchingWithSchemaRules(ctx, key, type, changedFields, numChangedFields);
+    Indexes_DeleteMatchingWithSchemaRules(ctx, key, type);
     return;
   }
 
@@ -648,17 +618,15 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
 
-    if (hashFieldChanged(specOp->spec, changedFields, numChangedFields)) {
-      if (specOp->op == SpecOp_Add) {
-        IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL, changedFields,
-                            numChangedFields);
-      } else {
-        // specOp->op is SpecOp_Del when the key matches the index prefix but
-        // the filter expression fails (e.g. a field value changed so the filter
-        // no longer passes, or a required field is missing). If the document was
-        // previously indexed, it must be removed now.
-        IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
-      }
+    if (specOp->op == SpecOp_Add) {
+      IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL, changedFields,
+                          numChangedFields);
+    } else {
+      // specOp->op is SpecOp_Del when the key matches the index prefix but
+      // the filter expression fails (e.g. a field value changed so the filter
+      // no longer passes, or a required field is missing). If the document was
+      // previously indexed, it must be removed now.
+      IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
     }
   }
 
@@ -736,16 +704,12 @@ void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString 
 }
 
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
-                                           DocumentType type,
-                                           RedisModuleString **changedFields,
-                                           size_t numChangedFields) {
+                                           DocumentType type) {
   SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, type, false, NULL);
 
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
-    if (hashFieldChanged(specOp->spec, changedFields, numChangedFields)) {
-      IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
-    }
+    IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
   }
 
   Indexes_SpecOpsIndexingCtxFree(specs);

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -626,19 +626,20 @@ static bool changeSetAllowsSkippingReindex(IndexSpec *spec, RedisModuleCtx *ctx,
   }
 
   // TODO: improve implementation to avoid O(n^2)
+  //
+  // The change set is the outer loop deliberately: it holds the fields one command wrote,
+  // normally one or two, against a schema that can hold many more. Nesting it this way also
+  // fetches each name once instead of once per schema field.
   for (size_t i = 0; i < numChangedFields; ++i) {
     size_t length = 0;
     const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
     for (size_t j = 0; j < spec->numFields; ++j) {
-      // Match on the path, not the name: a changed field is the hash field the command
-      // wrote, which is `fieldPath`. `fieldName` is the `AS` alias, so comparing it would
-      // find no match on an aliased schema and skip a reindex the document needed.
-      // `IndexSpec_CreateField` points `fieldPath` at `fieldName` when `AS` is absent, so
-      // unaliased schemas are unaffected.
-      if (!HiddenString_CompareC(spec->fields[j].fieldPath, field, length)) {
+      if (FieldSpec_PathEquals(&spec->fields[j], field, length)) {
         return false;
       }
     }
+    // The rule's language, score and payload fields are read from the document without being
+    // part of the schema, so they are matched by name rather than through a FieldSpec.
     if ((spec->rule->lang_field && !strcmp(field, spec->rule->lang_field)) ||
         (spec->rule->score_field && !strcmp(field, spec->rule->score_field)) ||
         (spec->rule->payload_field && !strcmp(field, spec->rule->payload_field))) {

--- a/src/indexes.h
+++ b/src/indexes.h
@@ -78,8 +78,17 @@ void Indexes_Propagate(RedisModuleCtx *ctx);
 
 void Indexes_SetTempSpecsTimers(TimerOp op);
 
+/**
+ * Re-index `key` on every spec whose schema rules match it.
+ *
+ * `changedFields` / `numChangedFields` name the fields the originating command
+ * modified, letting a spec that indexes none of them skip the reindex. They come
+ * from a hash subkey notification; pass `NULL` / `0` when the change set is
+ * unknown — for JSON writes, the background scan, and any event that carries no
+ * subkeys — which reindexes unconditionally.
+ */
 void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type,
-                                           RedisModuleString **hashFields);
+                                           RedisModuleString **changedFields, size_t numChangedFields);
 // Refresh the per-field TTL entries on every spec that indexes `key`: reads
 // the hash's current per-field expiration timestamps and writes them onto
 // the matching specs' TTL tables, without re-tokenizing the document or
@@ -93,9 +102,12 @@ void Indexes_UpdateMatchingHashFieldExpiration(RedisModuleCtx *ctx, RedisModuleS
 // re-indexing the document. In-memory flow only; callers must fall back to
 // Indexes_UpdateMatchingWithSchemaRules for disk-backed indexes.
 void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type);
+// `changedFields` / `numChangedFields` carry the same meaning as in
+// Indexes_UpdateMatchingWithSchemaRules.
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
                                            DocumentType type,
-                                           RedisModuleString **hashFields);
+                                           RedisModuleString **changedFields,
+                                           size_t numChangedFields);
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key);
 void Indexes_List(RedisModule_Reply* reply, bool obfuscate);

--- a/src/indexes.h
+++ b/src/indexes.h
@@ -102,12 +102,8 @@ void Indexes_UpdateMatchingHashFieldExpiration(RedisModuleCtx *ctx, RedisModuleS
 // re-indexing the document. In-memory flow only; callers must fall back to
 // Indexes_UpdateMatchingWithSchemaRules for disk-backed indexes.
 void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type);
-// `changedFields` / `numChangedFields` carry the same meaning as in
-// Indexes_UpdateMatchingWithSchemaRules.
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
-                                           DocumentType type,
-                                           RedisModuleString **changedFields,
-                                           size_t numChangedFields);
+                                           DocumentType type);
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key);
 void Indexes_List(RedisModule_Reply* reply, bool obfuscate);

--- a/src/indexes_asyncscan.c
+++ b/src/indexes_asyncscan.c
@@ -114,7 +114,7 @@ static void Indexes_AsyncScanKeyCB(RedisModuleCtx *ctx, RedisModuleScanCursor *c
       if (DocIdMeta_GetWithOpenKey(key, sp->specId, &docId) == REDISMODULE_OK && docId != 0) {
         // Already indexed in this spec; skip to avoid clobbering a fresher version.
       } else {
-        IndexSpec_UpdateDoc(sp, ctx, name, type, key);
+        IndexSpec_UpdateDoc(sp, ctx, name, type, key, NULL, 0);
       }
     }
   } else {

--- a/src/indexes_scan.c
+++ b/src/indexes_scan.c
@@ -176,7 +176,7 @@ static void IndexScanner_DrainPendingScanKeys(RedisModuleCtx *ctx, ScanProcCtx *
     }
 
     if (scanner->global) {
-      Indexes_UpdateMatchingWithSchemaRules(ctx, keyname, type, NULL);
+      Indexes_UpdateMatchingWithSchemaRules(ctx, keyname, type, NULL, 0);
     } else {
       StrongRef curr_run_ref = IndexSpecRef_Promote(scanner->spec_ref);
       IndexSpec *sp = StrongRef_Get(curr_run_ref);
@@ -184,7 +184,7 @@ static void IndexScanner_DrainPendingScanKeys(RedisModuleCtx *ctx, ScanProcCtx *
         // This check is performed without locking the spec, but it's ok since we locked the GIL
         // So the main thread is not running and the GC is not touching the relevant data
         if (SchemaRule_ShouldIndex(sp, keyname, type, NULL)) {
-          IndexSpec_UpdateDoc(sp, ctx, keyname, type, NULL);
+          IndexSpec_UpdateDoc(sp, ctx, keyname, type, NULL, NULL, 0);
         }
         IndexSpecRef_Release(curr_run_ref);
       } else {

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -294,3 +294,11 @@ void FieldsGlobalStats_UpdateFieldDocsIndexed(FieldType field_types, int toAdd) 
       break;
   }
 }
+
+void FieldsGlobalStats_UpdateFieldDocsRelabeled(FieldType field_types, int toAdd) {
+  // Same threading argument as `FieldsGlobalStats_UpdateFieldDocsIndexed`: indexing runs on the
+  // main thread or with the GIL held, so no atomics are needed.
+  if (field_types == INDEXFLD_T_VECTOR) {
+    RSGlobalStats.fieldsStats.vectorTotalDocsRelabeled += toAdd;
+  }
+}

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -51,6 +51,11 @@ typedef struct {
   size_t geoTotalDocsIndexed;
   size_t geometryTotalDocsIndexed;
   size_t vectorTotalDocsIndexed;
+  // Updates served by moving an existing entry onto the document's new doc-id instead of
+  // re-adding its value. Disjoint from the count above, not a subset of it: moving an entry is
+  // not an indexing operation, so exactly one of the two is counted per field per update. Only
+  // vector fields can move an entry today, so there is one counter rather than one per type.
+  size_t vectorTotalDocsRelabeled;
 } FieldsGlobalStats;
 
 // The pipeline stage a timeout occurred in, used to break down the timeout metric.
@@ -211,6 +216,12 @@ MultiThreadingStats GlobalStats_GetMultiThreadingStats();
 
 // Increase the number of documents indexed by the given field type by `toAdd`.
 void FieldsGlobalStats_UpdateFieldDocsIndexed(FieldType field_types, int toAdd);
+
+// Increase, by `toAdd`, the number of documents whose entry for the given field type was moved
+// onto a new doc-id rather than re-added. Counted instead of, not as well as,
+// `FieldsGlobalStats_UpdateFieldDocsIndexed`: a move is not an indexing operation. Field types
+// that cannot move an entry are accepted and ignored, so callers need no type check.
+void FieldsGlobalStats_UpdateFieldDocsRelabeled(FieldType field_types, int toAdd);
 
 #ifdef __cplusplus
 }

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -246,6 +246,10 @@ void AddToInfo_Fields(RedisModuleInfoCtx *ctx, TotalIndexesFieldsInfo *aggregate
                                   RSGlobalStats.fieldsStats.geometryTotalDocsIndexed);
   RedisModule_InfoAddFieldLongLong(ctx, "total_indexing_ops_vector_fields",
                                   RSGlobalStats.fieldsStats.vectorTotalDocsIndexed);
+  // Sibling of the vector count above, not part of it: updates served by moving an existing
+  // entry onto the document's new doc-id, which is not an indexing operation.
+  RedisModule_InfoAddFieldLongLong(ctx, "total_relabel_ops_vector_fields",
+                                  RSGlobalStats.fieldsStats.vectorTotalDocsRelabeled);
 }
 
 void AddToInfo_Indexes(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -197,7 +197,6 @@ int RediSearch_Init(RedisModuleCtx *ctx) {
 
   ASM_StateMachine_Init();
   Initialize_ServerEventNotifications(ctx);
-  Initialize_CommandFilter(ctx);
   Initialize_RdbNotifications(ctx);
   Initialize_RoleChangeNotifications(ctx);
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -43,7 +43,6 @@
 
 RedisModuleString *global_RenameFromKey = NULL;
 extern RedisModuleCtx *RSDummyContext;
-RedisModuleString **hashFields = NULL;
 
 // The list of events we handle in the notification callback.
 #define REDIS_NOTIFICATION_EVENT_LIST(X)  \
@@ -109,18 +108,9 @@ enum RedisCmd {
 REDIS_NOTIFICATION_EVENT_LIST(DECLARE_REDIS_NOTIFICATION_EVENT_CACHE)
 #undef DECLARE_REDIS_NOTIFICATION_EVENT_CACHE
 
-static void freeHashFields() {
-  if (hashFields != NULL) {
-    for (size_t i = 0; hashFields[i] != NULL; ++i) {
-      RedisModule_FreeString(RSDummyContext, hashFields[i]);
-    }
-    rm_free(hashFields);
-    hashFields = NULL;
-  }
-}
-
 int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
-                               RedisModuleString *key);
+                               RedisModuleString *key, RedisModuleString **changedFields,
+                               size_t numChangedFields);
 
 // Transform the event string into its corresponding enum value. The core events
 // (REDIS_NOTIFICATION_EVENT_LIST) are pointer-cached: Redis core passes static
@@ -164,7 +154,36 @@ static enum RedisCmd GetRedisCmd(const char *event) {
 // nothing per notification. We deliberately do not carry the raw event string:
 // RedisJSON frees it once the notification returns (see GetRedisCmd).
 void HandlePerKeyJobFunc(RedisModuleCtx *ctx, RedisModuleString *key, void *pd) {
-  HandleKeyspaceNotification(ctx, (enum RedisCmd)(uintptr_t)pd, key);
+  HandleKeyspaceNotification(ctx, (enum RedisCmd)(uintptr_t)pd, key, NULL, 0);
+}
+
+/**
+ * Deferred payload for a subkey notification.
+ *
+ * The plain path packs its event enum into the payload pointer and allocates
+ * nothing, but subkeys cannot travel that way: Redis owns `subkeys[]` and it is
+ * only valid for the duration of the callback, while the indexing work runs
+ * later in a post-notification job. So the array is copied and each element
+ * retained here, and released by `freeSubkeyJobCtx`.
+ */
+typedef struct {
+  enum RedisCmd redisCommand;
+  size_t numFields;
+  RedisModuleString **fields;
+} SubkeyJobCtx;
+
+static void freeSubkeyJobCtx(void *pd) {
+  SubkeyJobCtx *jobCtx = pd;
+  for (size_t i = 0; i < jobCtx->numFields; ++i) {
+    RedisModule_FreeString(RSDummyContext, jobCtx->fields[i]);
+  }
+  rm_free(jobCtx->fields);
+  rm_free(jobCtx);
+}
+
+static void HandleSubkeyPerKeyJobFunc(RedisModuleCtx *ctx, RedisModuleString *key, void *pd) {
+  SubkeyJobCtx *jobCtx = pd;
+  HandleKeyspaceNotification(ctx, jobCtx->redisCommand, key, jobCtx->fields, jobCtx->numFields);
 }
 
 static bool ShouldDeferKeyspaceNotification(enum RedisCmd redisCommand) {
@@ -192,11 +211,55 @@ int KeySpaceNotificationCallback(RedisModuleCtx *ctx, int type, const char *even
     RS_LOG_ASSERT(rc == REDISMODULE_OK, "Failed to add post-notification job for key");
     return REDISMODULE_OK;
   }
-  return HandleKeyspaceNotification(ctx, redisCommand, key);
+  return HandleKeyspaceNotification(ctx, redisCommand, key, NULL, 0);
+}
+
+/**
+ * Hash notifications, carrying the fields the command modified.
+ *
+ * Registered only when the running Redis exposes subkey notifications, and only
+ * for `REDISMODULE_NOTIFY_HASH`. JSON and every other type keep
+ * `KeySpaceNotificationCallback`
+ *
+ * `subkeys` may contain duplicates: Redis does not dedupe them, and neither do
+ * we — a repeated field only costs a redundant comparison in the schema match.
+ */
+void KeySpaceNotificationWithSubkeysCallback(RedisModuleCtx *ctx, int type, const char *event,
+                                             RedisModuleString *key, RedisModuleString **subkeys,
+                                             int count) {
+  REDISMODULE_NOT_USED(type);
+  enum RedisCmd redisCommand = GetRedisCmd(event);
+  if (redisCommand == _null_cmd) {
+    return;
+  }
+
+  // Hash events are always deferred (ShouldDeferKeyspaceNotification only
+  // exempts _null_cmd / loaded / rename_from, none of which reach here), so the
+  // subkeys must outlive this callback.
+  RS_LOG_ASSERT(ShouldDeferKeyspaceNotification(redisCommand),
+                "hash subkey notifications are expected to be deferred");
+
+  SubkeyJobCtx *jobCtx = rm_new(SubkeyJobCtx);
+  jobCtx->redisCommand = redisCommand;
+  jobCtx->numFields = count > 0 ? (size_t)count : 0;
+  jobCtx->fields = jobCtx->numFields ? rm_malloc(jobCtx->numFields * sizeof(*jobCtx->fields)) : NULL;
+  for (size_t i = 0; i < jobCtx->numFields; ++i) {
+    RedisModule_RetainString(RSDummyContext, subkeys[i]);
+    jobCtx->fields[i] = subkeys[i];
+  }
+
+  int rc = RedisModule_AddPostNotificationJobForKey(ctx, HandleSubkeyPerKeyJobFunc, key, jobCtx,
+                                                   freeSubkeyJobCtx);
+  if (rc != REDISMODULE_OK) {
+    // The job never runs, so nothing else will release the payload.
+    freeSubkeyJobCtx(jobCtx);
+    RS_LOG_ASSERT(false, "Failed to add post-notification job for key");
+  }
 }
 
 int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
-                               RedisModuleString *key) {
+                               RedisModuleString *key, RedisModuleString **changedFields,
+                               size_t numChangedFields) {
 
   RedisModuleKey *kp;
   DocumentType kType;
@@ -211,7 +274,7 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
       // document we must copy it
       if (!IS_SST_RDB_LOADING(ctx)) {
         key = RedisModule_CreateStringFromString(ctx, key);
-        Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields); //TODO: avoid getDocTypeFromString ?
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), changedFields, numChangedFields); //TODO: avoid getDocTypeFromString ?
         RedisModule_FreeString(ctx, key);
       }
       break;
@@ -223,12 +286,12 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
     case hincrbyfloat_cmd:
     case hdel_cmd:
       if (!IS_SST_RDB_LOADING(ctx)) {
-        Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, changedFields, numChangedFields);
       }
       break;
     case hexpired_cmd:
       if (!SearchDisk_IsEnabled()) {
-        Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, changedFields, numChangedFields);
       } else {
         static bool hexpired_warned = false;
         if (!hexpired_warned && Indexes_Count() > 0) {
@@ -246,7 +309,7 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
       // the matching DMDs. Disk-backed indexes still take the full reindex
       // path until they grow an equivalent fast path.
       if (SearchDisk_IsEnabled()) {
-        Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), changedFields, numChangedFields);
       } else {
         Indexes_UpdateMatchingDocExpiration(ctx, key, getDocTypeFromString(key));
       }
@@ -254,7 +317,7 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
 
     case restore_cmd:
     case copy_to_cmd:
-      Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
+      Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), changedFields, numChangedFields);
       break;
 
     // Any RedisJSON write event reindexes the doc. Each command has its own enum
@@ -272,7 +335,7 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
     case json_arrpop_cmd:
     case json_arrtrim_cmd:
     case json_toggle_cmd:
-      Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Json, hashFields);
+      Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Json, changedFields, numChangedFields);
       break;
 
     case rename_from_cmd:
@@ -336,75 +399,13 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, enum RedisCmd redisCommand,
       }
       // todo: here we will open the key again, we can optimize it by
       //       somehow passing the key pointer
-      Indexes_UpdateMatchingWithSchemaRules(ctx, key, kType, hashFields);
+      Indexes_UpdateMatchingWithSchemaRules(ctx, key, kType, changedFields, numChangedFields);
       break;
   }
-
-  freeHashFields();
 
   return REDISMODULE_OK;
 }
 
-/*****************************************************************************/
-
-void CommandFilterCallback(RedisModuleCommandFilterCtx *filter) {
-  size_t len;
-  const RedisModuleString *cmd = RedisModule_CommandFilterArgGet(filter, 0);
-  const char *cmdStr = RedisModule_StringPtrLen(cmd, &len);
-  if (*cmdStr != 'H' && *cmdStr != 'h') {
-    return;
-  }
-
-  int numArgs = RedisModule_CommandFilterArgsCount(filter);
-  if (numArgs < 3) {
-    return;
-  }
-  int cmdFactor = 1;
-
-  // HSETNX does not fire keyspace event if hash exists. No need to keep fields
-  if (!strcasecmp("HSET", cmdStr) || !strcasecmp("HMSET", cmdStr) || !strcasecmp("HSETNX", cmdStr) ||
-      !strcasecmp("HINCRBY", cmdStr) || !strcasecmp("HINCRBYFLOAT", cmdStr)) {
-    if (numArgs % 2 != 0) return;
-    // HSET receives field&value, HDEL receives field
-    cmdFactor = 2;
-  } else if (!strcasecmp("HDEL", cmdStr)) {
-    // Nothing to do
-  } else {
-    // TODO: HEXPIRE/HPEXPIRE/HEXPIREAT/HPEXPIREAT/HPERSIST also carry an
-    // explicit `FIELDS numfields field [field ...]` list. Capturing it here
-    // (scan argv for the FIELDS keyword, parse numfields, retain each field)
-    // would let Indexes_UpdateMatchingHashFieldExpiration in src/spec.c skip
-    // specs whose schema does not reference any of the affected fields,
-    // saving a HashFieldMinExpire + per-indexed-field HashGet pass on wide
-    // schemas where HEXPIRE only touches unindexed fields.
-    return;
-  }
-
-  freeHashFields();
-
-  const RedisModuleString *keyStr = RedisModule_CommandFilterArgGet(filter, 1);
-  RedisModuleString *copyKeyStr = RedisModule_CreateStringFromString(RSDummyContext, keyStr);
-  int fieldsNum = 0;
-
-  RedisModuleKey *k = RedisModule_OpenKey(RSDummyContext, copyKeyStr, REDISMODULE_READ);
-  if (!k || RedisModule_KeyType(k) != REDISMODULE_KEYTYPE_HASH) {
-    // key does not exist or is not a hash, nothing to do
-    goto done;
-  }
-
-  fieldsNum = (numArgs - 2) / cmdFactor;
-  hashFields = (RedisModuleString **)rm_calloc(fieldsNum + 1, sizeof(*hashFields));
-
-  for (size_t i = 0; i < fieldsNum; ++i) {
-    RedisModuleString *field = (RedisModuleString *)RedisModule_CommandFilterArgGet(filter, 2 + i * cmdFactor);
-    RedisModule_RetainString(RSDummyContext, field);
-    hashFields[i] = field;
-  }
-
-done:
-  RedisModule_FreeString(RSDummyContext, copyKeyStr);
-  RedisModule_CloseKey(k);
-}
 
 // These events do not use ASM State Machine
 void ShardingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
@@ -773,6 +774,10 @@ void ConfigChangedCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t e
   }
 }
 
+bool HashSubkeyNotificationsSupported(void) {
+  return RedisModule_SubscribeToKeyspaceEventsWithSubkeys != NULL;
+}
+
 void Initialize_KeyspaceNotifications() {
   static bool RS_KeyspaceEvents_Initialized = false;
   if (!RS_KeyspaceEvents_Initialized) {
@@ -790,6 +795,23 @@ void Initialize_KeyspaceNotifications() {
     // Disk does not reshard today, and keeps the cheaper background path.
     if (!SearchDisk_IsEnabled()) {
       notifyFlags |= REDISMODULE_NOTIFY_KEY_TRIMMED;
+    }
+    // Take hash events over the subkey channel when the server has one: it names
+    // the fields the command touched, letting a spec that indexes none of them
+    // skip the reindex. Every hash event upstream carries subkeys, so hash moves
+    // off the plain subscription entirely rather than being served by both --
+    // subscribing twice would deliver each hash event to both callbacks and
+    // index it twice. SUBKEYS_REQUIRED drops any hash event that arrives without
+    // subkeys, which we could not act on anyway.
+    //
+    // The pointer is NULL against a Redis that predates subkey notifications
+    // (REDISMODULE_GET_API leaves it unset rather than failing the load); there
+    // hash stays on the plain path and reindexes unconditionally, as before.
+    if (RedisModule_SubscribeToKeyspaceEventsWithSubkeys) {
+      notifyFlags &= ~REDISMODULE_NOTIFY_HASH;
+      RedisModule_SubscribeToKeyspaceEventsWithSubkeys(
+          RSDummyContext, REDISMODULE_NOTIFY_HASH, REDISMODULE_NOTIFY_FLAG_SUBKEYS_REQUIRED,
+          KeySpaceNotificationWithSubkeysCallback);
     }
     RedisModule_SubscribeToKeyspaceEvents(RSDummyContext, notifyFlags, KeySpaceNotificationCallback);
     RS_KeyspaceEvents_Initialized = true;
@@ -1192,11 +1214,6 @@ void Initialize_ServerEventNotifications(RedisModuleCtx *ctx) {
   }
 }
 
-void Initialize_CommandFilter(RedisModuleCtx *ctx) {
-  if (RSGlobalConfig.filterCommands) {
-    RedisModule_RegisterCommandFilter(ctx, CommandFilterCallback, 0);
-  }
-}
 
 
 void ReplicaBackupCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -20,11 +20,30 @@ extern "C" {
 // they are must open its own window, or the close at POST_FORK finds it unpaired.
 bool DiskConsistencyWindow_IsIndexWindowOpen(void);
 
+/**
+ * Whether this server can tell us which fields a hash command touched, i.e. whether
+ * `Initialize_KeyspaceNotifications` will take the subkey channel for hash events.
+ *
+ * Reports the server capability rather than whether the subscription has happened,
+ * because the subscription is lazy — it waits for the first index — while callers
+ * need an answer that does not depend on when they ask.
+ *
+ * Against a Redis predating subkey notifications the module degrades silently to
+ * reindexing the whole document, so this is what distinguishes "the change set said
+ * nothing changed" from "there was no change set". Exposed for
+ * `_FT.DEBUG HASH_SUBKEY_NOTIFICATIONS`: without it a test for change-set-driven
+ * behavior cannot tell an unsupported server from a broken one, and neither can an
+ * operator.
+ */
+bool HashSubkeyNotificationsSupported(void);
+
 int KeySpaceNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
                                RedisModuleString *key);
+void KeySpaceNotificationWithSubkeysCallback(RedisModuleCtx *ctx, int type, const char *event,
+                                             RedisModuleString *key, RedisModuleString **subkeys,
+                                             int count);
 void Initialize_KeyspaceNotifications();
 void Initialize_ServerEventNotifications(RedisModuleCtx *ctx);
-void Initialize_CommandFilter(RedisModuleCtx *ctx);
 void Initialize_RdbNotifications(RedisModuleCtx *ctx);
 void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx);
 void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data);

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -20,8 +20,8 @@ use ffi::{
     QueryRequestTimeoutKind_QUERY_REQUEST_TIMEOUT_UNARMED, VecSearchMode, VecSearchMode_EMPTY_MODE,
     VecSimAlgo_VecSimAlgo_BF, VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex, VecSimIndex_AddVector,
     VecSimIndex_Free, VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine,
-    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
-    t_docId,
+    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQuantType_VecSimQuant_NONE,
+    VecSimQueryParams, VecSimType_VecSimType_FLOAT32, t_docId,
 };
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use top_k::Ascending;
@@ -105,6 +105,8 @@ impl TestIndex {
                     efConstruction: 100,
                     efRuntime: 0,
                     epsilon: 0.0,
+                    quantType: VecSimQuantType_VecSimQuant_NONE,
+                    quantParams: ptr::null(),
                 },
             },
             logCtx: ptr::null_mut(),

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -47,7 +47,8 @@ use ffi::{
     HNSWParams, QueryRequestTimeout, QueryRequestTimeoutKind_QUERY_REQUEST_TIMEOUT_UNARMED,
     VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES, VecSimAlgo_VecSimAlgo_HNSWLIB,
     VecSimIndex, VecSimIndex_AddVector, VecSimIndex_Free, VecSimIndex_New,
-    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
+    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQuantType_VecSimQuant_NONE,
+    VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
 };
 use rqe_iterators::{IdList, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
@@ -102,6 +103,8 @@ unsafe fn make_index(n: usize) -> *mut VecSimIndex {
                 efConstruction: 200,
                 efRuntime: 10,
                 epsilon: 0.01,
+                quantType: VecSimQuantType_VecSimQuant_NONE,
+                quantParams: std::ptr::null(),
             },
         },
         logCtx: std::ptr::null_mut(),

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -282,6 +282,11 @@ This flag should not be used directly by the module.
 #define REDISMODULE_NOTIFY_TO_SUBSCRIBER_MODULES (1<<0)
 #define REDISMODULE_NOTIFY_TO_SUBSCRIBER_CLIENTS (1<<1)
 
+/* Delivery flags for RM_SubscribeToKeyspaceEventsWithSubkeys.
+ * These are passed in the 'flags' parameter, not in 'types'. */
+#define REDISMODULE_NOTIFY_FLAG_NONE 0                  /* Invoke callback for all matching events */
+#define REDISMODULE_NOTIFY_FLAG_SUBKEYS_REQUIRED (1<<0) /* Only invoke callback when subkeys are present */
+
 /* A special pointer that we can use between the core and the module to signal
  * field deletion, and that is impossible to be a valid pointer. */
 #define REDISMODULE_HASH_DELETE ((RedisModuleString*)(long)1)
@@ -1174,6 +1179,7 @@ typedef struct RedisModuleConfigIterator RedisModuleConfigIterator;
 typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 typedef void (*RedisModuleDisconnectFunc)(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc);
 typedef int (*RedisModuleNotificationFunc)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key);
+typedef void (*RedisModuleNotificationWithSubkeysFunc)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key, RedisModuleString **subkeys, int count);
 typedef void (*RedisModulePostNotifyJobFunc) (RedisModuleCtx *ctx, void *pd);
 typedef void (*RedisModulePostNotifyJobPerKeyFunc) (RedisModuleCtx *ctx, RedisModuleString *key, void *pd);
 /* Backward-compatible alias for the original (pre-rename) name. */
@@ -1655,6 +1661,9 @@ REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx)
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnsubscribeFromKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEventsWithSubkeys)(RedisModuleCtx *ctx, int types, int flags, RedisModuleNotificationWithSubkeysFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_UnsubscribeFromKeyspaceEventsWithSubkeys)(RedisModuleCtx *ctx, int types, int flags, RedisModuleNotificationWithSubkeysFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_NotifyKeyspaceEventWithSubkeys)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key, RedisModuleString **subkeys, int count) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AddPostNotificationJob)(RedisModuleCtx *ctx, RedisModulePostNotifyJobFunc callback, void *pd, void (*free_pd)(void*)) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AddPostNotificationJobForKey)(RedisModuleCtx *ctx, RedisModulePostNotifyJobPerKeyFunc callback, RedisModuleString *key, void *pd, void (*free_pd)(void*)) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
@@ -2129,6 +2138,9 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(SetDisconnectCallback);
     REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
     REDISMODULE_GET_API(UnsubscribeFromKeyspaceEvents);
+    REDISMODULE_GET_API(SubscribeToKeyspaceEventsWithSubkeys);
+    REDISMODULE_GET_API(UnsubscribeFromKeyspaceEventsWithSubkeys);
+    REDISMODULE_GET_API(NotifyKeyspaceEventWithSubkeys);
     REDISMODULE_GET_API(AddPostNotificationJob);
     REDISMODULE_GET_API(AddPostNotificationJobForKey);
     REDISMODULE_GET_API(NotifyKeyspaceEvent);

--- a/src/spec.c
+++ b/src/spec.c
@@ -3572,8 +3572,8 @@ int CompareVersions(Version v1, Version v2) {
  * re-adding the blob.
  *
  * With a change set, absence from it settles the question — `ChangedField_VerifiedNo`. Compares
- * against `fieldPath`, the hash field the command wrote, for the same reason
- * `hashFieldChanged` does.
+ * against `fieldPath`, the hash field the command wrote, rather than `fieldName`, which is the
+ * `AS` alias and would match nothing on an aliased schema.
  *
  * Without one, every vector field is marked `ChangedField_Unverified`: the question is
  * deferred to `Indexer_HandleReplacedDocVectorAndGeometry`, which compares the field's new

--- a/src/spec.c
+++ b/src/spec.c
@@ -3580,6 +3580,9 @@ int CompareVersions(Version v1, Version v2) {
  * value against what the index is holding. This is the JSON path (RedisJSON's API cannot
  * report a change set), and also a background scan or a hash on a server without subkey
  * notifications.
+ *
+ * Nothing is marked for a disk-backed spec: the disk vector index cannot move an entry, so every
+ * field would take the delete + re-add path anyway. See the body.
  */
 static void AddDocumentCtx_MarkForRelabel(RSAddDocumentCtx *aCtx, const IndexSpec *spec,
                                            RedisModuleString **changedFields,
@@ -3588,6 +3591,14 @@ static void AddDocumentCtx_MarkForRelabel(RSAddDocumentCtx *aCtx, const IndexSpe
     return;
   }
   if (!(spec->flags & Index_HasVecSim)) {
+    return;
+  }
+  if (spec->diskSpec) {
+    // A disk-backed vector field cannot move an entry, so marking one only buys a refusal.
+    // `HNSWDiskIndex` does not implement `relabelVector` (MOD-18101), and its `getDataByLabel`
+    // exists only in test builds, so neither the change-set nor the comparison path can be
+    // served: `VectorIndex_CheckRemoveId` would read nothing, conclude "changed", and delete.
+    // Same outcome as not marking, reached after a wasted comparison per field per update.
     return;
   }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -3566,8 +3566,74 @@ int CompareVersions(Version v1, Version v2) {
 }
 
 
+/**
+ * Mark each VECTOR field whose value this update may not have touched, so the
+ * indexer moves its existing entry onto the new doc-id instead of deleting and
+ * re-adding the blob.
+ *
+ * With a change set, absence from it settles the question — `ChangedField_VerifiedNo`. Compares
+ * against `fieldPath`, the hash field the command wrote, for the same reason
+ * `hashFieldChanged` does.
+ *
+ * Without one, every vector field is marked `ChangedField_Unverified`: the question is
+ * deferred to `Indexer_HandleReplacedDocVectorAndGeometry`, which compares the field's new
+ * value against what the index is holding. This is the JSON path (RedisJSON's API cannot
+ * report a change set), and also a background scan or a hash on a server without subkey
+ * notifications.
+ */
+static void AddDocumentCtx_MarkForRelabel(RSAddDocumentCtx *aCtx, const IndexSpec *spec,
+                                           RedisModuleString **changedFields,
+                                           size_t numChangedFields) {
+  if (!RSGlobalConfig.enableUnstableFeatures) {
+    return;
+  }
+  if (!(spec->flags & Index_HasVecSim)) {
+    return;
+  }
+
+  const Document *doc = aCtx->doc;
+  for (size_t ii = 0; ii < doc->numFields; ++ii) {
+    const FieldSpec *fs = aCtx->fspecs + ii;
+    // Only mark a field the vector-insert site will actually visit: the relabeling
+    // runs there, and `Indexer_HandleReplacedDocVectorAndGeometry` skips a marked
+    // field's delete. A mark that never reaches an insert would strand the old entry
+    // under the old doc-id.
+    // `indexAs` is already resolved here — `AddDocumentCtx_SetDocument` defaults it
+    // to `fs->types` — and skipped fields (not in the schema) leave fieldName NULL.
+    //
+    // `fdata->isNull` is the one insert-site skip this cannot mirror, because
+    // `vectorPreprocessor` has not run yet and `fdatas` is still zeroed.
+    // `Indexer_HandleReplacedDocVectorAndGeometry` checks it once the preprocessors have
+    // run, which is what keeps the invariant true for a JSON document that dropped its
+    // vector field.
+    if (!fs->fieldName || !FieldSpec_IsIndexable(fs) ||
+        !(doc->fields[ii].indexAs & INDEXFLD_T_VECTOR)) {
+      continue;
+    }
+    // An absent change set says nothing; a present one is a positive statement about
+    // every field it does not name, including when it names none.
+    ChangedField mark = changedFields ? ChangedField_VerifiedNo : ChangedField_Unverified;
+    for (size_t i = 0; i < numChangedFields; ++i) {
+      size_t length = 0;
+      const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
+      if (!HiddenString_CompareC(fs->fieldPath, field, length)) {
+        mark = ChangedField_VerifiedYes;  // named in the change set: the value was written
+        break;
+      }
+    }
+    if (mark == ChangedField_VerifiedYes) {
+      continue;  // nothing to record: an unmarked field already reads this way
+    }
+    if (!aCtx->fieldChanges) {
+      aCtx->fieldChanges = rm_calloc(spec->numFields, sizeof(*aCtx->fieldChanges));
+    }
+    aCtx->fieldChanges[fs->index] = mark;
+  }
+}
+
 int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
-                        DocumentType type, RedisModuleKey *openKey) {
+                        DocumentType type, RedisModuleKey *openKey,
+                        RedisModuleString **changedFields, size_t numChangedFields) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
 
   if (!spec->rule) {
@@ -3627,6 +3693,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   aCtx->stateFlags |= ACTX_F_NOFREEDOC;
   // Reuse the caller's open key handle for the DocIdMeta update, if provided.
   aCtx->disk.openKey = openKey;
+  AddDocumentCtx_MarkForRelabel(aCtx, spec, changedFields, numChangedFields);
   AddDocumentCtx_Submit(aCtx, &sctx, DOCUMENT_ADD_REPLACE);
 
   Document_Free(&doc);

--- a/src/spec.c
+++ b/src/spec.c
@@ -3622,14 +3622,19 @@ static void AddDocumentCtx_MarkForRelabel(RSAddDocumentCtx *aCtx, const IndexSpe
       continue;
     }
     // An absent change set says nothing; a present one is a positive statement about
-    // every field it does not name, including when it names none.
-    ChangedField mark = changedFields ? ChangedField_VerifiedNo : ChangedField_Unverified;
-    for (size_t i = 0; i < numChangedFields; ++i) {
-      size_t length = 0;
-      const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
-      if (!HiddenString_CompareC(fs->fieldPath, field, length)) {
-        mark = ChangedField_VerifiedYes;  // named in the change set: the value was written
-        break;
+    // every field it does not name, including when it names none. Scanning inside the
+    // non-NULL branch keeps `numChangedFields` from being trusted on its own -- callers
+    // pair a NULL array with a zero count, and this does not depend on them doing so.
+    ChangedField mark = ChangedField_Unverified;
+    if (changedFields) {
+      mark = ChangedField_VerifiedNo;
+      for (size_t i = 0; i < numChangedFields; ++i) {
+        size_t length = 0;
+        const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
+        if (!HiddenString_CompareC(fs->fieldPath, field, length)) {
+          mark = ChangedField_VerifiedYes;  // named in the change set: the value was written
+          break;
+        }
       }
     }
     if (mark == ChangedField_VerifiedYes) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -3621,21 +3621,15 @@ static void AddDocumentCtx_MarkForRelabel(RSAddDocumentCtx *aCtx, const IndexSpe
         !(doc->fields[ii].indexAs & INDEXFLD_T_VECTOR)) {
       continue;
     }
-    // An absent change set says nothing; a present one is a positive statement about
-    // every field it does not name, including when it names none. Scanning inside the
-    // non-NULL branch keeps `numChangedFields` from being trusted on its own -- callers
-    // pair a NULL array with a zero count, and this does not depend on them doing so.
+    // An absent change set says nothing; a present one is a positive statement about every
+    // field it does not name, including when it names none. `FieldSpec_IsInChangeSet` answers
+    // false for both "absent" and "present but does not name this field", so the change set
+    // has to be tested separately to tell those apart.
     ChangedField mark = ChangedField_Unverified;
     if (changedFields) {
-      mark = ChangedField_VerifiedNo;
-      for (size_t i = 0; i < numChangedFields; ++i) {
-        size_t length = 0;
-        const char *field = RedisModule_StringPtrLen(changedFields[i], &length);
-        if (!HiddenString_CompareC(fs->fieldPath, field, length)) {
-          mark = ChangedField_VerifiedYes;  // named in the change set: the value was written
-          break;
-        }
-      }
+      mark = FieldSpec_IsInChangeSet(fs, changedFields, numChangedFields)
+                 ? ChangedField_VerifiedYes  // named in the change set: the value was written
+                 : ChangedField_VerifiedNo;
     }
     if (mark == ChangedField_VerifiedYes) {
       continue;  // nothing to record: an unmarked field already reads this way

--- a/src/spec.h
+++ b/src/spec.h
@@ -644,8 +644,11 @@ const RSDocumentMetadata *IndexSpec_BorrowDocByKeyR(IndexSpec *sp, RedisModuleCt
 // callback) so the DocIdMeta update can reuse the handle instead of reopening
 // the key by name; pass NULL otherwise. The caller retains ownership of
 // `openKey` and must keep it valid for the duration of the call.
+// `changedFields` / `numChangedFields` name the fields the originating command
+// modified (NULL / 0 when unknown);
 int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
-                        DocumentType type, RedisModuleKey *openKey);
+                        DocumentType type, RedisModuleKey *openKey,
+                        RedisModuleString **changedFields, size_t numChangedFields);
 
 // Format the legacy (separate-key) Redis key name for a numeric/tag/geo field.
 RedisModuleString *IndexSpec_LegacyGetFormattedKey(IndexSpec *sp, const FieldSpec *fs,

--- a/src/vector_compare/CMakeLists.txt
+++ b/src/vector_compare/CMakeLists.txt
@@ -1,0 +1,8 @@
+# The comparison has to be C++: VecSim exposes stored vectors through `getDataByLabel`, a
+# template method no C caller can name. Kept in its own library, like src/geometry, so it
+# inherits VecSim's include paths and C++ standard instead of imposing them on rscore -- which
+# is otherwise a pure-C target.
+set(CMAKE_CXX_STANDARD 20)
+
+add_library(redisearch-vector-compare STATIC vector_compare.cpp)
+target_link_libraries(redisearch-vector-compare PUBLIC VectorSimilarity)

--- a/src/vector_compare/vector_compare.cpp
+++ b/src/vector_compare/vector_compare.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "vector_compare.h"
+
+#include "VecSim/vec_sim_index.h"
+#include "VecSim/vec_sim_tiered_index.h"
+#include "VecSim/types/bfloat16.h"
+#include "VecSim/types/float16.h"
+
+#include <vector>
+
+namespace {
+
+/**
+ * Compare the vector(s) stored under `label` against `blobs`.
+ *
+ * `getDataByLabel` is typed while the index handle is not, so the caller below dispatches on
+ * the index's data type -- the same shape `VecSimDebug_GetElementNeighborsInHNSWGraph` uses
+ * for the same reason.
+ *
+ * A cosine index stores the blob normalized, so a copy is normalized before comparing;
+ * without that, an unchanged vector would compare unequal every time. Only the elements take
+ * part: `getDataByLabel` omits any trailing norm, and the norm is a function of the elements
+ * anyway.
+ */
+template <typename DataType, typename DistType>
+bool holdsVectors(VecSimIndex *index, const VecSimIndexBasicInfo &info, size_t label,
+                  const void *blobs, size_t numBlobs) {
+  std::vector<std::vector<DataType>> stored;
+  if (info.isTiered) {
+    dynamic_cast<VecSimTieredIndex<DataType, DistType> *>(index)->getDataByLabel(label, stored);
+  } else {
+    dynamic_cast<VecSimIndexAbstract<DataType, DistType> *>(index)->getDataByLabel(label, stored);
+  }
+  // Absent, or holding a different number of vectors than the caller offers.
+  if (stored.size() != numBlobs) {
+    return false;
+  }
+
+  const size_t elementsSize = info.dim * sizeof(DataType);
+  const bool normalize = info.metric == VecSimMetric_Cosine;
+  std::vector<char> scratch(
+      normalize ? VecSimParams_GetQueryBlobSize(info.type, info.dim, info.metric) : 0);
+
+  const char *blob = static_cast<const char *>(blobs);
+  for (size_t i = 0; i < numBlobs; ++i, blob += elementsSize) {
+    const void *comparand = blob;
+    if (normalize) {
+      memcpy(scratch.data(), blob, elementsSize);
+      VecSim_Normalize(scratch.data(), info.dim, info.type);
+      comparand = scratch.data();
+    }
+    if (memcmp(stored[i].data(), comparand, elementsSize) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+extern "C" bool VectorIndex_HoldsVectors(VecSimIndex *index, size_t label, const void *blobs,
+                                         size_t numBlobs) {
+  if (!index || !blobs || numBlobs == 0) {
+    return false;
+  }
+  const VecSimIndexBasicInfo info = index->basicInfo();
+  switch (info.type) {
+    case VecSimType_FLOAT32:
+      return holdsVectors<float, float>(index, info, label, blobs, numBlobs);
+    case VecSimType_FLOAT64:
+      return holdsVectors<double, double>(index, info, label, blobs, numBlobs);
+    case VecSimType_BFLOAT16:
+      return holdsVectors<vecsim_types::bfloat16, float>(index, info, label, blobs, numBlobs);
+    case VecSimType_FLOAT16:
+      return holdsVectors<vecsim_types::float16, float>(index, info, label, blobs, numBlobs);
+    case VecSimType_INT8:
+      return holdsVectors<int8_t, float>(index, info, label, blobs, numBlobs);
+    case VecSimType_UINT8:
+      return holdsVectors<uint8_t, float>(index, info, label, blobs, numBlobs);
+    default:
+      // A data type this function has not been taught: reindex rather than guess.
+      return false;
+  }
+}

--- a/src/vector_compare/vector_compare.h
+++ b/src/vector_compare/vector_compare.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#pragma once
+
+#include "VecSim/vec_sim.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Whether `label` in `index` already holds exactly the vector(s) in `blobs`, i.e. whether
+ * adding them under `label` would leave the index unchanged.
+ *
+ * Lets an update that replaces a document skip re-adding a vector that did not change and
+ * move the existing entry to the document's new doc-id instead. See
+ * `VectorIndex_RelabelField`.
+ *
+ * Compares the *stored* bytes, having first put each blob through the same normalization an
+ * insert would apply, so a cosine index -- which stores vectors normalized -- is answered
+ * correctly rather than reported as changed every time.
+ *
+ * Answers false whenever the vectors differ **or the comparison cannot be made**: a lossy
+ * storage that cannot reproduce the input, or a count that does not match what the label
+ * holds. False is always the safe answer, costing a delete + re-add that could have been
+ * avoided; a wrong true would leave a stale vector answering queries.
+ *
+ * Lives in a C++ translation unit because VecSim exposes stored vectors through
+ * `getDataByLabel`, a template method that no C caller can name.
+ *
+ * @param index the index to inspect.
+ * @param label the label to inspect.
+ * @param blobs `numBlobs` contiguous binary vectors, each of the index's input blob size.
+ * @param numBlobs how many vectors `blobs` holds; must match what `label` stores for the
+ *        answer to be true.
+ */
+bool VectorIndex_HoldsVectors(VecSimIndex *index, size_t label, const void *blobs,
+                              size_t numBlobs);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -8,6 +8,8 @@
 */
 #include "vector_index.h"
 
+#include "info/global_stats.h"
+
 #include <string.h>
 // __GLIBC__; glibc-only header
 #if __has_include(<features.h>)
@@ -71,6 +73,27 @@ bool isLVQSupported() {
 #endif
   return false; // In which case we know that LVQ not supported.
 }
+// Contract documented on the declaration in vector_index.h.
+bool VectorIndex_RelabelField(VecSimIndex *vecsim, t_docId oldDocId, t_docId newDocId) {
+  const VecSimRelabelCode rc = VecSimIndex_RelabelVector(vecsim, oldDocId, newDocId);
+  // `SameLabel` is a success for this caller, not a refusal. Memory mode never hits it
+  // (doc-ids are monotonic), but a doc-table that reuses the id on replace would.
+  if (rc == VecSimRelabel_OK || rc == VecSimRelabel_SameLabel) {
+    FieldsGlobalStats_UpdateFieldDocsRelabeled(INDEXFLD_T_VECTOR, 1);
+    return true;
+  }
+
+  // Fall back to delete + re-add. `VectorIndex_CheckRemoveId` skipped this field's delete on
+  // the strength of the mark, so it has to happen here before the caller inserts.
+  VecSimIndex_DeleteVector(vecsim, oldDocId);
+  if (rc == VecSimRelabel_NewLabelTaken) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "Vector relabel %llu -> %llu refused: target label already in use",
+                    (unsigned long long)oldDocId, (unsigned long long)newDocId);
+  }
+  return false;
+}
+
 
 VecSimIndex *openVectorIndex(RedisModuleCtx *ctx, FieldSpec *fieldSpec, bool create_if_missing) {
   RS_ASSERT(FIELD_IS(fieldSpec, INDEXFLD_T_VECTOR));

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -150,6 +150,18 @@ typedef struct VecSimLogCtx {
 
 VecSimIndex *openVectorIndex(RedisModuleCtx *ctx, FieldSpec *fs, bool create_if_missing);
 
+/**
+ * Move the vector(s) stored under `oldDocId` onto `newDocId`, for a field whose value this
+ * update did not change — see `AddDocumentCtx_ShouldRelabelField`, which is what the
+ * vector-insert sites check before calling this.
+ *
+ * Returns whether the entry was moved, i.e. whether the caller should skip its insert. On a
+ * refusal the old entry is dropped here, so the caller can insert into a clean label: VecSim
+ * refuses when the index type does not implement relabeling (SVS), when the old label holds
+ * nothing, and when the new label is already taken.
+ */
+bool VectorIndex_RelabelField(VecSimIndex *vecsim, t_docId oldDocId, t_docId newDocId);
+
 QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator *child_it);
 
 int VectorQuery_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -32,7 +32,8 @@ extern "C" {
 #include <stdio.h>
 
 extern "C" int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
-                                   DocumentType type, RedisModuleKey *openKey);
+                                   DocumentType type, RedisModuleKey *openKey,
+                                   RedisModuleString **changedFields, size_t numChangedFields);
 
 
 #define QUERY_PARSE_CTX(ctx, qt, opts) NewQueryParseCtx(&ctx, qt, strlen(qt), &opts);
@@ -131,7 +132,7 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
 
   ASSERT_TRUE(RMCK::hset(redisCtx, "doc:1", "title", "hello"));
   ASSERT_TRUE(RMCK::hset(redisCtx, "doc:1", "vec_field", "abcdefghijklmnop", false));
-  ASSERT_EQ(IndexSpec_UpdateDoc(ctx.spec, redisCtx, RMCK::RString("doc:1"), DocumentType_Hash, NULL), REDISMODULE_OK);
+  ASSERT_EQ(IndexSpec_UpdateDoc(ctx.spec, redisCtx, RMCK::RString("doc:1"), DocumentType_Hash, NULL, NULL, 0), REDISMODULE_OK);
 
   ASSERT_NE(openVectorIndex(redisCtx, &ctx.spec->fields[1], DONT_CREATE_INDEX), nullptr);
 

--- a/tests/cpptests/test_cpp_reindex_skip.cpp
+++ b/tests/cpptests/test_cpp_reindex_skip.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Tests for the reindex skip in `Indexes_UpdateMatchingWithSchemaRules`.
+//
+// Subkey notifications name the fields a command wrote, which lets an update that touches
+// nothing the index reads be dropped instead of reindexing the document. Every condition
+// guarding that decision, wrong in the permissive direction, silently loses indexed data,
+// and the failure is invisible until someone queries for what went missing. So each
+// condition gets its own test.
+//
+// These drive the public dispatcher rather than the static gate itself, which also covers
+// the wiring: a gate that is correct but never consulted, or consulted with the wrong
+// arguments, fails here too.
+//
+// The observable throughout is the doc-id. Indexing a document again gives it a new one, so
+// an unchanged doc-id means the update was skipped and a higher one means it was not.
+
+#include "gtest/gtest.h"
+#include "redismock/redismock.h"
+#include "redismock/util.h"
+
+#include "spec.h"
+#include "indexes.h"
+#include "doc_id_meta.h"
+
+#include <string>
+#include <vector>
+
+class ReindexSkipTest : public ::testing::Test {
+protected:
+  RedisModuleCtx *ctx = nullptr;
+  IndexSpec *spec = nullptr;
+  std::string indexName;
+
+  void SetUp() override {
+    ctx = RedisModule_GetThreadSafeContext(nullptr);
+    RMCK::flushdb(ctx);
+    static int counter = 0;
+    indexName = "skipidx" + std::to_string(++counter);
+  }
+
+  void TearDown() override {
+    if (ctx) {
+      RedisModule_FreeThreadSafeContext(ctx);
+      ctx = nullptr;
+    }
+  }
+
+  // `extraArgs` go between the index name and SCHEMA, for rule options such as FILTER or
+  // SCORE_FIELD. The schema is always a single TEXT field named `title`.
+  void createIndex(const std::vector<std::string> &extraArgs = {}) {
+    std::vector<std::string> args = {"FT.CREATE", indexName, "ON", "HASH"};
+    args.insert(args.end(), extraArgs.begin(), extraArgs.end());
+    args.insert(args.end(), {"SCHEMA", "title", "TEXT"});
+
+    QueryError err = QueryError_Default();
+    RMCK::ArgvList argv(ctx, args);
+    spec = Indexes_CreateNewSpec(ctx, argv, argv.size(), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+    ASSERT_TRUE(spec != nullptr);
+  }
+
+  t_docId docIdOf(const char *key) {
+    uint64_t docId = 0;
+    if (DocIdMeta_Get(ctx, RMCK::RString(key), spec->specId, &docId) != REDISMODULE_OK) {
+      return 0;
+    }
+    return (t_docId)docId;
+  }
+
+  // Run the update the way a keyspace notification would, naming `changed` as the fields the
+  // command wrote. An empty `changed` means no change set at all -- what a server without
+  // subkey notifications, a JSON document or a background scan delivers -- which is a
+  // different statement from a change set that happens to name nothing.
+  void notifyUpdate(const char *key, const std::vector<std::string> &changed) {
+    std::vector<RedisModuleString *> fields;
+    for (const std::string &f : changed) {
+      fields.push_back(RedisModule_CreateString(nullptr, f.c_str(), f.size()));
+    }
+    Indexes_UpdateMatchingWithSchemaRules(ctx, RMCK::RString(key), DocumentType_Hash,
+                                         fields.empty() ? nullptr : fields.data(), fields.size());
+    for (RedisModuleString *f : fields) {
+      RedisModule_FreeString(nullptr, f);
+    }
+  }
+};
+
+// A field the schema does not mention cannot change anything the index holds for a document
+// it already has, so the update is dropped. This is the one case the skip exists for; every
+// other test here is a case where it must not fire.
+TEST_F(ReindexSkipTest, unindexedFieldChangeIsSkipped) {
+  createIndex();
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  notifyUpdate("doc:1", {"title"});
+  const t_docId first = docIdOf("doc:1");
+  ASSERT_NE(first, 0u);
+
+  RMCK::hset(ctx, "doc:1", "unread", "x");
+  notifyUpdate("doc:1", {"unread"});
+  EXPECT_EQ(docIdOf("doc:1"), first);
+}
+
+TEST_F(ReindexSkipTest, schemaFieldChangeReindexes) {
+  createIndex();
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  notifyUpdate("doc:1", {"title"});
+  const t_docId first = docIdOf("doc:1");
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  notifyUpdate("doc:1", {"title"});
+  EXPECT_GT(docIdOf("doc:1"), first);
+}
+
+// A document the index does not hold yet has to be indexed however little the write touched:
+// a hash matching the prefix is a document whether or not it carries an indexed field, and
+// `*`, result counts and `ismissing()` all depend on it being registered.
+TEST_F(ReindexSkipTest, unseenDocumentIsIndexedEvenWithNoIndexedFieldChanged) {
+  createIndex();
+  RMCK::hset(ctx, "doc:1", "unread", "x");
+  notifyUpdate("doc:1", {"unread"});
+  EXPECT_NE(docIdOf("doc:1"), 0u) << "a document absent from the index must be indexed";
+}
+
+// A rule FILTER may test a field the schema never mentions, and its verdict flips when that
+// field changes, so a spec carrying one can never skip. Here the verdict does not flip: the
+// document stays indexed, and the proof the update was not dropped is a new doc-id.
+TEST_F(ReindexSkipTest, filterExpressionDisablesTheSkip) {
+  createIndex({"FILTER", "@indexme!='no'"});
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  RMCK::hset(ctx, "doc:1", "indexme", "yes");
+  notifyUpdate("doc:1", {"title", "indexme"});
+  const t_docId first = docIdOf("doc:1");
+  ASSERT_NE(first, 0u);
+
+  // `indexme` is not in the schema, so without the FILTER check this would be skipped.
+  // Still not "no", so the document remains a match either way.
+  RMCK::hset(ctx, "doc:1", "indexme", "maybe");
+  notifyUpdate("doc:1", {"indexme"});
+  EXPECT_GT(docIdOf("doc:1"), first);
+}
+
+// The write makes the rule stop matching, so the document has to leave the index.
+//
+// Unlike its neighbours this one does not exercise the gate, and deliberately survives having
+// every guard in it removed: a rule that no longer matches sends the dispatcher down its
+// SpecOp_Del branch, which is not gated on the change set at all. What it pins is that the
+// branch stays ungated -- gating a delete on "no indexed field changed" would leave the
+// document queryable on the strength of a filter that no longer holds.
+TEST_F(ReindexSkipTest, filterTurningFalseRemovesTheDocument) {
+  createIndex({"FILTER", "@indexme!='no'"});
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  RMCK::hset(ctx, "doc:1", "indexme", "yes");
+  notifyUpdate("doc:1", {"title", "indexme"});
+  ASSERT_NE(docIdOf("doc:1"), 0u);
+
+  RMCK::hset(ctx, "doc:1", "indexme", "no");
+  notifyUpdate("doc:1", {"indexme"});
+  EXPECT_EQ(docIdOf("doc:1"), 0u) << "the rule no longer matches, so the document must be gone";
+}
+
+// SCORE_FIELD, LANGUAGE_FIELD and PAYLOAD_FIELD are read off the document without appearing
+// in the schema. Three independent comparisons in the gate, so three cases: dropping any one
+// of them leaves the doc-table entry holding a stale score, language or payload.
+TEST_F(ReindexSkipTest, ruleFieldChangeReindexes) {
+  createIndex({"SCORE_FIELD", "__score", "LANGUAGE_FIELD", "__language", "PAYLOAD_FIELD",
+               "__payload"});
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  RMCK::hset(ctx, "doc:1", "__score", "1");
+  RMCK::hset(ctx, "doc:1", "__language", "english");
+  RMCK::hset(ctx, "doc:1", "__payload", "p0");
+  notifyUpdate("doc:1", {"title"});
+  t_docId previous = docIdOf("doc:1");
+  ASSERT_NE(previous, 0u);
+
+  // Values a document would plausibly carry: a bad language logs a warning and tells us
+  // nothing about the skip.
+  const std::vector<std::pair<const char *, const char *>> writes = {
+      {"__score", "0.5"}, {"__language", "french"}, {"__payload", "p1"}};
+  for (const auto &[field, value] : writes) {
+    RMCK::hset(ctx, "doc:1", field, value);
+    notifyUpdate("doc:1", {field});
+    const t_docId now = docIdOf("doc:1");
+    EXPECT_GT(now, previous) << "writing " << field << " must reindex the document";
+    previous = now;
+  }
+}
+
+// No change set is not a statement that nothing changed -- it is the absence of one, and the
+// document has to be reindexed. This is the path JSON, background scans and servers without
+// subkey notifications take.
+TEST_F(ReindexSkipTest, absentChangeSetNeverSkips) {
+  createIndex();
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  notifyUpdate("doc:1", {});
+  const t_docId first = docIdOf("doc:1");
+  ASSERT_NE(first, 0u);
+
+  RMCK::hset(ctx, "doc:1", "unread", "x");
+  notifyUpdate("doc:1", {});
+  EXPECT_GT(docIdOf("doc:1"), first) << "without a change set there is nothing to skip on";
+}

--- a/tests/cpptests/test_cpp_vector_relabel.cpp
+++ b/tests/cpptests/test_cpp_vector_relabel.cpp
@@ -41,13 +41,13 @@ extern "C" int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisMo
                                    RedisModuleString **changedFields, size_t numChangedFields);
 
 // FLOAT32 DIM 4 -- the blob is 16 bytes, matching expBlobSize.
-static const char *kVecA = "aaaabbbbccccdddd";
-static const char *kVecB = "eeeeffffgggghhhh";
+static const char *const kVecA = "aaaabbbbccccdddd";
+static const char *const kVecB = "eeeeffffgggghhhh";
 // Read as four float32s, kVecA and kVecB happen to be nearly parallel (their
 // components share a ~1:4:16:64 ratio), so cosine cannot tell them apart -- the
 // distance between them is 2e-10. kVecC is kVecA byte-reversed, which keeps the same
 // magnitudes but puts it 0.94 away under cosine. Use it wherever direction matters.
-static const char *kVecC = "ddddccccbbbbaaaa";
+static const char *const kVecC = "ddddccccbbbbaaaa";
 
 class VectorRelabelTest : public ::testing::Test {
 protected:
@@ -166,7 +166,7 @@ protected:
   // The strings are built directly rather than via RMCK::RString: that is a
   // scope guard whose destructor frees the string, so collecting temporaries
   // into a vector would leave it holding freed pointers.
-  t_docId reindexWithChangeSet(const char *key, std::vector<std::string> changed) {
+  t_docId reindexWithChangeSet(const char *key, const std::vector<std::string> &changed) {
     std::vector<RedisModuleString *> fields;
     for (const std::string &f : changed) {
       fields.push_back(RedisModule_CreateString(nullptr, f.c_str(), f.size()));

--- a/tests/cpptests/test_cpp_vector_relabel.cpp
+++ b/tests/cpptests/test_cpp_vector_relabel.cpp
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Relabeling an unchanged vector onto a document's new doc-id, instead of
+// deleting the entry and re-adding the blob (MOD-17688).
+//
+// The optimization is driven by the change set a hash subkey notification
+// carries, so these tests call IndexSpec_UpdateDoc with that set directly rather
+// than going through a keyspace notification: the SKN path needs a server that
+// emits subkeys, and what is under test here is the indexer's response to the
+// set, not how the set is obtained.
+
+#include "gtest/gtest.h"
+#include "redismock/redismock.h"
+#include "redismock/util.h"
+
+#include "spec.h"
+#include "indexes.h"
+#include "doc_id_meta.h"
+#include "VecSim/vec_sim.h"
+
+// `openVectorIndex` is declared outside vector_index.h's own extern "C" block.
+extern "C" {
+#include "vector_index.h"
+#include "redis_index.h"
+#include "vector_compare/vector_compare.h"
+}
+
+#include <array>
+#include <cmath>
+#include <string>
+
+extern "C" int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
+                                   DocumentType type, RedisModuleKey *openKey,
+                                   RedisModuleString **changedFields, size_t numChangedFields);
+
+// FLOAT32 DIM 4 -- the blob is 16 bytes, matching expBlobSize.
+static const char *kVecA = "aaaabbbbccccdddd";
+static const char *kVecB = "eeeeffffgggghhhh";
+// Read as four float32s, kVecA and kVecB happen to be nearly parallel (their
+// components share a ~1:4:16:64 ratio), so cosine cannot tell them apart -- the
+// distance between them is 2e-10. kVecC is kVecA byte-reversed, which keeps the same
+// magnitudes but puts it 0.94 away under cosine. Use it wherever direction matters.
+static const char *kVecC = "ddddccccbbbbaaaa";
+
+class VectorRelabelTest : public ::testing::Test {
+protected:
+  RedisModuleCtx *ctx = nullptr;
+  IndexSpec *spec = nullptr;
+  std::string indexName;
+
+  bool previousEnableUnstableFeatures = false;
+
+  void SetUp() override {
+    ctx = RedisModule_GetThreadSafeContext(nullptr);
+    RMCK::flushdb(ctx);
+    static int counter = 0;
+    indexName = "relabelidx" + std::to_string(++counter);
+    // Relabeling is gated behind ENABLE_UNSTABLE_FEATURES. Restored in TearDown,
+    // which runs even when an assertion fails, so no state leaks to other tests.
+    previousEnableUnstableFeatures = RSGlobalConfig.enableUnstableFeatures;
+    RSGlobalConfig.enableUnstableFeatures = true;
+  }
+
+  void TearDown() override {
+    RSGlobalConfig.enableUnstableFeatures = previousEnableUnstableFeatures;
+    if (ctx) {
+      RedisModule_FreeThreadSafeContext(ctx);
+      ctx = nullptr;
+    }
+  }
+
+  // `vectorAlias` is the AS alias for the vector field, or nullptr for none. The
+  // alias case matters: a change set names the hash field (the path), so a
+  // schema-side comparison against the alias would classify every field wrongly.
+  //
+  // `algo` selects the vector backend. It is a test parameter because relabeling
+  // is optional in VecSim: FLAT and HNSW implement it, SVS does not.
+  // `metric` is a test parameter because the no-change-set path can only compare
+  // blobs under L2; see `storedVectorIsUnchanged`.
+  void createIndex(const char *vectorAlias, const char *algo = "FLAT",
+                   const char *metric = "L2") {
+    QueryError err = QueryError_Default();
+    RMCK::ArgvList args =
+        vectorAlias
+            ? RMCK::ArgvList(ctx, "FT.CREATE", indexName.c_str(), "ON", "HASH", "SCHEMA", "title",
+                             "TEXT", "vec", "AS", vectorAlias, "VECTOR", algo, "6", "TYPE",
+                             "FLOAT32", "DIM", "4", "DISTANCE_METRIC", metric)
+            : RMCK::ArgvList(ctx, "FT.CREATE", indexName.c_str(), "ON", "HASH", "SCHEMA", "title",
+                             "TEXT", "vec", "VECTOR", algo, "6", "TYPE", "FLOAT32", "DIM", "4",
+                             "DISTANCE_METRIC", metric);
+    spec = Indexes_CreateNewSpec(ctx, args, args.size(), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+    ASSERT_TRUE(spec != nullptr);
+  }
+
+  VecSimIndex *vecsim() {
+    const FieldSpec *fs = nullptr;
+    for (size_t i = 0; i < spec->numFields; ++i) {
+      if (spec->fields[i].types & INDEXFLD_T_VECTOR) {
+        fs = &spec->fields[i];
+        break;
+      }
+    }
+    if (!fs) return nullptr;
+    return openVectorIndex(ctx, (FieldSpec *)fs, DONT_CREATE_INDEX);
+  }
+
+  t_docId docIdOf(const char *key) {
+    uint64_t docId = 0;
+    if (DocIdMeta_Get(ctx, RMCK::RString(key), spec->specId, &docId) != REDISMODULE_OK) {
+      return 0;
+    }
+    return (t_docId)docId;
+  }
+
+  // A label holds `blob` iff the distance to itself is 0. An absent label yields
+  // NaN, which is how these tests tell "moved" from "still there".
+  bool labelHolds(t_docId label, const char *blob) {
+    VecSimIndex *idx = vecsim();
+    if (!idx) return false;
+    double d = VecSimIndex_GetDistanceFrom_Unsafe(idx, label, blob);
+    return !std::isnan(d) && d == 0.0;
+  }
+
+  // The cosine counterpart of `labelHolds`. A cosine index stores the blob normalized
+  // and `VecSimIndex_GetDistanceFrom_Unsafe` documents that the caller passes an
+  // already-normalized vector, so the probe has to normalize a copy -- and then compare
+  // with a tolerance, since the normalize-store-compare round trip is not exact. That
+  // inexactness is the reason the product code refuses to compare cosine vectors at
+  // all; here it only has to separate two vectors 0.94 apart.
+  bool labelHoldsNormalized(t_docId label, const char *blob) {
+    VecSimIndex *idx = vecsim();
+    if (!idx) return false;
+    std::array<float, 4> normalized;
+    memcpy(normalized.data(), blob, sizeof(normalized));
+    VecSim_Normalize(normalized.data(), normalized.size(), VecSimType_FLOAT32);
+    double d = VecSimIndex_GetDistanceFrom_Unsafe(idx, label, normalized.data());
+    return !std::isnan(d) && std::fabs(d) < 1e-6;
+  }
+
+  bool labelAbsent(t_docId label) {
+    VecSimIndex *idx = vecsim();
+    if (!idx) return true;
+    return std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(idx, label, kVecA));
+  }
+
+  // Index `key` for the first time, with no change set.
+  t_docId indexFresh(const char *key, const char *title, const char *blob) {
+    RMCK::hset(ctx, key, "title", title);
+    RMCK::hset(ctx, key, "vec", blob, false);
+    EXPECT_EQ(IndexSpec_UpdateDoc(spec, ctx, RMCK::RString(key), DocumentType_Hash, nullptr,
+                                  nullptr, 0),
+              REDISMODULE_OK);
+    return docIdOf(key);
+  }
+
+  // Re-index `key`, declaring exactly `changed` as the modified fields.
+  //
+  // The strings are built directly rather than via RMCK::RString: that is a
+  // scope guard whose destructor frees the string, so collecting temporaries
+  // into a vector would leave it holding freed pointers.
+  t_docId reindexWithChangeSet(const char *key, std::vector<std::string> changed) {
+    std::vector<RedisModuleString *> fields;
+    for (const std::string &f : changed) {
+      fields.push_back(RedisModule_CreateString(nullptr, f.c_str(), f.size()));
+    }
+    int rc = IndexSpec_UpdateDoc(spec, ctx, RMCK::RString(key), DocumentType_Hash, nullptr,
+                                 fields.empty() ? nullptr : fields.data(), fields.size());
+    for (RedisModuleString *f : fields) {
+      RedisModule_FreeString(nullptr, f);
+    }
+    EXPECT_EQ(rc, REDISMODULE_OK);
+    return docIdOf(key);
+  }
+  // A schema with two vector fields on different backends. Relabeling is decided
+  // per field, so the interesting case is one vector changing while the other does
+  // not; the single-vector helpers above cannot express it.
+  void createTwoVectorIndex() {
+    QueryError err = QueryError_Default();
+    RMCK::ArgvList args(ctx, "FT.CREATE", indexName.c_str(), "ON", "HASH", "SCHEMA", "title",
+                        "TEXT", "v_flat", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "4",
+                        "DISTANCE_METRIC", "L2", "v_hnsw", "VECTOR", "HNSW", "6", "TYPE",
+                        "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2");
+    spec = Indexes_CreateNewSpec(ctx, args, args.size(), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+    ASSERT_TRUE(spec != nullptr);
+  }
+
+  VecSimIndex *vecsimNamed(const std::string &field) {
+    for (size_t i = 0; i < spec->numFields; ++i) {
+      if (!(spec->fields[i].types & INDEXFLD_T_VECTOR)) continue;
+      if (!HiddenString_CompareC(spec->fields[i].fieldName, field.c_str(), field.size())) {
+        return openVectorIndex(ctx, &spec->fields[i], DONT_CREATE_INDEX);
+      }
+    }
+    return nullptr;
+  }
+
+  bool namedLabelHolds(const std::string &field, t_docId label, const char *blob) {
+    VecSimIndex *idx = vecsimNamed(field);
+    if (!idx) return false;
+    double d = VecSimIndex_GetDistanceFrom_Unsafe(idx, label, blob);
+    return !std::isnan(d) && d == 0.0;
+  }
+
+  bool namedLabelAbsent(const std::string &field, t_docId label) {
+    VecSimIndex *idx = vecsimNamed(field);
+    return !idx || std::isnan(VecSimIndex_GetDistanceFrom_Unsafe(idx, label, kVecA));
+  }
+};
+
+// The optimization itself: text changed, vector did not, so the doc takes a new
+// doc-id and the existing vector entry moves onto it.
+TEST_F(VectorRelabelTest, textChangeRelabelsUnchangedVector) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+  ASSERT_TRUE(labelHolds(first, kVecA));
+  size_t sizeBefore = VecSimIndex_IndexSize(vecsim());
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  t_docId second = reindexWithChangeSet("doc:1", {"title"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_NE(second, first) << "an append-only field changed, so the doc-id must advance";
+  EXPECT_TRUE(labelHolds(second, kVecA)) << "the vector should have moved to the new doc-id";
+  EXPECT_TRUE(labelAbsent(first)) << "the old label must not survive the relabel";
+  // A relabel rewrites bookkeeping only, so the stored vector count is unchanged.
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), sizeBefore);
+}
+
+// The vector itself changed, so there is new data to store and relabeling cannot
+// serve it: the entry is re-added under the new doc-id.
+TEST_F(VectorRelabelTest, vectorChangeReAddsUnderNewDocId) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"vec"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecB)) << "the new blob must be indexed";
+  EXPECT_FALSE(labelHolds(second, kVecA)) << "the stale blob must not be what is stored";
+  EXPECT_TRUE(labelAbsent(first));
+}
+
+// Both changed: the vector is re-added, not relabeled, because its data moved.
+TEST_F(VectorRelabelTest, textAndVectorChangeReAdds) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"title", "vec"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecB));
+  EXPECT_TRUE(labelAbsent(first));
+}
+
+// With no change set -- the path every JSON write and every background scan takes --
+// the question is settled by comparing the field's new value against what the index
+// holds. An unchanged value still ends up under the new doc-id.
+//
+// Whether it got there by a move or a re-add is not observable from here: for an
+// unchanged blob the two are identical in label, distance and count, and the
+// tombstone route needs a tiered index (workers are disabled in these tests). The
+// pytest suite pins the move itself via FT.INFO's `marked_deleted`.
+TEST_F(VectorRelabelTest, unknownChangeSetKeepsUnchangedVector) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+  size_t sizeBefore = VecSimIndex_IndexSize(vecsim());
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  t_docId second = reindexWithChangeSet("doc:1", {});  // NULL change set
+
+  ASSERT_NE(second, 0);
+  EXPECT_NE(second, first);
+  EXPECT_TRUE(labelHolds(second, kVecA));
+  EXPECT_TRUE(labelAbsent(first));
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), sizeBefore) << "no orphan at the old label";
+}
+
+// The comparison is what makes the no-change-set path safe, and this is the test that
+// exercises it: the vector really did change, and nothing external says so. Moving the
+// entry here would leave the *old* blob under the new doc-id, so a KNN query would
+// return a vector the document no longer has.
+TEST_F(VectorRelabelTest, unknownChangeSetWithChangedVectorReAdds) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {});  // NULL change set
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecB)) << "the document's current value must be indexed";
+  EXPECT_FALSE(labelHolds(second, kVecA))
+      << "the old blob here means the entry was moved without checking whether it changed";
+  EXPECT_TRUE(labelAbsent(first));
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), 1u);
+}
+
+// Cosine is the case a distance-based comparison could not serve, and the byte one can.
+// The index stores the blob normalized, so the comparison has to normalize before comparing
+// -- `VecSimIndexAbstract::holdsVector` runs the blob through `preprocessForStorage` for
+// exactly that reason. Here the vector genuinely changed, so it must be re-added.
+TEST_F(VectorRelabelTest, unknownChangeSetOnCosineIndexDetectsChange) {
+  createIndex(nullptr, "FLAT", "COSINE");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "vec", kVecC, false);
+  t_docId second = reindexWithChangeSet("doc:1", {});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHoldsNormalized(second, kVecC)) << "the document's current value must be indexed";
+  EXPECT_FALSE(labelHoldsNormalized(second, kVecA))
+      << "the old blob here means the comparison missed a changed vector";
+  EXPECT_TRUE(labelAbsent(first));
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), 1u);
+}
+
+// The primitive the unverified path rests on, tested directly rather than through its effect.
+//
+// Worth pinning separately because every test above is outcome-based, and for an unchanged
+// vector the two paths produce identical index contents -- so nothing else here would notice
+// `VectorIndex_HoldsVectors` answering true for a vector that changed, or false for one that
+// did not. Cosine is the interesting case: the stored form is normalized, so a comparison
+// against the raw blob would say "changed" every time and silently cost the optimization.
+TEST_F(VectorRelabelTest, holdsVectorComparesTheStoredForm) {
+  createIndex(nullptr, "FLAT", "COSINE");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  EXPECT_TRUE(VectorIndex_HoldsVectors(vecsim(), first, kVecA, 1))
+      << "the stored vector is the normalized kVecA, so the raw blob has to be normalized too";
+  EXPECT_FALSE(VectorIndex_HoldsVectors(vecsim(), first, kVecC, 1));
+  EXPECT_FALSE(VectorIndex_HoldsVectors(vecsim(), first + 1000, kVecA, 1))
+      << "an absent label holds nothing";
+  EXPECT_FALSE(VectorIndex_HoldsVectors(vecsim(), first, kVecA, 2))
+      << "a label holding one vector does not hold two";
+}
+
+// L2 needs no preprocessing, so this is the same primitive with the transformation removed --
+// and the pair rules out a comparison that only works because normalization happens to be a
+// no-op, or only when it is not.
+TEST_F(VectorRelabelTest, holdsVectorOnL2Index) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  EXPECT_TRUE(VectorIndex_HoldsVectors(vecsim(), first, kVecA, 1));
+  EXPECT_FALSE(VectorIndex_HoldsVectors(vecsim(), first, kVecB, 1));
+}
+
+// An SVS schema field is created as a *tiered* index (see `spec.c`), so with workers disabled
+// nothing is ever ingested and the comparison is answered from the flat buffer -- which is a
+// brute-force index like any other. SVS's own accessor reports nothing, by design: it keeps
+// vectors in the SVS library's reduced form and cannot hand them back.
+//
+// So this covers the tiered read, not SVS storage, and what it pins is that the comparison and
+// the relabel refusal are independent: a match here still ends in delete + re-add, because
+// relabeling is what SVS does not implement. `svsRefusalFallsBackToDeleteAndAdd` covers that
+// half. Conflating the two is the easy mistake.
+TEST_F(VectorRelabelTest, holdsVectorOnSvsIndexAnswersFromTheFlatBuffer) {
+  createIndex(nullptr, "SVS-VAMANA");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  EXPECT_TRUE(VectorIndex_HoldsVectors(vecsim(), first, kVecA, 1));
+  EXPECT_FALSE(VectorIndex_HoldsVectors(vecsim(), first, kVecB, 1));
+}
+
+// A field the schema does not index cannot force a reindex of the vector.
+TEST_F(VectorRelabelTest, nonSchemaFieldChangeRelabels) {
+  createIndex(nullptr);
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "untracked", "whatever");
+  t_docId second = reindexWithChangeSet("doc:1", {"untracked"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecA));
+  EXPECT_TRUE(labelAbsent(first));
+}
+
+// With `AS`, the change set names the hash field (`vec`) while the schema knows the field by
+// its alias. Classifying on the alias would read a changed vector as unchanged and relabel a
+// stale entry, so the blob at the new doc-id would be the old one.
+TEST_F(VectorRelabelTest, aliasedVectorChangeIsDetected) {
+  createIndex("embedding");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"vec"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecB)) << "aliased vector change must re-add the new blob";
+  EXPECT_FALSE(labelHolds(second, kVecA)) << "a stale blob here means the alias was mismatched";
+}
+
+// Pins which primitive ran on the *verified* path, not just where the vector ended up.
+//
+// For a genuinely unchanged blob a relabel and a delete + re-add are indistinguishable --
+// same label, same distance, same count. This separates them by feeding a change set that
+// deliberately understates what changed: the hash's vector is rewritten to a different blob
+// while the change set names only `title`. The two paths then diverge in what the new label
+// holds:
+//
+//   relabel       -> moves the existing entry, so the label holds the OLD blob
+//   delete+re-add -> re-reads the document, so the label holds the CURRENT blob
+//
+// The input is intentionally inconsistent -- a real notification would list `vec` -- and it is
+// not modelling a reachable state. It is the only way to observe the choice from outside,
+// since the tombstone route needs a tiered index (plain HNSW's deleteVector removes in place,
+// marking nothing) and so is unavailable with workers disabled.
+//
+// It is also what separates a verified mark from an unverified one: on the unverified path the
+// blob comparison would notice the rewrite and re-add.
+TEST_F(VectorRelabelTest, relabelMovesTheExistingEntryRatherThanReReading) {
+  createIndex(nullptr, "HNSW");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+  ASSERT_TRUE(labelHolds(first, kVecA));
+
+  // Rewrite the stored vector but claim only `title` changed.
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"title"});
+
+  ASSERT_NE(second, 0);
+  ASSERT_NE(second, first);
+  EXPECT_TRUE(labelHolds(second, kVecA))
+      << "the new label should hold the moved entry; the current document value here would mean "
+         "the vector was re-read and re-added instead of relabeled";
+  EXPECT_FALSE(labelHolds(second, kVecB));
+  EXPECT_TRUE(labelAbsent(first));
+
+  // Control on the same backend: name the vector in the change set and the value is re-read,
+  // proving the probe above can distinguish the two paths at all rather than being insensitive
+  // to both.
+  t_docId third = reindexWithChangeSet("doc:1", {"vec"});
+  ASSERT_NE(third, 0);
+  EXPECT_TRUE(labelHolds(third, kVecB)) << "a declared vector change must re-read the document";
+  EXPECT_FALSE(labelHolds(third, kVecA));
+}
+
+// SVS does not implement relabeling, so `VecSimIndex_RelabelVector` refuses with
+// `VecSimRelabel_Unsupported`. `Indexer_HandleReplacedDocVectorAndGeometry` has already
+// skipped this field's delete on the strength of the unchanged mark, so the refusal
+// has to perform it before letting the insert run -- otherwise the old entry is
+// orphaned at a doc-id no document owns, and a KNN query can return it.
+//
+// The index-size assertion is what catches that: an orphan plus the re-add
+// leaves two stored vectors for one document.
+TEST_F(VectorRelabelTest, svsRefusalFallsBackToDeleteAndAdd) {
+  createIndex(nullptr, "SVS-VAMANA");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+  ASSERT_TRUE(labelHolds(first, kVecA));
+  ASSERT_EQ(VecSimIndex_IndexSize(vecsim()), 1u);
+
+  // Pin the premise. Without it this test passes whether the relabel was refused
+  // or succeeded, because an unchanged blob leaves identical state either way --
+  // so it would stop covering the fallback the moment SVS gained relabel support,
+  // silently. Probing with an unused target label mutates nothing on refusal.
+  ASSERT_EQ(VecSimIndex_RelabelVector(vecsim(), first, first + 1000),
+            VecSimRelabel_Unsupported)
+      << "premise: SVS does not implement relabeling. If this now succeeds, this test no "
+         "longer exercises the refusal fallback and needs a different backend.";
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  t_docId second = reindexWithChangeSet("doc:1", {"title"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_NE(second, first);
+  EXPECT_TRUE(labelHolds(second, kVecA)) << "the vector must still be reachable at the new doc-id";
+  EXPECT_TRUE(labelAbsent(first)) << "the refused relabel must not leave the old entry behind";
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), 1u)
+      << "an orphan at the old label would make this 2";
+}
+
+// The gate. With ENABLE_UNSTABLE_FEATURES off, a text-only change must take the
+// pre-existing delete + re-add path even though the change set proves the vector
+// is unchanged. Uses the same understated-change-set probe as
+// `relabelMovesTheExistingEntryRatherThanReReading`, so the two are direct
+// opposites on identical input: there, the new label holds the moved (old) blob;
+// here it must hold the document's current one, because the vector was re-read.
+TEST_F(VectorRelabelTest, relabelRequiresUnstableFeatures) {
+  RSGlobalConfig.enableUnstableFeatures = false;  // restored by TearDown
+
+  createIndex(nullptr, "HNSW");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  RMCK::hset(ctx, "doc:1", "vec", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"title"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_TRUE(labelHolds(second, kVecB))
+      << "with the flag off the vector must be re-read and re-added, not relabeled";
+  EXPECT_FALSE(labelHolds(second, kVecA));
+  EXPECT_TRUE(labelAbsent(first));
+}
+
+// The mirror of the above: on an aliased schema a text-only change must still
+// relabel, so the alias fix cannot have been made by simply never matching.
+TEST_F(VectorRelabelTest, aliasedTextChangeRelabels) {
+  createIndex("embedding");
+  t_docId first = indexFresh("doc:1", "hello", kVecA);
+  ASSERT_NE(first, 0);
+  size_t sizeBefore = VecSimIndex_IndexSize(vecsim());
+
+  RMCK::hset(ctx, "doc:1", "title", "goodbye");
+  t_docId second = reindexWithChangeSet("doc:1", {"title"});
+
+  ASSERT_NE(second, 0);
+  EXPECT_NE(second, first);
+  EXPECT_TRUE(labelHolds(second, kVecA));
+  EXPECT_TRUE(labelAbsent(first));
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsim()), sizeBefore);
+}
+
+// Per-field granularity: one vector changed, the other did not, so within a single
+// update one field is re-added and the other is relabeled. A whole-document
+// decision would get one of the two wrong -- either re-adding a vector that never
+// changed, or moving a stale entry for the one that did.
+//
+// Both hash values are rewritten while the change set names only `v_flat`, which
+// is the probe from `relabelMovesTheExistingEntryRatherThanReReading`: the
+// re-added field ends up holding the current blob, the relabeled one the old.
+TEST_F(VectorRelabelTest, perFieldRelabelWithTwoVectorFields) {
+  createTwoVectorIndex();
+
+  RMCK::hset(ctx, "doc:1", "title", "hello");
+  RMCK::hset(ctx, "doc:1", "v_flat", kVecA, false);
+  RMCK::hset(ctx, "doc:1", "v_hnsw", kVecA, false);
+  ASSERT_EQ(IndexSpec_UpdateDoc(spec, ctx, RMCK::RString("doc:1"), DocumentType_Hash, nullptr,
+                                nullptr, 0),
+            REDISMODULE_OK);
+  t_docId first = docIdOf("doc:1");
+  ASSERT_NE(first, 0);
+  ASSERT_TRUE(namedLabelHolds("v_flat", first, kVecA));
+  ASSERT_TRUE(namedLabelHolds("v_hnsw", first, kVecA));
+
+  RMCK::hset(ctx, "doc:1", "v_flat", kVecB, false);
+  RMCK::hset(ctx, "doc:1", "v_hnsw", kVecB, false);
+  t_docId second = reindexWithChangeSet("doc:1", {"v_flat"});
+
+  ASSERT_NE(second, 0);
+  ASSERT_NE(second, first);
+  EXPECT_TRUE(namedLabelHolds("v_flat", second, kVecB))
+      << "the declared change must be re-read and re-added";
+  EXPECT_TRUE(namedLabelHolds("v_hnsw", second, kVecA))
+      << "the undeclared field must be moved, not re-read";
+  EXPECT_TRUE(namedLabelAbsent("v_flat", first));
+  EXPECT_TRUE(namedLabelAbsent("v_hnsw", first));
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsimNamed("v_flat")), 1u);
+  EXPECT_EQ(VecSimIndex_IndexSize(vecsimNamed("v_hnsw")), 1u);
+}

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -678,6 +678,19 @@ def shard_set_info_on_zero_indexes(env, enabled: bool):
     env.assertEqual(res, 'OK')
     return res
 
+def skip_if_no_hash_subkey_notifications(env):
+    """
+    Skip unless every shard is served hash events over the subkey channel.
+
+    A server that predates subkey notifications degrades to reindexing the whole
+    document, which is correct but makes any assertion about change-set-driven
+    behavior fail. Asked per shard because the module decides this per process, at
+    load time, from whether the API symbol resolved.
+    """
+    active = run_command_on_all_shards(env, debug_cmd(), 'HASH_SUBKEY_NOTIFICATIONS')
+    if not all(active):
+        env.skip()
+
 def get_vecsim_debug_dict(env, index_name, vector_field):
     return to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_name, vector_field))
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -678,19 +678,6 @@ def shard_set_info_on_zero_indexes(env, enabled: bool):
     env.assertEqual(res, 'OK')
     return res
 
-def skip_if_no_hash_subkey_notifications(env):
-    """
-    Skip unless every shard is served hash events over the subkey channel.
-
-    A server that predates subkey notifications degrades to reindexing the whole
-    document, which is correct but makes any assertion about change-set-driven
-    behavior fail. Asked per shard because the module decides this per process, at
-    load time, from whether the API symbol resolved.
-    """
-    active = run_command_on_all_shards(env, debug_cmd(), 'HASH_SUBKEY_NOTIFICATIONS')
-    if not all(active):
-        env.skip()
-
 def get_vecsim_debug_dict(env, index_name, vector_field):
     return to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_name, vector_field))
 

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -77,6 +77,7 @@ class TestDebugCommands(object):
             "INDEXES",
             "INFO",
             'GET_HIDE_USER_DATA_FROM_LOGS',
+            'HASH_SUBKEY_NOTIFICATIONS',
             'YIELDS_COUNTER',
             'GC_TIMER_ARMS',
             'INDEXER_SLEEP_BEFORE_YIELD_MICROS',
@@ -114,6 +115,7 @@ class TestDebugCommands(object):
         arity_2_cmds = ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_LOCAL_CURSORS',
                         'DELETE_LOCAL_COORD_CURSORS', 'SHARD_CONNECTION_STATES',
                         'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY', 'INFO', 'INDEXES', 'GET_HIDE_USER_DATA_FROM_LOGS',
+                        'HASH_SUBKEY_NOTIFICATIONS',
                         'REGISTER_TEST_SCORERS', 'BG_PENDING_REPLIES',
                         'IO_RUNTIME_PENDING_REQUESTS']
         for cmd in [c for c in help_list if c not in arity_2_cmds]:

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -662,7 +662,15 @@ def gc_test_common(env, num_workers):
     dim = 28
     data_type = 'FLOAT32'
     training_threshold = DEFAULT_BLOCK_SIZE
-    index_size = DEFAULT_BLOCK_SIZE
+    # SVS gives dataset memory back a whole block at a time, and `svs::data::SimpleData::resize`
+    # keeps one empty block when it shrinks, so a deletion has to free at least two blocks
+    # before the "memory decreased" assertion below can see anything. Four blocks in and three
+    # deleted leaves a block of live vectors plus a block of margin over that minimum. Sizing
+    # the index at exactly one block -- as this did before VectorSimilarity #980 changed block
+    # handling -- freed nothing measurable however many vectors were deleted.
+    blocks_in_index = 4
+    blocks_to_delete = 3
+    index_size = blocks_in_index * DEFAULT_BLOCK_SIZE * env.shardsCount
     compression_types = ['NO_COMPRESSION', 'LVQ8']
     if is_intel_opt_enabled():
         compression_types.append('LeanVec4x8')
@@ -684,7 +692,7 @@ def gc_test_common(env, num_workers):
         label_count_before = tiered_backend_debug_info['INDEX_LABEL_COUNT']
 
         # Phase 1: Delete some vectors
-        vecs_to_delete = 1000
+        vecs_to_delete = blocks_to_delete * DEFAULT_BLOCK_SIZE * env.shardsCount
         for i in range (vecs_to_delete):
             env.execute_command('DEL', f'{DEFAULT_DOC_NAME_PREFIX}{i + 1}')
 

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -662,15 +662,6 @@ def gc_test_common(env, num_workers):
     dim = 28
     data_type = 'FLOAT32'
     training_threshold = DEFAULT_BLOCK_SIZE
-    # SVS gives dataset memory back a whole block at a time, and `svs::data::SimpleData::resize`
-    # keeps one empty block when it shrinks, so a deletion has to free at least two blocks
-    # before the "memory decreased" assertion below can see anything. Four blocks in and three
-    # deleted leaves a block of live vectors plus a block of margin over that minimum. Sizing
-    # the index at exactly one block -- as this did before VectorSimilarity #980 changed block
-    # handling -- freed nothing measurable however many vectors were deleted.
-    blocks_in_index = 4
-    blocks_to_delete = 3
-    index_size = blocks_in_index * DEFAULT_BLOCK_SIZE * env.shardsCount
     compression_types = ['NO_COMPRESSION', 'LVQ8']
     if is_intel_opt_enabled():
         compression_types.append('LeanVec4x8')
@@ -680,6 +671,21 @@ def gc_test_common(env, num_workers):
         if compression_type != 'NO_COMPRESSION':
             compression_params = ['COMPRESSION', compression_type, 'TRAINING_THRESHOLD', training_threshold]
         message_prefix = f"compression_params: {compression_params}"
+
+        # SVS hands dataset memory back a whole block at a time, and
+        # `svs::data::SimpleData::resize` keeps one empty block when it shrinks
+        # (VectorSimilarity #980). So "GC returned memory" is only observable once a deletion
+        # frees two blocks: three blocks in and two deleted is the cheapest sizing that does,
+        # leaving a block of live vectors. At one block -- the sizing this test used before
+        # #980 -- nothing measurable is ever freed, however many vectors are deleted.
+        #
+        # Only one variant pays for that. Block retention is a property of the SVS dataset, not
+        # of the compression applied to it, so testing it once is enough, and the coverage lane
+        # runs this instrumented: three blocks across every variant timed out there.
+        checks_memory_release = compression_type == 'NO_COMPRESSION'
+        index_size = (3 if checks_memory_release else 1) * DEFAULT_BLOCK_SIZE * env.shardsCount
+        vecs_to_delete = (2 * DEFAULT_BLOCK_SIZE * env.shardsCount if checks_memory_release
+                          else DEFAULT_BLOCK_SIZE * env.shardsCount - 24)
         set_up_database_with_vectors(env, dim, num_docs=index_size, index_name=DEFAULT_INDEX_NAME, datatype=data_type, alg='SVS-VAMANA', additional_vec_params=compression_params)
         wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME, message=message_prefix)
 
@@ -692,7 +698,6 @@ def gc_test_common(env, num_workers):
         label_count_before = tiered_backend_debug_info['INDEX_LABEL_COUNT']
 
         # Phase 1: Delete some vectors
-        vecs_to_delete = blocks_to_delete * DEFAULT_BLOCK_SIZE * env.shardsCount
         for i in range (vecs_to_delete):
             env.execute_command('DEL', f'{DEFAULT_DOC_NAME_PREFIX}{i + 1}')
 
@@ -744,9 +749,10 @@ def gc_test_common(env, num_workers):
         # Verify that the number of marked deleted vectors is as expected
         env.assertEqual(tiered_backend_debug_info['NUMBER_OF_MARKED_DELETED'], 0, message=f"{message_prefix}")
 
-        # Memory should decrease
-        after_gc_memory = get_vecsim_memory(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
-        env.assertLess(after_gc_memory, after_del_memory, message=f"{message_prefix}")
+        # Memory should decrease -- only where the deletion freed whole blocks; see above.
+        if checks_memory_release:
+            after_gc_memory = get_vecsim_memory(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+            env.assertLess(after_gc_memory, after_del_memory, message=f"{message_prefix}")
 
         # Index size should be updated
         size_after = tiered_backend_debug_info['INDEX_SIZE']

--- a/tests/pytests/test_vector_relabel.py
+++ b/tests/pytests/test_vector_relabel.py
@@ -1,0 +1,258 @@
+from common import *
+
+# Relabeling an unchanged vector onto a document's new doc-id, instead of deleting
+# the entry and re-adding the blob (MOD-17688). Gated behind
+# ENABLE_UNSTABLE_FEATURES.
+#
+# These tests cover what the C++ suite (`VectorRelabelTest`) cannot: the whole
+# chain from a real `HSET` through the hash subkey notification to the indexer's
+# change set. The C++ tests call `IndexSpec_UpdateDoc` with a change set directly,
+# so the notification plumbing itself is only exercised here.
+#
+# The observable is `FT.INFO`'s per-field `marked_deleted`. It needs a *tiered*
+# HNSW index (`WORKERS 1`), because that is the configuration where dropping a
+# vector leaves a tombstone: plain HNSW removes in place and counts nothing, which
+# would make relabel and delete + re-add indistinguishable. The vector must also
+# have reached the HNSW backend before the update -- a delete from the flat
+# frontend is likewise in-place -- hence the `WORKERS DRAIN` after loading.
+
+DIM = 4
+MODULE_ARGS = 'WORKERS 1 FORK_GC_RUN_INTERVAL 50000'
+
+def _blob(fill):
+    return create_np_array_typed([fill] * DIM, 'FLOAT32').tobytes()
+
+VEC_A = _blob(0.25)
+VEC_B = _blob(0.75)
+
+def _create_index(env):
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
+               'title', 'TEXT',
+               'vector', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', DIM,
+               'DISTANCE_METRIC', 'L2').ok()
+
+def _load_doc(env, conn):
+    conn.execute_command('HSET', 'doc:1', 'title', 'hello', 'vector', VEC_A)
+    # Move the vector out of the flat frontend and into the HNSW backend, so that a
+    # delete of its label would be recorded as a tombstone rather than done in place.
+    verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN')
+
+def _create_json_index(env):
+    env.expect('FT.CREATE', 'jsonidx', 'ON', 'JSON', 'SCHEMA',
+               '$.title', 'AS', 'title', 'TEXT',
+               '$.vector', 'AS', 'vector', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', DIM,
+               'DISTANCE_METRIC', 'L2').ok()
+
+def _load_json_doc(env, conn):
+    # A JSON vector is an array of numbers, not the binary blob a hash field holds.
+    # Same values as VEC_A, so the KNN assertions can reuse it as the query.
+    conn.execute_command('JSON.SET', 'doc:1', '$',
+                         '{"title":"hello","vector":[0.25,0.25,0.25,0.25]}')
+    verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN')
+
+def _marked_deleted(env, index='idx'):
+    """Tombstones on the vector field, once any pending ingest jobs have settled.
+
+    Selected by attribute rather than by position: `field statistics` carries an
+    entry per schema field and only the vector one has this key, so an index-based
+    lookup silently reads the TEXT field instead. Attribute and not identifier
+    because a JSON schema's identifier is the path (`$.vector`).
+    """
+    verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN')
+    stats = index_info(env, index)['field statistics']
+    vector_stats = [f for f in stats if f['attribute'] == 'vector']
+    env.assertEqual(len(vector_stats), 1)
+    return vector_stats[0]['marked_deleted']
+
+def _vector_ops(env):
+    """(indexing ops, relabel ops) for vector fields, summed across shards.
+
+    The two are disjoint: moving an entry is not an indexing operation, so exactly one of them
+    is counted per vector field per update. Asserting both is what pins that -- either alone
+    would still pass if a move were counted twice.
+    """
+    infos = run_command_on_all_shards(env, 'INFO', 'MODULES')
+    return (sum(int(i['search_total_indexing_ops_vector_fields']) for i in infos),
+            sum(int(i['search_total_relabel_ops_vector_fields']) for i in infos))
+
+def _search_ids(env, query, index='idx'):
+    # RESP3 (needed for FT.INFO's nested field statistics) replies with a map, not
+    # the flat RESP2 array.
+    res = env.cmd('FT.SEARCH', index, query, 'NOCONTENT')
+    return [doc['id'] for doc in res['results']]
+
+def _assert_doc_is_queryable(env, expected_title, expected_vector, index='idx'):
+    # Holds whichever path ran: the point of the optimization is that it is
+    # invisible except in the tombstone count.
+    env.assertEqual(_search_ids(env, expected_title, index), ['doc:1'])
+    res = env.cmd('FT.SEARCH', index, '*=>[KNN 1 @vector $b AS score]', 'PARAMS', '2', 'b',
+                  expected_vector, 'RETURN', '1', 'score', 'DIALECT', '2')
+    env.assertEqual(res['total_results'], 1)
+    env.assertEqual(res['results'][0]['id'], 'doc:1')
+    # Distance 0 to the blob the caller expects: this is what catches a relabel that
+    # moved an entry holding the wrong vector.
+    env.assertEqual(res['results'][0]['extra_attributes']['score'], '0')
+
+def test_relabel_unchanged_vector_on_text_update():
+    """A text-only update must move the existing vector entry, leaving no tombstone."""
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    enable_unstable_features(env)
+    skip_if_no_hash_subkey_notifications(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_index(env)
+    _load_doc(env, conn)
+    env.assertEqual(_marked_deleted(env), 0)
+
+    conn.execute_command('HSET', 'doc:1', 'title', 'goodbye')
+
+    env.assertEqual(_marked_deleted(env), 0,
+                    message='a tombstone here means the unchanged vector was deleted and re-added')
+    # One indexing op for the initial load, and the update counted as a move rather than a
+    # second indexing op.
+    env.assertEqual(_vector_ops(env), (1, 1))
+    _assert_doc_is_queryable(env, 'goodbye', VEC_A)
+    env.assertEqual(_search_ids(env, 'hello'), [])
+
+def test_vector_change_reindexes():
+    """The safety direction: when the vector *does* change it must be re-added, not moved.
+
+    A relabel here would leave the old blob in the index under the new doc-id, so
+    the KNN assertion on VEC_B is what catches it; the tombstone assertion pins
+    that the old entry was dropped rather than orphaned.
+    """
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    enable_unstable_features(env)
+    skip_if_no_hash_subkey_notifications(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_index(env)
+    _load_doc(env, conn)
+
+    conn.execute_command('HSET', 'doc:1', 'title', 'goodbye', 'vector', VEC_B)
+
+    env.assertEqual(_marked_deleted(env), 1)
+    # Load plus a genuine re-add: two indexing ops, no move.
+    env.assertEqual(_vector_ops(env), (2, 0))
+    _assert_doc_is_queryable(env, 'goodbye', VEC_B)
+
+def test_relabel_requires_unstable_features():
+    """The gate: with the flag off, the same update takes the delete + re-add path.
+
+    Deliberately the same input and the same query assertions as
+    `test_relabel_unchanged_vector_on_text_update` -- only the tombstone count
+    differs, which is the whole claim of Requirement 1 (no behavior difference with
+    the flag off). Needs no subkey-notification support: with the flag off the
+    change set is not consulted at all.
+    """
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    run_command_on_all_shards(env, 'CONFIG', 'SET', 'search-enable-unstable-features', 'no')
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_index(env)
+    _load_doc(env, conn)
+
+    conn.execute_command('HSET', 'doc:1', 'title', 'goodbye')
+
+    env.assertEqual(_marked_deleted(env), 1,
+                    message='with the flag off the vector must be deleted and re-added')
+    env.assertEqual(_vector_ops(env), (2, 0), message='the gate is off, so nothing is moved')
+    _assert_doc_is_queryable(env, 'goodbye', VEC_A)
+    env.assertEqual(_search_ids(env, 'hello'), [])
+
+@skip(no_json=True)
+def test_json_doc_relabels_unchanged_vector():
+    """JSON relabels too, decided by comparing the vector against what the index holds.
+
+    RedisJSON's API cannot report which paths a command wrote, so there is no change
+    set here and `AddDocumentCtx_MarkForRelabel` can only mark the field
+    `ChangedField_Unverified`. The insert site then settles it: the new value equals the
+    stored one, so the entry moves.
+
+    This is the only place that proves the move for the unverified path -- for an
+    unchanged blob a move and a re-add are indistinguishable in the index contents, and
+    only the tombstone count separates them.
+    """
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    enable_unstable_features(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_json_index(env)
+    _load_json_doc(env, conn)
+    env.assertEqual(_marked_deleted(env, 'jsonidx'), 0)
+
+    conn.execute_command('JSON.SET', 'doc:1', '$.title', '"goodbye"')
+
+    env.assertEqual(_marked_deleted(env, 'jsonidx'), 0,
+                    message='a tombstone means the unchanged vector was deleted and re-added')
+    _assert_doc_is_queryable(env, 'goodbye', VEC_A, 'jsonidx')
+    env.assertEqual(_search_ids(env, 'hello', 'jsonidx'), [])
+
+@skip(no_json=True)
+def test_json_doc_with_changed_vector_reindexes():
+    """The safety half of the JSON path: a changed vector must not be moved.
+
+    Nothing external says the vector changed, so only the blob comparison stands
+    between this and a stale entry surviving under the new doc-id.
+    """
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    enable_unstable_features(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_json_index(env)
+    _load_json_doc(env, conn)
+
+    conn.execute_command('JSON.SET', 'doc:1', '$.vector', '[0.75,0.75,0.75,0.75]')
+
+    env.assertEqual(_marked_deleted(env, 'jsonidx'), 1)
+    _assert_doc_is_queryable(env, 'hello', VEC_B, 'jsonidx')
+
+@skip(no_json=True)
+def test_json_doc_relabel_requires_unstable_features():
+    """The gate, on the JSON path: flag off, so no comparison and no move."""
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    run_command_on_all_shards(env, 'CONFIG', 'SET', 'search-enable-unstable-features', 'no')
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_json_index(env)
+    _load_json_doc(env, conn)
+
+    conn.execute_command('JSON.SET', 'doc:1', '$.title', '"goodbye"')
+
+    env.assertEqual(_marked_deleted(env, 'jsonidx'), 1,
+                    message='with the flag off the vector must be deleted and re-added')
+    _assert_doc_is_queryable(env, 'goodbye', VEC_A, 'jsonidx')
+
+@skip(no_json=True)
+def test_json_doc_nulling_the_vector_leaves_no_orphan():
+    """A JSON document that stops carrying a vector must not strand the old entry.
+
+    Two ways for the field to lose its value, and they take different routes through the
+    marking. Setting the path to `null` still loads the field -- as `FLD_VAR_T_NULL` -- so it
+    is still marked for relabeling, and `Indexer_HandleReplacedDocVectorAndGeometry` has to
+    notice there is no value to move and drop the entry anyway. Removing the path outright
+    never produces a document field, so it is never marked and takes the ordinary delete.
+
+    Either way the entry must go: an orphan sits at a doc-id no document owns, is returned by
+    KNN queries, and is never collected.
+    """
+    env = Env(protocol=3, moduleArgs=MODULE_ARGS)
+    enable_unstable_features(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    _create_json_index(env)
+
+    for description, document in (('null vector', '{"title":"goodbye","vector":null}'),
+                                  ('no vector', '{"title":"goodbye"}')):
+        conn.execute_command('DEL', 'doc:1')
+        _load_json_doc(env, conn)
+        conn.execute_command('JSON.SET', 'doc:1', '$', document)
+        verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN')
+
+        # Still indexed for its text, but owning no vector, so a KNN query must find nothing
+        # rather than the entry the old doc-id used to hold.
+        env.assertEqual(_search_ids(env, 'goodbye', 'jsonidx'), ['doc:1'], message=description)
+        res = env.cmd('FT.SEARCH', 'jsonidx', '*=>[KNN 1 @vector $b]', 'PARAMS', '2', 'b', VEC_A,
+                      'NOCONTENT', 'DIALECT', '2')
+        env.assertEqual(res['total_results'], 0,
+                        message=f'{description}: an orphaned vector entry is still queryable')

--- a/tests/pytests/test_vector_relabel.py
+++ b/tests/pytests/test_vector_relabel.py
@@ -94,10 +94,16 @@ def _assert_doc_is_queryable(env, expected_title, expected_vector, index='idx'):
     env.assertEqual(res['results'][0]['extra_attributes']['score'], '0')
 
 def test_relabel_unchanged_vector_on_text_update():
-    """A text-only update must move the existing vector entry, leaving no tombstone."""
+    """A text-only update must move the existing vector entry, leaving no tombstone.
+
+    Deliberately not gated on subkey-notification support. Both routes to that outcome are
+    in scope: the change set names `title` and not `vector`, and without one the blob
+    comparison finds the stored vector unchanged. The assertions below hold either way, so
+    running this against a server that predates subkey notifications is the coverage for
+    the comparison route on a hash.
+    """
     env = Env(protocol=3, moduleArgs=MODULE_ARGS)
     enable_unstable_features(env)
-    skip_if_no_hash_subkey_notifications(env)
     conn = env.getClusterConnectionIfNeeded()
 
     _create_index(env)
@@ -120,10 +126,13 @@ def test_vector_change_reindexes():
     A relabel here would leave the old blob in the index under the new doc-id, so
     the KNN assertion on VEC_B is what catches it; the tombstone assertion pins
     that the old entry was dropped rather than orphaned.
+
+    Ungated for the same reason as `test_relabel_unchanged_vector_on_text_update`: the
+    change set names `vector`, and without one the comparison sees VEC_B differ from
+    VEC_A. Both reach the re-add this asserts.
     """
     env = Env(protocol=3, moduleArgs=MODULE_ARGS)
     enable_unstable_features(env)
-    skip_if_no_hash_subkey_notifications(env)
     conn = env.getClusterConnectionIfNeeded()
 
     _create_index(env)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** an update to a document assigns it a new doc-id, so every vector it owns is
   deleted and re-added — even when the vector itself did not change. On HNSW that is a graph
   insertion plus a tombstone for the fork GC to collect, paid on every write to a document
   that happens to carry an embedding.
2. **Change:** when an update leaves a vector field's value alone, its existing index entry
   moves onto the new doc-id instead. Whether it was left alone comes either from a hash subkey
   notification, which names the fields the command wrote, or — for JSON, background scans, and
   servers without subkey notifications — from comparing the field's new value against what the
   index is holding. Gated on `ENABLE_UNSTABLE_FEATURES`.
3. **Outcome:** none with the flag off; nothing is marked and no comparison runs. With it on, a
   text-only update to a document with an unchanged vector leaves no tombstone behind, which is
   observable as `marked_deleted` staying at 0 in `FT.INFO`'s per-field statistics.

#### Which additional issues this PR fixes

1. MOD-17688

#### Main objects this PR modified

1. `notifications.c` — hash events move to the subkey channel when the server has one, so the
   indexing path learns which fields a command wrote. Retires the `search-_filter-commands`
   filter, now deprecated in place.
2. `VectorIndex_CheckRemoveId` (`indexer.c`) — the single place a relabel decision is settled,
   before anything is deleted.
3. `vector_compare/` — byte comparison of a field's new value against the stored form, in a C++
   TU because VecSim exposes stored vectors through a template method.
4. `VectorIndex_RelabelField` (`vector_index.c`) — performs the move, or refuses and cleans up.
5. `deps/VectorSimilarity` — bumped to `5bd11d1e` on `main`, which makes `getDataByLabel`
   available outside test builds.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

#### For the release note

`total_indexing_ops_vector_fields` no longer counts an update that leaves a vector field's value
alone. Those updates are counted by the new `total_relabel_ops_vector_fields` instead — the two
are disjoint, since moving an existing entry is not an indexing operation. A dashboard tracking
the first metric will see it drop for workloads that update documents without touching their
embeddings, and should add the second.

#### What a reviewer would otherwise miss

- **`search-_filter-commands` is deprecated, not deleted.** Removing a registered module config
  makes the server refuse to start (`Module Configuration detected without loadmodule
  directive`), so it stays registered and now warns and does nothing.
- **The comparison fails closed.** `VectorIndex_HoldsVectors` answers false whenever it cannot
  tell — a quantized index whose stored form it cannot read, a count mismatch, a type it does
  not handle — costing a reindex rather than risking a stale vector answering queries.
- **Disk mode opts out at the marking site**, rather than attempting a relabel that cannot
  succeed: `HNSWDiskIndex` does not implement `relabelVector`, and its `getDataByLabel` exists
  only in test builds, so neither path can be served and both would end in the delete + re-add
  they were meant to avoid. Implementing it is MOD-18101.
- **Coverage gap.** The four JSON tests need RedisJSON and have only ever run in CI.
