### PR TITLE
[MOD-18088] strconv: fix heap-buffer-overflow read in unicode_tolower for a dangling multi-byte UTF-8 lead byte

### DIFF
--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -145,11 +145,69 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
     }
   }
 
+  // `nu_utf8_read` (deps/libnu/utf8.h) is documented to take "a pointer
+  // to UTF-8 encoded string". `encoded` here is caller-supplied and not
+  // guaranteed to be valid UTF-8 (this is reachable from raw query
+  // tokens), so we're passing it input against its safety docs -- it has
+  // no bounds checking of its own to fall back on, so the result is
+  // undefined behavior: for a lead byte whose declared sequence length
+  // extends past `in_len`, it reads past the allocation. Work around
+  // that below.
+  //
+  // Walk the string exactly as the decode loop below will, one declared
+  // sequence at a time from the start, and stop `safe_len` at the first
+  // position whose sequence would extend past `in_len`. A dangling
+  // sequence earlier in the string is just as unsafe as one at the very
+  // end (e.g. a lead byte followed by unrelated trailing bytes, not just
+  // one at the tail), so this must walk forward from the start rather
+  // than inspect only the string's last few bytes. Everything from
+  // `safe_len` to `in_len` is excluded from decoding and appended to the
+  // output unchanged instead, since it cannot be decoded without reading
+  // past the allocation.
+  //
+  // A sequence that decodes to codepoint 0 is a separate case, checked
+  // only once its length is already known to fit: both the measuring
+  // pass and the decode loop below treat codepoint 0 as end-of-string
+  // and stop there, the same truncate-at-NUL contract the ASCII fast
+  // path above applies. Everything past it is beyond what this function
+  // processes at all -- unlike a dangling sequence, it is not preserved,
+  // only dropped, since splicing it back in as a tail would resurrect
+  // bytes the decode loop never sees past it (and, if a dangling
+  // sequence follows further along, silently skip whatever sits between
+  // the two). This is not limited to a literal 0x00 byte: `nu_utf8_read`
+  // has no overlong-encoding check either, so e.g. 0xC0 0x80 -- an
+  // overlong 2-byte encoding of NUL -- decodes to codepoint 0 exactly
+  // like a bare 0x00 does, via `utf8_2b`'s bit math on two all-zero
+  // payload bytes. Reading the codepoint is only safe once the sequence
+  // is already confirmed to fit, hence checking it after the length
+  // guard below rather than folding it into the same pass.
+  size_t safe_len = in_len;
+  size_t tail_len = 0;
+  {
+    size_t p = 0;
+    while (p < in_len) {
+      unsigned char c = (unsigned char)encoded[p];
+      size_t seq_len = (c < 0x80) ? 1 : (c < 0xE0) ? 2 : (c < 0xF0) ? 3 : 4;
+      if (p + seq_len > in_len) {
+        safe_len = p;
+        tail_len = in_len - p;
+        break;
+      }
+      uint32_t codepoint;
+      nu_utf8_read(encoded + p, &codepoint);
+      if (codepoint == 0) {
+        safe_len = p;
+        break;
+      }
+      p += seq_len;
+    }
+  }
+
   uint32_t u_stack_buffer[SSO_MAX_LENGTH];
   uint32_t *u_buffer = u_stack_buffer;
   char *longer_dst = NULL;
 
