### PR TITLE
[MOD-18106] Fix flaky testSortableFieldWithExpirationAndRegularField timing race

### DIFF
--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -489,8 +489,16 @@ def commonFieldExpiration(env, schema, fields, expiration_interval_to_fields, do
     expected_inverted_index = build_inverted_index_dict_for_documents(expected_results)
     # now allow active expiration to delete the expired fields
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')
-    time.sleep(0.5)
-    env.expect('FT.SEARCH', 'idx', '*').apply(transform_document_list_to_dict).equal(expected_results)
+    # Active expiration runs on Redis's background cycle, so a fixed sleep can be too
+    # short under CI load. Poll for the expected post-expiration state instead of
+    # assuming a single fixed delay is always enough.
+    actual_results = transform_document_list_to_dict(env.cmd('FT.SEARCH', 'idx', '*'))
+    for _ in range(20):
+        if actual_results == expected_results:
+            break
+        time.sleep(0.1)
+        actual_results = transform_document_list_to_dict(env.cmd('FT.SEARCH', 'idx', '*'))
+    env.assertEqual(actual_results, expected_results)
     for field_name_and_value, expected_docs in expected_inverted_index.items():
         (env.expect('FT.SEARCH', 'idx', f'@{field_name_and_value}:{field_name_and_value}', 'NOCONTENT')
          .apply(sort_document_names).equal([len(expected_docs), *expected_docs]))

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -490,15 +490,14 @@ def commonFieldExpiration(env, schema, fields, expiration_interval_to_fields, do
     # now allow active expiration to delete the expired fields
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')
     # Active expiration runs on Redis's background cycle, so a fixed sleep can be too
-    # short under CI load. Poll for the expected post-expiration state instead of
-    # assuming a single fixed delay is always enough.
-    actual_results = transform_document_list_to_dict(env.cmd('FT.SEARCH', 'idx', '*'))
-    for _ in range(20):
-        if actual_results == expected_results:
-            break
-        time.sleep(0.1)
+    # short under CI load. Wait deterministically for the expected post-expiration
+    # state instead of assuming a fixed delay is always enough.
+    actual_results = {}
+    def check_expired():
+        nonlocal actual_results
         actual_results = transform_document_list_to_dict(env.cmd('FT.SEARCH', 'idx', '*'))
-    env.assertEqual(actual_results, expected_results)
+        return actual_results == expected_results, actual_results
+    wait_for_condition(check_expired, 'Timeout waiting for active expiration to reap expired fields', timeout=10)
     for field_name_and_value, expected_docs in expected_inverted_index.items():
         (env.expect('FT.SEARCH', 'idx', f'@{field_name_and_value}:{field_name_and_value}', 'NOCONTENT')
          .apply(sort_document_names).equal([len(expected_docs), *expected_docs]))


### PR DESCRIPTION
## Summary
- `commonFieldExpiration` (used by `testSortableFieldWithExpirationAndRegularField` and other field-expiration tests) enabled active expiration and then slept a fixed 0.5s before asserting the expired fields were gone. Under CI load, active expiration doesn't reliably complete in that window, causing intermittent failures such as https://github.com/redislabsdev/RediSearchEnterprise/actions/runs/33053324567/job/98453931817.
- Replaced the fixed sleep + single assertion with a bounded poll loop (up to 20 tries, 0.1s apart) that waits for the expected post-expiration state, then asserts.

Jira: MOD-18106

## Test plan
- [ ] CI run passes on this branch (RoR OSS suite, standalone)
- [ ] `test_expire.py` field-expiration tests (`testSingleExpireField`, `testTwoFieldsOneOfThemWillExpire`, `testSingleSortableFieldWithExpiration`, `testSortableFieldWithExpirationAndRegularField`, etc.) pass locally