### PR TITLE
ci: add lowercase owner/team tags to EC2 CI runners

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -19,6 +19,8 @@ env:
       {"Key": "Run ID",       "Value": "${{ github.run_id }}"},
       {"Key": "PR",           "Value": "${{ github.event.number }}"},
       {"Key": "Owner",        "Value": "${{ github.actor }}"},
+      {"Key": "owner",        "Value": "${{ github.actor }}"},
+      {"Key": "team",         "Value": "performance_analysis_optimization"},
       {"Key": "Project",      "Value": "${{ github.repository }}"},
       {"Key": "Context",      "Value": "micro-benchmarks"}
     ]

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -25,6 +25,8 @@ env:
       {"Key": "PR",           "Value": "${{ github.event.number }}"},
       {"Key": "Container",    "Value": "${{ inputs.container }}"},
       {"Key": "Owner",        "Value": "${{ github.actor }}"},
+      {"Key": "owner",        "Value": "${{ github.actor }}"},
+      {"Key": "team",         "Value": "performance_analysis_optimization"},
       {"Key": "Project",      "Value": "${{ github.repository }}"}
     ]
 

--- a/.github/workflows/task-start-ec2-runner.yml
+++ b/.github/workflows/task-start-ec2-runner.yml
@@ -44,6 +44,8 @@ jobs:
           {"Key": "Run ID",       "Value": "${{ github.run_id }}"},
           {"Key": "PR",           "Value": "${{ github.event.number }}"},
           {"Key": "Owner",        "Value": "${{ github.actor }}"},
+          {"Key": "owner",        "Value": "${{ github.actor }}"},
+          {"Key": "team",         "Value": "performance_analysis_optimization"},
           {"Key": "Project",      "Value": "${{ github.repository }}"}
         ]
     outputs:


### PR DESCRIPTION
## Summary
- The self-hosted EC2 CI runners (`redisearch-ci-runner`) only ever carried a capitalized `Owner` tag and no `team` tag.
- The org's cost-governance scanner checks for lowercase `owner`/`team` tags specifically, so every runner launched by these workflows shows up as a tagging violation and risks auto-stop.
- Adds `{"Key": "owner", ...}` (mirrors the existing `Owner` value) and `{"Key": "team", "Value": "performance_analysis_optimization"}` to both `flow-micro-benchmarks-runner.yml` and the shared `task-start-ec2-runner.yml`.

## Test plan
- [ ] Trigger a workflow that starts an EC2 runner (e.g. push to a PR touching micro-benchmarks) and confirm the launched instance carries both `owner` and `team` tags via `aws ec2 describe-tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)