-  ssize_t u_len = nu_strtransformnlen(encoded, in_len, nu_utf8_read,
+  ssize_t u_len = nu_strtransformnlen(encoded, safe_len, nu_utf8_read,
                                               nu_tolower, nu_casemap_read);
 
   if (u_len > (SSO_MAX_LENGTH - 1)) {
@@ -159,7 +217,7 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
   // Decode utf8 string into Unicode codepoints and transform to lower
   const char *encoded_char = encoded;
   unsigned i = 0;
-  while (encoded_char < encoded + in_len) {
+  while (encoded_char < encoded + safe_len) {
     uint32_t codepoint = 0;
     // Read unicode codepoint from utf8 string
     // This might read more than one char.
@@ -192,20 +250,38 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
   RS_LOG_ASSERT_FMT(i == u_len, "i (%u) should be equal to u_len (%zd)", i, u_len);
   // Encode Unicode codepoints back to utf8 string
   ssize_t reencoded_len = nu_bytenlen(u_buffer, i, nu_utf8_write);
-  if (reencoded_len > 0) {
-    if (reencoded_len <= in_len) {
+  if (reencoded_len > 0 || tail_len > 0) {
+    size_t head_len = reencoded_len > 0 ? (size_t)reencoded_len : 0;
+    size_t total_len = head_len + tail_len;
+    if (total_len <= in_len) {
       // If the reencoded length is less than or equal to the original length,
       // we can write directly to the original buffer
       // Write the reencoded string back to the original buffer
       // Note: nu_writenstr does not null-terminate the string, so we handle that separately
       // it should be updated by the caller if needed
-      nu_writenstr(u_buffer, i, encoded, nu_utf8_write);
+      // `total_len <= in_len` and `total_len = head_len + tail_len` (with
+      // `tail_len = in_len - safe_len`) together guarantee `head_len <=
+      // safe_len`, so the head write above never touches the excluded
+      // suffix still sitting at its original offset. `head_len` can still
+      // be less than `safe_len` (the head shrank), so the source and
+      // destination ranges here can overlap -- memmove, not memcpy.
+      if (head_len > 0) {
+        nu_writenstr(u_buffer, i, encoded, nu_utf8_write);
+      }
+      if (tail_len > 0) {
+        memmove(encoded + head_len, encoded + safe_len, tail_len);
+      }
     } else {
-      longer_dst = (char *)rm_malloc((reencoded_len + 1) * sizeof(*longer_dst));
-      nu_writenstr(u_buffer, i, longer_dst, nu_utf8_write);
-      longer_dst[reencoded_len] = '\0';
+      longer_dst = (char *)rm_malloc((total_len + 1) * sizeof(*longer_dst));
+      if (head_len > 0) {
+        nu_writenstr(u_buffer, i, longer_dst, nu_utf8_write);
+      }
+      if (tail_len > 0) {
+        memcpy(longer_dst + head_len, encoded + safe_len, tail_len);
+      }
+      longer_dst[total_len] = '\0';
     }
-    *inout_len = reencoded_len;
+    *inout_len = total_len;
   }
 
   // Free heap-allocated memory if needed

--- a/tests/cpptests/test_cpp_unicode_tolower.cpp
+++ b/tests/cpptests/test_cpp_unicode_tolower.cpp
@@ -246,3 +246,142 @@ TEST_F(UnicodeToLowerTest, testEmbeddedNulAfterMultibyte) {
   ASSERT_EQ(str[4], 'B');
   ASSERT_EQ(str[5], 'C');
 }
+
+TEST_F(UnicodeToLowerTest, testInvalidUtf8LeadByteAtEnd) {
+  // A trailing byte whose declared sequence doesn't fit in the string is
+  // left unchanged instead of decoded.
+  char str[] = {'c', 'a', 'f', (char)0xff};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'c');
+  ASSERT_EQ(str[1], 'a');
+  ASSERT_EQ(str[2], 'f');
+  ASSERT_EQ((unsigned char)str[3], 0xff);
+}
+
+TEST_F(UnicodeToLowerTest, testInvalidUtf8LeadByteAfterUppercase) {
+  // Companion to testInvalidUtf8LeadByteAtEnd: the real (safe) prefix must
+  // still lowercase normally, only the dangling byte itself is left alone.
+  char str[] = {'C', 'A', 'F', (char)0xff};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'c');
+  ASSERT_EQ(str[1], 'a');
+  ASSERT_EQ(str[2], 'f');
+  ASSERT_EQ((unsigned char)str[3], 0xff);
+}
+
+TEST_F(UnicodeToLowerTest, testDanglingFourByteLeadWithPartialContinuation) {
+  // 0xf0 is a valid 4-byte UTF-8 lead byte (unlike 0xff above), but it still
+  // declares 3 continuation bytes it does not have here -- the guard is not
+  // specific to invalid lead bytes, only to whether the declared sequence
+  // fits within the string.
+  char str[] = {'a', 'b', (char)0xf0};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'a');
+  ASSERT_EQ(str[1], 'b');
+  ASSERT_EQ((unsigned char)str[2], 0xf0);
+}
+
+TEST_F(UnicodeToLowerTest, testDanglingThreeByteLeadWithOneContinuationByte) {
+  // 0xe0 declares a 3-byte sequence; only one continuation byte (0x80)
+  // follows it here instead of the two it needs, so it dangles too.
+  char str[] = {'a', 'b', (char)0xe0, (char)0x80};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'a');
+  ASSERT_EQ(str[1], 'b');
+  ASSERT_EQ((unsigned char)str[2], 0xe0);
+  ASSERT_EQ((unsigned char)str[3], 0x80);
+}
+
+TEST_F(UnicodeToLowerTest, testChainedDanglingLeads) {
+  // Two dangling lead bytes back to back are both left unchanged.
+  char str[] = {'a', 'b', (char)0xf0, (char)0xff};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'a');
+  ASSERT_EQ(str[1], 'b');
+  ASSERT_EQ((unsigned char)str[2], 0xf0);
+  ASSERT_EQ((unsigned char)str[3], 0xff);
+}
+
+TEST_F(UnicodeToLowerTest, testDanglingLeadFollowedByMoreContent) {
+  // A dangling lead byte is not necessarily the last byte of the string
+  // -- e.g. the prefix-query token "caf<0xff>*" ends with a trailing '*' // codespell:ignore
+  // after the dangling byte. 0xff still declares a 4-byte sequence that
+  // does not fit within in_len, regardless of what follows it, so it and
+  // everything after it must be excluded from decoding.
+  char str[] = {'c', 'a', 'f', (char)0xff, '*'};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], 'c');
+  ASSERT_EQ(str[1], 'a');
+  ASSERT_EQ(str[2], 'f');
+  ASSERT_EQ((unsigned char)str[3], 0xff);
+  ASSERT_EQ(str[4], '*');
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulBeforeDanglingLead) {
+  // A leading multibyte sequence (bypassing the ASCII fast path above)
+  // followed by an embedded NUL, then more content, then a dangling
+  // lead byte. The decode loop stops at the NUL, same as
+  // testEmbeddedNulBeforeMultibyte -- the dangling lead further along
+  // must not cause the bytes between the NUL and it ('c', 'd') to be
+  // silently dropped while the dangling byte itself is spliced back in
+  // as if it were a preserved tail.
+  char str[] = {(char)0xC3, (char)0x89, '\0', 'c', 'd', (char)0xff}; // "\xC3\x89" == U+00C9 (E acute, upper)
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Fits in the original buffer
+  ASSERT_EQ(newLen, 2u);
+  ASSERT_EQ((unsigned char)str[0], 0xC3);
+  ASSERT_EQ((unsigned char)str[1], 0xA9); // lowered to U+00E9 (e acute)
+}
+
+TEST_F(UnicodeToLowerTest, testOverlongNulEncoding) {
+  // 0xC0 0x80 is an overlong encoding of NUL (U+0000); it truncates the
+  // string the same way a literal 0x00 byte would.
+  char str[] = {(char)0xC0, (char)0x80, 'x', 'y', (char)0xff};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // No codepoints decoded, nothing to (re)allocate
+  ASSERT_EQ(newLen, sizeof(str)); // No output produced -- left untouched, same as testEmbeddedNulAtStart
+  ASSERT_EQ((unsigned char)str[0], 0xC0);
+  ASSERT_EQ((unsigned char)str[1], 0x80);
+  ASSERT_EQ(str[2], 'x');
+  ASSERT_EQ(str[3], 'y');
+  ASSERT_EQ((unsigned char)str[4], 0xff);
+}
+
+TEST_F(UnicodeToLowerTest, testDanglingLeadAfterExpandingLowercase) {
+  // İ (U+0130, C4 B0) lowers to i + combining dot above (U+0307, i.e.
+  // 69 CC 87) -- 3 bytes from 2, an expansion, same as testTurkishDottedI.
+  // Followed by a dangling 0xff, total_len (head + 1-byte tail) exceeds
+  // in_len, so this is the only case that exercises the reallocated
+  // longer_dst buffer's tail-append memcpy, as opposed to the in-place
+  // memmove every other dangling-tail test above goes through.
+  char str[] = {(char)0xC4, (char)0xB0, (char)0xff};
+  size_t newLen = sizeof(str);
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_NE(dst, nullptr); // Expansion forces a reallocated buffer
+  ASSERT_EQ(newLen, 4u);
+  ASSERT_EQ(dst[0], 'i');
+  ASSERT_EQ((unsigned char)dst[1], 0xCC);
+  ASSERT_EQ((unsigned char)dst[2], 0x87);
+  ASSERT_EQ((unsigned char)dst[3], 0xff);
+  rm_free(dst);
+}

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1179,3 +1179,67 @@ def testTagSuffixTrieInfoOverhead(env):
         res = env.cmd('FT.SEARCH', 'idx', '@t:{*llo}', 'NOCONTENT')
         env.assertEqual(res[0], 2)  # hello, jello
         env.assertEqual(py2sorted(res[1:]), ['doc1', 'doc2'])
+
+# A byte `nu_utf8_read` (deps/libnu/utf8.h) treats as the lead byte of a
+# 4-byte UTF-8 sequence -- any byte >= 0xf0 -- but which is not a valid UTF-8
+# lead byte at all (only 0xf0-0xf4 are). `utf8_4b` (deps/libnu/utf8_internal.h)
+# unconditionally reads the 3 bytes following the lead byte with no bounds
+# check, so ending a token in this byte makes the decoder read past whatever
+# it is embedded in.
+_INVALID_UTF8_LEAD = b'\xff'
+
+def _assertSurvivesInvalidUtf8TagToken(env, conn, query):
+    """Send `query` (a tag token ending in `_INVALID_UTF8_LEAD`) and assert
+    the server survives it.
+
+    Case-insensitive tag matching lowercases every non-ASCII token through
+    `unicode_tolower` (src/util/strconv.h), which decodes it with
+    `nu_utf8_read`. That decoder has no bounds checking of its own: a lead
+    byte whose declared multi-byte sequence extends past the token's length
+    reads past the token's allocation regardless of what memory follows it.
+    Under AddressSanitizer (`SAN=address`) this is an immediate, reliably
+    detected heap-buffer-overflow; on a plain build it silently reads
+    adjacent heap memory instead of crashing. A correct build bounds the
+    read and stays responsive either way.
+    """
+    try:
+        conn.execute_command('FT.SEARCH', 'idx', query, 'NOCONTENT')
+    except Exception:
+        # A graceful error reply is fine; a dropped connection means the
+        # server crashed, which the liveness check below reports. Either
+        # way the test must not stop here.
+        pass
+
+    # check server is still alive
+    try:
+        alive = bool(conn.execute_command('PING'))
+    except redis.exceptions.ConnectionError:
+        alive = False
+    env.assertTrue(alive,
+                    message='server crashed evaluating an invalid-UTF-8 tag token: %r' % query)
+
+def testTagInvalidUtf8LoweringOverflow():
+    """Regression: a case-insensitive tag token ending in a byte
+    `nu_utf8_read` reads as a multi-byte UTF-8 lead must not overflow past
+    its allocation during `unicode_tolower`'s lowering.
+
+    Covers the token, prefix, and wildcard branches, which each reach
+    `tag_strtolower` independently in `src/query.c`. See
+    `_assertSurvivesInvalidUtf8TagToken` for the overflow mechanism.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello')
+
+    # Exact token, through QN_TOKEN. A leading ASCII run keeps the invalid
+    # byte off the very first position, off the ASCII-only fast path that
+    # ASCII-only tokens like `hello` above would take.
+    _assertSurvivesInvalidUtf8TagToken(env, conn, b'@t:{caf' + _INVALID_UTF8_LEAD + b'}')
+    # Prefix token, through Query_EvalTagPrefixNode.
+    _assertSurvivesInvalidUtf8TagToken(env, conn, b'@t:{caf' + _INVALID_UTF8_LEAD + b'*}')
+    # Wildcard token, through Query_EvalTagWildcardNode.
+    _assertSurvivesInvalidUtf8TagToken(env, conn, b"@t:{w'caf" + _INVALID_UTF8_LEAD + b"*'}")
+
+    # The server must still serve a well-formed tag query.
+    env.expect('FT.SEARCH', 'idx', '@t:{hello}', 'NOCONTENT').equal([1, 'doc1'])

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1218,7 +1218,7 @@ def _assertSurvivesInvalidUtf8TagToken(env, conn, query):
     env.assertTrue(alive,
                     message='server crashed evaluating an invalid-UTF-8 tag token: %r' % query)
 
-def testTagInvalidUtf8LoweringOverflow():
+def testTagInvalidUtf8LoweringOverflow(env):
     """Regression: a case-insensitive tag token ending in a byte
     `nu_utf8_read` reads as a multi-byte UTF-8 lead must not overflow past
     its allocation during `unicode_tolower`'s lowering.
@@ -1227,7 +1227,6 @@ def testTagInvalidUtf8LoweringOverflow():
     `tag_strtolower` independently in `src/query.c`. See
     `_assertSurvivesInvalidUtf8TagToken` for the overflow mechanism.
     """
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
     conn.execute_command('HSET', 'doc1', 't', 'hello')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `unicode_tolower` (src/util/strconv.h) decodes a token with
   `nu_utf8_read`, which has no bounds checking — a lead byte >= 0xf0
   (valid or not) makes it unconditionally read the 3 bytes following it.
   A case-insensitive TAG query token ending in such a byte makes the
   decoder read past the token's allocation, a heap-buffer-overflow read
   reachable from `FT.SEARCH`.
2. Change: bound the decode/measure passes to a `safe_len` that excludes
   any trailing lead byte whose declared multi-byte sequence would
   extend past the token; those excluded tail bytes are passed through
   unchanged instead of being decoded.
3. Outcome: invalid or truncated UTF-8 at the end of a tag token no
   longer reads out of bounds. The server stays up and still answers
   queries after such a token; the excluded tail is left unmodified in
   the token.

#### Which additional issues this PR fixes
1. https://github.com/RediSearch/RediSearch/issues/11135

#### Main objects this PR modified
1. `unicode_tolower` (src/util/strconv.h) — the fix itself.
2. `tag_strtolower` / TAG query evaluation (src/query.c) — the reachable
   call site from `FT.SEARCH` on a case-insensitive TAG field.
3. `test_cpp_unicode_tolower.cpp` — 4 new unit tests exercising dangling
   4-byte, 3-byte, and invalid (0xff) lead bytes directly.
4. `test_tags.py` — `testTagInvalidUtf8LoweringOverflow`, covering the
   exact-token, prefix, and wildcard tag-query branches end to end.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-relevant memory-safety fix in shared string lowering used by query parsing; behavior for malformed UTF-8 tails changes (pass-through vs unsafe decode) but scope is bounded to invalid/truncated suffixes.
> 
> **Overview**
> Fixes a **heap-buffer-overflow** when `unicode_tolower` decodes tokens whose last byte looks like a multi-byte UTF-8 lead (e.g. `0xff`) via unbounded `nu_utf8_read`. That path is hit on **case-insensitive TAG** queries (`FT.SEARCH`) when tokens are lowercased.
> 
> The change adds a forward **safe-length** scan: decode/measure only bytes before the first incomplete sequence or decoded **NUL** (including overlong `0xC0 0x80`). Any excluded suffix is **copied through unchanged** after the lowered prefix, using in-place `memmove` or a larger `longer_dst` when casing expansion needs more room.
> 
> **Tests** add C++ coverage for dangling/invalid leads, embedded NUL, and expansion + tail; Python `testTagInvalidUtf8LoweringOverflow` checks the server stays alive for exact, prefix, and wildcard tag tokens ending in `0xff`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a622aaf8ee36b95f0f84ab69ee9602e6d312d266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->