### PR TITLE
[MOD-18123] Add per-field indexing latency metrics

### DIFF
--- a/src/disk_indexer.c
+++ b/src/disk_indexer.c
@@ -112,6 +112,7 @@ static void stageText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   ForwardIndexIterator it = ForwardIndex_Iterate(aCtx->fwIdx);
   for (ForwardIndexEntry *entry = ForwardIndexIterator_Next(&it); entry;
        entry = ForwardIndexIterator_Next(&it)) {
+    rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
     const uint8_t *offsets = NULL;
     size_t offsetsLen = 0;
     if ((spec->flags & Index_StoreTermOffsets) && entry->vw) {
@@ -122,6 +123,8 @@ static void stageText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
                                          entry->term, entry->len, aCtx->doc->docId,
                                          entry->fieldMask, entry->freq,
                                          offsets, offsetsLen);
+    Indexer_RecordTextFieldTiming(spec, entry->fieldMask, FIELD_INDEXING_INDEX,
+                                  rs_wall_clock_now_ns() - start);
   }
 }
 
@@ -254,12 +257,15 @@ static void applyTextIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   ForwardIndexIterator it = ForwardIndex_Iterate(aCtx->fwIdx);
   for (ForwardIndexEntry *entry = ForwardIndexIterator_Next(&it); entry;
        entry = ForwardIndexIterator_Next(&it)) {
+    rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
     if (entry->staged) {
       IndexSpec_AddTerm(spec, entry->term, entry->len);
     }
     if (entryWantsSuffixTrie(spec, entry)) {
       addSuffixTrie(spec->suffix, entry->term, entry->len);
     }
+    Indexer_RecordTextFieldTiming(spec, entry->fieldMask, FIELD_INDEXING_APPLY,
+                                  rs_wall_clock_now_ns() - start);
   }
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_FULLTEXT, spec->stats.scoring.numTerms - prevNumTerms);
 }
@@ -305,11 +311,14 @@ static void applyVectorInserts(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
     // the next RDB save would persist that divergence. Match the post-commit
     // policy used by `applyDocTable` for `DocIdMeta_Set` failure.
     RS_LOG_ASSERT_ALWAYS(vecsim, "openVectorIndex returned NULL after a successful disk commit");
+    rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
     const char *curr_vec = (const char *)fdata->vector;
     for (size_t i = 0; i < fdata->numVec; i++) {
       VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
       curr_vec += fdata->vecLen;
     }
+    FieldSpec_AddIndexingTime(&spec->fields[fs->index], FIELD_INDEXING_APPLY,
+                              rs_wall_clock_now_ns() - start);
   }
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -407,6 +407,13 @@ static void writeByteOffsets(ForwardIndexTokenizerCtx *tokCtx, const Token *tokI
   static void name(RSAddDocumentCtx *aCtx, const DocumentField *field,        \
                    const FieldSpec *fs, FieldIndexerData *fdata)
 
+typedef int (*FieldBulkIndexerFunc)(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx,
+                                    const DocumentField *field, const FieldSpec *fs,
+                                    FieldIndexerData *fdata, QueryError *status);
+
+typedef void (*FieldBulkApplierFunc)(RSAddDocumentCtx *aCtx, const DocumentField *field,
+                                     const FieldSpec *fs, FieldIndexerData *fdata);
+
 #define FIELD_BULK_CTOR(name) \
   static void name(IndexBulkData *bulk, const FieldSpec *fs, RedisSearchCtx *ctx)
 #define FIELD_BULK_FINALIZER(name) static void name(IndexBulkData *bulk, RedisSearchCtx *ctx)
@@ -922,6 +929,42 @@ static PreprocessorFunc preprocessorMap[] = {
     [IXFLDPOS_GEOMETRY] = geometryPreprocessor,
     };
 
+static FieldBulkIndexerFunc bulkIndexerMap[] = {
+    [IXFLDPOS_TAG] = tagIndexer,
+    [IXFLDPOS_NUMERIC] = numericIndexer,
+    [IXFLDPOS_GEO] = numericIndexer,
+    [IXFLDPOS_VECTOR] = vectorIndexer,
+    [IXFLDPOS_GEOMETRY] = geometryIndexer,
+};
+
+static FieldBulkApplierFunc bulkApplierMap[] = {
+    [IXFLDPOS_TAG] = tagApplier,
+    [IXFLDPOS_NUMERIC] = numericApplier,
+    [IXFLDPOS_GEO] = geoApplier,
+    [IXFLDPOS_VECTOR] = vectorApplier,
+    [IXFLDPOS_GEOMETRY] = geometryApplier,
+};
+
+static int timedBulkIndex(FieldBulkIndexerFunc indexer, RSAddDocumentCtx *cur,
+                          RedisSearchCtx *sctx, const DocumentField *field,
+                          const FieldSpec *fs, FieldIndexerData *fdata,
+                          QueryError *status) {
+  rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
+  int rc = indexer(cur, sctx, field, fs, fdata, status);
+  FieldSpec_AddIndexingTime(&cur->spec->fields[fs->index], FIELD_INDEXING_INDEX,
+                            rs_wall_clock_now_ns() - start);
+  return rc;
+}
+
+static void timedBulkApply(FieldBulkApplierFunc applier, RSAddDocumentCtx *aCtx,
+                           const DocumentField *field, const FieldSpec *fs,
+                           FieldIndexerData *fdata) {
+  rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
+  applier(aCtx, field, fs, fdata);
+  FieldSpec_AddIndexingTime(&aCtx->spec->fields[fs->index], FIELD_INDEXING_APPLY,
+                            rs_wall_clock_now_ns() - start);
+}
+
 int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
                    const DocumentField *field, const FieldSpec *fs, FieldIndexerData *fdata,
                    QueryError *status) {
@@ -929,34 +972,13 @@ int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
   for (size_t ii = 0; ii < INDEXFLD_NUM_TYPES && rc == 0; ++ii) {
     // see which types are supported in the current field...
     if (field->indexAs & INDEXTYPE_FROM_POS(ii)) {
-      switch (ii) {
-        case IXFLDPOS_TAG:
-          rc = tagIndexer(cur, sctx, field, fs, fdata, status);
-          break;
-        case IXFLDPOS_NUMERIC:
-        case IXFLDPOS_GEO:
-          rc = numericIndexer(cur, sctx, field, fs, fdata, status);
-          break;
-        case IXFLDPOS_VECTOR:
-          // Disk mode: defer the actual `VecSimIndex_AddVector` to
-          // `applyVectorInserts` (called after the batch commits) so a
-          // failed commit never leaves the vector index referencing a
-          // doc-id that was not persisted. The vector blob in
-          // `fdata->vector` is borrowed (not copied) and lives until
-          // `AddDocumentCtx_Free`, so it is safe to read post-commit.
-          if (cur->disk.batch) break;
-          rc = vectorIndexer(cur, sctx, field, fs, fdata, status);
-          break;
-        case IXFLDPOS_GEOMETRY:
-          rc = geometryIndexer(cur, sctx, field, fs, fdata, status);
-          break;
-        case IXFLDPOS_FULLTEXT:
-          break;
-        default:
-          rc = -1;
-          QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "BUG: invalid index type");
-          break;
+      FieldBulkIndexerFunc indexer = bulkIndexerMap[ii];
+      if (!indexer) {
+        continue;
       }
+      // Disk mode defers the actual vector add until after the write batch commits.
+      if (ii == IXFLDPOS_VECTOR && cur->disk.batch) continue;
+      rc = timedBulkIndex(indexer, cur, sctx, field, fs, fdata, status);
     }
   }
   return rc;
@@ -966,13 +988,9 @@ void IndexerBulkApply(RSAddDocumentCtx *aCtx, const DocumentField *field,
                       const FieldSpec *fs, FieldIndexerData *fdata) {
   for (size_t ii = 0; ii < INDEXFLD_NUM_TYPES; ++ii) {
     if (!(field->indexAs & INDEXTYPE_FROM_POS(ii))) continue;
-    switch (ii) {
-      case IXFLDPOS_TAG:      tagApplier(aCtx, field, fs, fdata);      break;
-      case IXFLDPOS_NUMERIC:  numericApplier(aCtx, field, fs, fdata);  break;
-      case IXFLDPOS_GEO:      geoApplier(aCtx, field, fs, fdata);      break;
-      case IXFLDPOS_VECTOR:   vectorApplier(aCtx, field, fs, fdata);   break;
-      case IXFLDPOS_GEOMETRY: geometryApplier(aCtx, field, fs, fdata); break;
-      case IXFLDPOS_FULLTEXT: break;
+    FieldBulkApplierFunc applier = bulkApplierMap[ii];
+    if (applier) {
+      timedBulkApply(applier, aCtx, field, fs, fdata);
     }
   }
 }
@@ -992,7 +1010,11 @@ int Document_AddToIndexes(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
       }
 
       PreprocessorFunc pp = preprocessorMap[ii];
-      if (pp(aCtx, sctx, ff, fs, fdata, &aCtx->status) != 0) {
+      rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
+      int rc = pp(aCtx, sctx, ff, fs, fdata, &aCtx->status);
+      FieldSpec_AddIndexingTime(&aCtx->spec->fields[fs->index], FIELD_INDEXING_PREPROCESS,
+                                rs_wall_clock_now_ns() - start);
+      if (rc != 0) {
         IndexError_AddQueryError(&aCtx->spec->stats.indexError, &aCtx->status, doc->docKey);
         FieldSpec_AddQueryError(&aCtx->spec->fields[fs->index], &aCtx->status, doc->docKey);
         ourRv = REDISMODULE_ERR;

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -15,6 +15,7 @@
 #include "geometry/geometry_types.h"
 #include "info/index_error.h"
 #include "obfuscation/hidden.h"
+#include "rs_wall_clock.h"
 
 struct TagIndex;
 struct NumericRangeTree;
@@ -76,6 +77,23 @@ typedef enum {
 } FieldSpecOptions;
 
 RS_ENUM_BITWISE_HELPER(FieldSpecOptions)
+
+typedef enum {
+  FIELD_INDEXING_PREPROCESS = 0,
+  FIELD_INDEXING_INDEX = 1,
+  FIELD_INDEXING_APPLY = 2,
+  FIELD_INDEXING_NUM_PHASES,
+} FieldIndexingPhase;
+
+typedef struct FieldIndexingPhaseStats {
+  uint64_t count;
+  rs_wall_clock_ns_t totalTimeNs;
+  rs_wall_clock_ns_t maxTimeNs;
+} FieldIndexingPhaseStats;
+
+typedef struct FieldIndexingStats {
+  FieldIndexingPhaseStats phases[FIELD_INDEXING_NUM_PHASES];
+} FieldIndexingStats;
 
 // Flags for tag fields
 typedef enum {
@@ -143,6 +161,7 @@ typedef struct FieldSpec {
 
   // The index error for this field
   IndexError indexError;
+  FieldIndexingStats indexingStats;
 } FieldSpec;
 
 #define FIELD_IS(f, t) (((f)->types) & (t))
@@ -180,6 +199,16 @@ void FieldSpec_AddError(FieldSpec *, ConstErrorMessage withoutUserData, ConstErr
 
 static inline void FieldSpec_AddQueryError(FieldSpec *fs, const QueryError *queryError, RedisModuleString *key) {
   FieldSpec_AddError(fs, QueryError_GetDisplayableError(queryError, true), QueryError_GetDisplayableError(queryError, false), key);
+}
+
+static inline void FieldSpec_AddIndexingTime(FieldSpec *fs, FieldIndexingPhase phase,
+                                             rs_wall_clock_ns_t duration) {
+  FieldIndexingPhaseStats *stats = &fs->indexingStats.phases[phase];
+  stats->count++;
+  stats->totalTimeNs += duration;
+  if (duration > stats->maxTimeNs) {
+    stats->maxTimeNs = duration;
+  }
 }
 
 size_t FieldSpec_GetIndexErrorCount(const FieldSpec *);

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -201,14 +201,34 @@ static inline void FieldSpec_AddQueryError(FieldSpec *fs, const QueryError *quer
   FieldSpec_AddError(fs, QueryError_GetDisplayableError(queryError, true), QueryError_GetDisplayableError(queryError, false), key);
 }
 
+// Indexing worker threads call this concurrently with each other and with FT.INFO's
+// unlocked read of the same counters (see `FieldSpec_GetIndexingStats`), so every
+// field is updated atomically rather than with plain ++/+=.
 static inline void FieldSpec_AddIndexingTime(FieldSpec *fs, FieldIndexingPhase phase,
                                              rs_wall_clock_ns_t duration) {
   FieldIndexingPhaseStats *stats = &fs->indexingStats.phases[phase];
-  stats->count++;
-  stats->totalTimeNs += duration;
-  if (duration > stats->maxTimeNs) {
-    stats->maxTimeNs = duration;
+  __atomic_fetch_add(&stats->count, 1, __ATOMIC_RELAXED);
+  __atomic_fetch_add(&stats->totalTimeNs, duration, __ATOMIC_RELAXED);
+  rs_wall_clock_ns_t cur = __atomic_load_n(&stats->maxTimeNs, __ATOMIC_RELAXED);
+  while (duration > cur &&
+         !__atomic_compare_exchange_n(&stats->maxTimeNs, &cur, duration, true, __ATOMIC_RELAXED,
+                                       __ATOMIC_RELAXED)) {
+    // `cur` is refreshed with the current value on CAS failure; retry.
   }
+}
+
+// Snapshot `fs->indexingStats` with atomic loads, matching the atomic writes in
+// `FieldSpec_AddIndexingTime`. Callers (FT.INFO) read this without the spec lock.
+static inline FieldIndexingStats FieldSpec_GetIndexingStats(const FieldSpec *fs) {
+  FieldIndexingStats stats = {0};
+  for (int phase = 0; phase < FIELD_INDEXING_NUM_PHASES; ++phase) {
+    const FieldIndexingPhaseStats *src = &fs->indexingStats.phases[phase];
+    FieldIndexingPhaseStats *dst = &stats.phases[phase];
+    dst->count = __atomic_load_n(&src->count, __ATOMIC_RELAXED);
+    dst->totalTimeNs = __atomic_load_n(&src->totalTimeNs, __ATOMIC_RELAXED);
+    dst->maxTimeNs = __atomic_load_n(&src->maxTimeNs, __ATOMIC_RELAXED);
+  }
+  return stats;
 }
 
 size_t FieldSpec_GetIndexErrorCount(const FieldSpec *);

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -203,7 +203,13 @@ static inline void FieldSpec_AddQueryError(FieldSpec *fs, const QueryError *quer
 
 // Indexing worker threads call this concurrently with each other and with FT.INFO's
 // unlocked read of the same counters (see `FieldSpec_GetIndexingStats`), so every
-// field is updated atomically rather than with plain ++/+=.
+// field is updated atomically rather than with plain ++/+=. The three fields are
+// updated as independent atomics rather than under one lock: a concurrent reader
+// can therefore observe a torn combination of a phase's sample (e.g. a `count`
+// bump not yet paired with its `totalTimeNs`), including transiently seeing
+// `maxTimeNs` exceed `totalTimeNs`. These are informational stats on a per-entry
+// indexing hot path, so this is an accepted trade-off rather than a lock: it
+// self-corrects on the next read once all writers finish.
 static inline void FieldSpec_AddIndexingTime(FieldSpec *fs, FieldIndexingPhase phase,
                                              rs_wall_clock_ns_t duration) {
   FieldIndexingPhaseStats *stats = &fs->indexingStats.phases[phase];

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -47,6 +47,7 @@
 #include "synonym_map.h"
 #include "ttl_table.h"
 #include "ttl_table_rs.h"
+#include "util/arr/arr.h"
 #include "util/block_alloc.h"
 #include "util/dict/dict.h"
 #include "util/khtable.h"
@@ -74,6 +75,21 @@ static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEnt
   if (spec->flags & Index_StoreTermOffsets) {
     spec->stats.offsetVecsSize += VVW_GetByteLength(entry->vw);
     spec->stats.offsetVecRecords += VVW_GetCount(entry->vw);
+  }
+}
+
+static void recordTextIndexingTime(IndexSpec *spec, t_fieldMask fieldMask,
+                                   rs_wall_clock_ns_t duration) {
+  while (fieldMask) {
+    t_fieldId fieldId = (t_fieldId)__builtin_ctzll(fieldMask);
+    fieldMask &= fieldMask - 1;
+    if (fieldId >= array_len(spec->fieldIdToIndex)) {
+      continue;
+    }
+    t_fieldIndex fieldIndex = spec->fieldIdToIndex[fieldId];
+    if (fieldIndex < spec->numFields) {
+      FieldSpec_AddIndexingTime(&spec->fields[fieldIndex], FIELD_INDEXING_INDEX, duration);
+    }
   }
 }
 
@@ -158,6 +174,7 @@ static void indexText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   ForwardIndexIterator it = ForwardIndex_Iterate(aCtx->fwIdx);
   for (ForwardIndexEntry *entry = ForwardIndexIterator_Next(&it); entry;
        entry = ForwardIndexIterator_Next(&it)) {
+    rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
     bool isNew;
     InvertedIndex *invidx = Redis_OpenInvertedIndex(spec, entry->term, entry->len, 1, &isNew);
     if (invidx) {
@@ -171,6 +188,7 @@ static void indexText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
     if (entryWantsSuffixTrie(spec, entry)) {
       addSuffixTrie(spec->suffix, entry->term, entry->len);
     }
+    recordTextIndexingTime(spec, entry->fieldMask, rs_wall_clock_now_ns() - start);
   }
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_FULLTEXT, spec->stats.scoring.numTerms - prevNumTerms);
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -47,7 +47,6 @@
 #include "synonym_map.h"
 #include "ttl_table.h"
 #include "ttl_table_rs.h"
-#include "util/arr/arr.h"
 #include "util/block_alloc.h"
 #include "util/dict/dict.h"
 #include "util/khtable.h"
@@ -75,21 +74,6 @@ static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEnt
   if (spec->flags & Index_StoreTermOffsets) {
     spec->stats.offsetVecsSize += VVW_GetByteLength(entry->vw);
     spec->stats.offsetVecRecords += VVW_GetCount(entry->vw);
-  }
-}
-
-static void recordTextIndexingTime(IndexSpec *spec, t_fieldMask fieldMask,
-                                   rs_wall_clock_ns_t duration) {
-  while (fieldMask) {
-    t_fieldId fieldId = (t_fieldId)__builtin_ctzll(fieldMask);
-    fieldMask &= fieldMask - 1;
-    if (fieldId >= array_len(spec->fieldIdToIndex)) {
-      continue;
-    }
-    t_fieldIndex fieldIndex = spec->fieldIdToIndex[fieldId];
-    if (fieldIndex < spec->numFields) {
-      FieldSpec_AddIndexingTime(&spec->fields[fieldIndex], FIELD_INDEXING_INDEX, duration);
-    }
   }
 }
 
@@ -188,7 +172,8 @@ static void indexText(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
     if (entryWantsSuffixTrie(spec, entry)) {
       addSuffixTrie(spec->suffix, entry->term, entry->len);
     }
-    recordTextIndexingTime(spec, entry->fieldMask, rs_wall_clock_now_ns() - start);
+    Indexer_RecordTextFieldTiming(spec, entry->fieldMask, FIELD_INDEXING_INDEX,
+                                  rs_wall_clock_now_ns() - start);
   }
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_FULLTEXT, spec->stats.scoring.numTerms - prevNumTerms);
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -421,7 +421,8 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx,
   // go over all the potentially missing fields and index the document in the matching inverted index
   dictIterator* iter = dictGetIterator(df_fields_dict);
   for (dictEntry *entry = dictNext(iter); entry; entry = dictNext(iter)) {
-    const FieldSpec *fs = dictGetVal(entry);
+    FieldSpec *fs = dictGetVal(entry);
+    rs_wall_clock_ns_t start = rs_wall_clock_now_ns();
     InvertedIndex *iiMissingDocs = dictFetchValue(spec->missingFieldDict, fs->fieldName);
     if (iiMissingDocs == NULL) {
       size_t index_size;
@@ -445,6 +446,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx,
     AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
     aCtx->spec->stats.invertedSize += r.mem_growth;
     IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
+    FieldSpec_AddIndexingTime(fs, FIELD_INDEXING_INDEX, rs_wall_clock_now_ns() - start);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);

--- a/src/indexer_internal.h
+++ b/src/indexer_internal.h
@@ -22,6 +22,7 @@
 #include "phonetic_manager.h"
 #include "stemmer.h"
 #include "synonym_map.h"
+#include "util/arr/arr.h"
 
 #include <stdbool.h>
 #include <string.h>
@@ -68,6 +69,34 @@ static inline bool entryWantsSuffixTrie(const IndexSpec *spec, const ForwardInde
       && entry->term[0] != PHONETIC_PREFIX
       && entry->term[0] != SYNONYM_PREFIX_CHAR
       && strlen(entry->term) != 0;
+}
+
+/**
+ * Attribute `duration` to every TEXT field set in `fieldMask` for the given
+ * indexing phase. `fieldMask` is in `ftId` bit space (see `FIELD_BIT`), which
+ * spans the full width of `t_fieldMask` — 128 bits on 64-bit builds — so this
+ * tests one bit at a time rather than a `ctz`-family builtin, which only
+ * examines the low 64 bits.
+ *
+ * Memory mode calls this once per forward-index entry from `indexText`
+ * (`FIELD_INDEXING_INDEX`); disk mode calls it from the matching points in
+ * `stageText` (`FIELD_INDEXING_INDEX`) and `applyTextIndex` (`FIELD_INDEXING_APPLY`).
+ */
+static inline void Indexer_RecordTextFieldTiming(IndexSpec *spec, t_fieldMask fieldMask,
+                                                  FieldIndexingPhase phase,
+                                                  rs_wall_clock_ns_t duration) {
+  for (t_fieldId fieldId = 0; fieldMask; ++fieldId, fieldMask >>= 1) {
+    if (!(fieldMask & 1)) {
+      continue;
+    }
+    if (fieldId >= array_len(spec->fieldIdToIndex)) {
+      continue;
+    }
+    t_fieldIndex fieldIndex = spec->fieldIdToIndex[fieldId];
+    if (fieldIndex < spec->numFields) {
+      FieldSpec_AddIndexingTime(&spec->fields[fieldIndex], phase, duration);
+    }
+  }
 }
 
 #ifdef __cplusplus

--- a/src/indexer_internal.h
+++ b/src/indexer_internal.h
@@ -75,8 +75,9 @@ static inline bool entryWantsSuffixTrie(const IndexSpec *spec, const ForwardInde
  * Attribute `duration` to every TEXT field set in `fieldMask` for the given
  * indexing phase. `fieldMask` is in `ftId` bit space (see `FIELD_BIT`), which
  * spans the full width of `t_fieldMask` — 128 bits on 64-bit builds — so this
- * tests one bit at a time rather than a `ctz`-family builtin, which only
- * examines the low 64 bits.
+ * walks the mask 64 bits at a time and uses `__builtin_ctzll` within each word
+ * to jump straight to each set bit; a plain `ctz`-family call on the whole
+ * mask would only examine the low 64 bits and misattribute higher `ftId`s.
  *
  * Memory mode calls this once per forward-index entry from `indexText`
  * (`FIELD_INDEXING_INDEX`); disk mode calls it from the matching points in
@@ -85,16 +86,19 @@ static inline bool entryWantsSuffixTrie(const IndexSpec *spec, const ForwardInde
 static inline void Indexer_RecordTextFieldTiming(IndexSpec *spec, t_fieldMask fieldMask,
                                                   FieldIndexingPhase phase,
                                                   rs_wall_clock_ns_t duration) {
-  for (t_fieldId fieldId = 0; fieldMask; ++fieldId, fieldMask >>= 1) {
-    if (!(fieldMask & 1)) {
-      continue;
-    }
-    if (fieldId >= array_len(spec->fieldIdToIndex)) {
-      continue;
-    }
-    t_fieldIndex fieldIndex = spec->fieldIdToIndex[fieldId];
-    if (fieldIndex < spec->numFields) {
-      FieldSpec_AddIndexingTime(&spec->fields[fieldIndex], phase, duration);
+  const int numWords = (int)(sizeof(t_fieldMask) * 8 / 64);
+  for (int word = 0; word < numWords; ++word) {
+    uint64_t bits = (uint64_t)(fieldMask >> (word * 64));
+    while (bits) {
+      t_fieldId fieldId = (t_fieldId)(word * 64 + __builtin_ctzll(bits));
+      bits &= bits - 1; // clear the lowest set bit
+      if (fieldId >= array_len(spec->fieldIdToIndex)) {
+        continue;
+      }
+      t_fieldIndex fieldIndex = spec->fieldIdToIndex[fieldId];
+      if (fieldIndex < spec->numFields) {
+        FieldSpec_AddIndexingTime(&spec->fields[fieldIndex], phase, duration);
+      }
     }
   }
 }

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -30,6 +30,30 @@
 #define FIELD_DISK_TOTAL_BYTES     "disk_total_bytes"
 #define FIELD_DISK_NUM_KEYS        "disk_num_keys"
 
+typedef struct FieldIndexingPhaseReplyKeys {
+    const char *count;
+    const char *totalTimeNs;
+    const char *maxTimeNs;
+} FieldIndexingPhaseReplyKeys;
+
+static const FieldIndexingPhaseReplyKeys FieldIndexingReplyKeys[FIELD_INDEXING_NUM_PHASES] = {
+    [FIELD_INDEXING_PREPROCESS] = {
+        .count = "indexing_preprocess_count",
+        .totalTimeNs = "indexing_preprocess_time_ns",
+        .maxTimeNs = "indexing_preprocess_max_time_ns",
+    },
+    [FIELD_INDEXING_INDEX] = {
+        .count = "indexing_index_count",
+        .totalTimeNs = "indexing_index_time_ns",
+        .maxTimeNs = "indexing_index_max_time_ns",
+    },
+    [FIELD_INDEXING_APPLY] = {
+        .count = "indexing_apply_count",
+        .totalTimeNs = "indexing_apply_time_ns",
+        .maxTimeNs = "indexing_apply_max_time_ns",
+    },
+};
+
 static FieldType getFieldType(const char *type){
     if (strcmp(type, "vector") == 0) {
         return INDEXFLD_T_VECTOR;
@@ -61,6 +85,22 @@ static void PerFieldCfDiskMetrics_Combine(PerFieldCfDiskMetrics *dst,
     dst->available = true;
 }
 
+static void FieldIndexingPhaseStats_Combine(FieldIndexingPhaseStats *dst,
+                                            const FieldIndexingPhaseStats *src) {
+    dst->count += src->count;
+    dst->totalTimeNs += src->totalTimeNs;
+    if (src->maxTimeNs > dst->maxTimeNs) {
+        dst->maxTimeNs = src->maxTimeNs;
+    }
+}
+
+static void FieldIndexingStats_Combine(FieldIndexingStats *dst,
+                                       const FieldIndexingStats *src) {
+    for (FieldIndexingPhase phase = 0; phase < FIELD_INDEXING_NUM_PHASES; ++phase) {
+        FieldIndexingPhaseStats_Combine(&dst->phases[phase], &src->phases[phase]);
+    }
+}
+
 static void FieldSpecStats_Combine(FieldSpecStats *first, const FieldSpecStats *second) {
     // The field type is consistent across shards; adopt it from the first shard
     // that reports one (non-vector fields carry type 0 on the coordinator).
@@ -70,6 +110,7 @@ static void FieldSpecStats_Combine(FieldSpecStats *first, const FieldSpecStats *
     if (first->type == INDEXFLD_T_VECTOR) {
         VectorIndexStats_Agg(&first->vecStats, &second->vecStats);
     }
+    FieldIndexingStats_Combine(&first->indexingStats, &second->indexingStats);
     // Disk metrics apply to every field type, independently of `type`.
     PerFieldTextDiskMetrics_Combine(&first->textDisk, &second->textDisk);
     PerFieldCfDiskMetrics_Combine(&first->cfDisk, &second->cfDisk);
@@ -141,6 +182,21 @@ static void FieldStats_DeserializeDiskMetrics(FieldSpecStats *stats, const MRRep
     }
 }
 
+static uint64_t FieldStats_DeserializeOptionalInteger(const MRReply *reply, const char *key) {
+    MRReply *metricReply = MRReply_MapElement(reply, key);
+    return metricReply ? (uint64_t)MRReply_Integer(metricReply) : 0;
+}
+
+static void FieldStats_DeserializeIndexingStats(FieldSpecStats *stats, const MRReply *reply) {
+    for (FieldIndexingPhase phase = 0; phase < FIELD_INDEXING_NUM_PHASES; ++phase) {
+        const FieldIndexingPhaseReplyKeys *keys = &FieldIndexingReplyKeys[phase];
+        FieldIndexingPhaseStats *phaseStats = &stats->indexingStats.phases[phase];
+        phaseStats->count = FieldStats_DeserializeOptionalInteger(reply, keys->count);
+        phaseStats->totalTimeNs = FieldStats_DeserializeOptionalInteger(reply, keys->totalTimeNs);
+        phaseStats->maxTimeNs = FieldStats_DeserializeOptionalInteger(reply, keys->maxTimeNs);
+    }
+}
+
 static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* reply){
     FieldSpecStats stats = {0};
     FieldType fieldType = getFieldType(type);
@@ -160,6 +216,7 @@ static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* re
         default:
             break;
     }
+    FieldStats_DeserializeIndexingStats(&stats, reply);
     // Disk metrics are field-type independent and keyed by name, so parse them
     // for every field regardless of the vector switch above.
     FieldStats_DeserializeDiskMetrics(&stats, reply);
@@ -167,6 +224,19 @@ static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* re
 }
 
 // IO and cluster traits
+
+static void FieldIndexingStats_Reply(const FieldIndexingStats* stats, RedisModule_Reply *reply){
+    for (FieldIndexingPhase phase = 0; phase < FIELD_INDEXING_NUM_PHASES; ++phase) {
+        const FieldIndexingPhaseStats *phaseStats = &stats->phases[phase];
+        if (phaseStats->count == 0) {
+            continue;
+        }
+        const FieldIndexingPhaseReplyKeys *keys = &FieldIndexingReplyKeys[phase];
+        REPLY_KVINT(keys->count, (long long)phaseStats->count);
+        REPLY_KVINT(keys->totalTimeNs, (long long)phaseStats->totalTimeNs);
+        REPLY_KVINT(keys->maxTimeNs, (long long)phaseStats->maxTimeNs);
+    }
+}
 
 void FieldSpecStats_Reply(const FieldSpecStats* stats, RedisModule_Reply *reply){
     RS_ASSERT(stats);
@@ -181,6 +251,8 @@ void FieldSpecStats_Reply(const FieldSpecStats* stats, RedisModule_Reply *reply)
         default:
             break;
     }
+
+    FieldIndexingStats_Reply(&stats->indexingStats, reply);
 
     // Per-field disk metrics (disk-backed indexes only; gated on `available`).
     if (stats->textDisk.available) {
@@ -306,12 +378,13 @@ VectorIndexStats IndexSpec_GetVectorIndexesStats(IndexSpec *sp) {
 FieldSpecStats IndexSpec_GetFieldStats(FieldSpec *fs){
   FieldSpecStats stats = {0};
   stats.type = fs->types;
+  stats.indexingStats = fs->indexingStats;
   switch (stats.type) {
     case INDEXFLD_T_VECTOR:
       stats.vecStats = IndexSpec_GetVectorIndexStats(fs);
       return stats;
     default:
-      return (FieldSpecStats){0};
+      return stats;
   }
 }
 

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -378,7 +378,7 @@ VectorIndexStats IndexSpec_GetVectorIndexesStats(IndexSpec *sp) {
 FieldSpecStats IndexSpec_GetFieldStats(FieldSpec *fs){
   FieldSpecStats stats = {0};
   stats.type = fs->types;
-  stats.indexingStats = fs->indexingStats;
+  stats.indexingStats = FieldSpec_GetIndexingStats(fs);
   switch (stats.type) {
     case INDEXFLD_T_VECTOR:
       stats.vecStats = IndexSpec_GetVectorIndexStats(fs);

--- a/src/info/field_spec_info.h
+++ b/src/info/field_spec_info.h
@@ -28,6 +28,7 @@ typedef struct FieldSpecStats {
     VectorIndexStats vecStats;
   };
   FieldType type;
+  FieldIndexingStats indexingStats;
   // Optional disk-backed FT.INFO metrics; each `available` flag gates output.
   PerFieldTextDiskMetrics textDisk;
   PerFieldCfDiskMetrics cfDisk;

--- a/tests/pytests/test_index_error.py
+++ b/tests/pytests/test_index_error.py
@@ -22,8 +22,26 @@ index_errors_unique_entries_dict = {
     "background indexing status": 'OK'
 }
 
+field_indexing_stat_keys = {
+  'indexing_preprocess_count',
+  'indexing_preprocess_time_ns',
+  'indexing_preprocess_max_time_ns',
+  'indexing_index_count',
+  'indexing_index_time_ns',
+  'indexing_index_max_time_ns',
+  'indexing_apply_count',
+  'indexing_apply_time_ns',
+  'indexing_apply_max_time_ns',
+}
+
 def get_field_stats_dict(info_command_output, index = 0):
   return to_dict(info_command_output['field statistics'][index])
+
+def field_stats_without_indexing_times(field_stats):
+  field_stats = to_dict(field_stats).copy()
+  for key in field_indexing_stat_keys:
+    field_stats.pop(key, None)
+  return [item for pair in field_stats.items() for item in pair]
 
 def test_vector_index_failures(env):
   con = getConnectionByEnv(env)
@@ -118,7 +136,8 @@ def test_alter_failures(env):
       ['indexing failures', 0, 'last indexing error', 'N/A', 'last indexing error key', 'N/A']
   ]
 
-  env.assertEqual(info['field statistics'][0], expected_no_error_field_stats)
+  env.assertEqual(field_stats_without_indexing_times(info['field statistics'][0]),
+                  expected_no_error_field_stats)
 
   # Add the field of which the document contains an invalid numeric value.
   env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'n2', 'NUMERIC').ok()
@@ -144,8 +163,10 @@ def test_alter_failures(env):
         'last indexing error key', 'doc']
   ]
 
-  env.assertEqual(info['field statistics'][0], expected_no_error_field_stats)
-  env.assertEqual(info['field statistics'][1], expected_failed_field_stats)
+  env.assertEqual(field_stats_without_indexing_times(info['field statistics'][0]),
+                  expected_no_error_field_stats)
+  env.assertEqual(field_stats_without_indexing_times(info['field statistics'][1]),
+                  expected_failed_field_stats)
 
 def test_mixed_index_failures(env):
   con = getConnectionByEnv(env)
@@ -342,8 +363,10 @@ def test_partial_doc_index_failures(env):
   for _ in env.reloadingIterator():
     info = index_info(env)
     env.assertEqual(info['num_docs'], 0)
-    env.assertEqual(info['field statistics'][0], expected_text_stats)
-    env.assertEqual(info['field statistics'][1], excepted_numeric_stats)
+    env.assertEqual(field_stats_without_indexing_times(info['field statistics'][0]),
+                    expected_text_stats)
+    env.assertEqual(field_stats_without_indexing_times(info['field statistics'][1]),
+                    excepted_numeric_stats)
 
 def test_multiple_index_failures(env):
     # Create 2 indices with a different schema order.
@@ -387,8 +410,10 @@ def test_multiple_index_failures(env):
         ]
 
         env.assertEqual(info['num_docs'], 0)
-        env.assertEqual(info['field statistics'][0], expected_failed_field_stats)
-        env.assertEqual(info['field statistics'][1], expected_no_error_field_stats)
+        env.assertEqual(field_stats_without_indexing_times(info['field statistics'][0]),
+                        expected_failed_field_stats)
+        env.assertEqual(field_stats_without_indexing_times(info['field statistics'][1]),
+                        expected_no_error_field_stats)
 
 
 ###################### JSON failures ######################
@@ -461,5 +486,7 @@ def test_multiple_index_failures_json(env):
           ]
 
           env.assertEqual(info['num_docs'], 0)
-          env.assertEqual(info['field statistics'][0], expected_failed_field_stats)
-          env.assertEqual(info['field statistics'][1], expected_no_error_field_stats)
+          env.assertEqual(field_stats_without_indexing_times(info['field statistics'][0]),
+                          expected_failed_field_stats)
+          env.assertEqual(field_stats_without_indexing_times(info['field statistics'][1]),
+                          expected_no_error_field_stats)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -535,7 +535,13 @@ def test_info():
                                         'indexing failures': 0,
                                         'last indexing error': 'N/A',
                                         'last indexing error key': 'N/A'
-                                       }
+                                       },
+                       'indexing_preprocess_count': ANY,
+                       'indexing_preprocess_time_ns': ANY,
+                       'indexing_preprocess_max_time_ns': ANY,
+                       'indexing_index_count': ANY,
+                       'indexing_index_time_ns': ANY,
+                       'indexing_index_max_time_ns': ANY,
                       },
                       {'attribute': 'f2',
                        'identifier': 'f2',
@@ -543,7 +549,13 @@ def test_info():
                                         'indexing failures': 0,
                                         'last indexing error': 'N/A',
                                         'last indexing error key': 'N/A'
-                                       }
+                                       },
+                       'indexing_preprocess_count': ANY,
+                       'indexing_preprocess_time_ns': ANY,
+                       'indexing_preprocess_max_time_ns': ANY,
+                       'indexing_index_count': ANY,
+                       'indexing_index_time_ns': ANY,
+                       'indexing_index_max_time_ns': ANY,
                         }
                       ],
       'bytes_per_record_avg': ANY,

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -407,3 +407,42 @@ def testInfoIndexingTime(env):
 
     d = index_info(env, 'idx2')
     env.assertGreater(float(d['total_indexing_time']), 0)
+
+def testInfoFieldIndexingTime(env):
+    conn = getConnectionByEnv(env)
+
+    def field_indexing_stats():
+        return {to_dict(field)['attribute']: to_dict(field)
+                for field in index_info(env, 'idx')['field statistics']}
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA',
+            'txt', 'TEXT',
+            'n', 'NUMERIC',
+            'tag', 'TAG')
+
+    fields = field_indexing_stats()
+    env.assertTrue('indexing_preprocess_count' not in fields['txt'])
+    env.assertTrue('indexing_preprocess_count' not in fields['n'])
+    env.assertTrue('indexing_preprocess_count' not in fields['tag'])
+
+    for i in range(100):
+        conn.execute_command('HSET', f'doc:{i}', 'txt', f'hello world {i}', 'n', i, 'tag', f'tag{i % 4}')
+
+    fields = field_indexing_stats()
+    for field_name in ('txt', 'n', 'tag'):
+        field_stats = fields[field_name]
+        env.assertGreater(int(field_stats['indexing_preprocess_count']), 0)
+        env.assertGreater(int(field_stats['indexing_preprocess_time_ns']), 0)
+        env.assertGreater(int(field_stats['indexing_preprocess_max_time_ns']), 0)
+
+    for field_name in ('txt', 'n', 'tag'):
+        field_stats = fields[field_name]
+        env.assertGreater(int(field_stats['indexing_index_count']), 0)
+        env.assertGreater(int(field_stats['indexing_index_time_ns']), 0)
+        env.assertGreater(int(field_stats['indexing_index_max_time_ns']), 0)
+
+    for field_name in ('n', 'tag'):
+        field_stats = fields[field_name]
+        env.assertGreater(int(field_stats['indexing_apply_count']), 0)
+        env.assertGreater(int(field_stats['indexing_apply_time_ns']), 0)
+        env.assertGreater(int(field_stats['indexing_apply_max_time_ns']), 0)


### PR DESCRIPTION
## Summary
- Add runtime indexing latency counters to each field statistics entry in FT.INFO.
- Track preprocess, index, and apply phase count/total/max timing per field.
- Aggregate the new per-field metrics across shards for coordinator FT.INFO responses.

## Notes
- TEXT index timing is attributed to every field in the term field mask, so per-field TEXT index totals are attribution totals and may sum above wall-clock elapsed time.
- No disk API or disk-layer code is touched.

## Test Plan
- [x] `./build.sh RUN_PYTEST TEST="test_stats:testInfoFieldIndexingTime"`
- [x] `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST="test_stats:testInfoFieldIndexingTime"`
- [x] `./build.sh RUN_PYTEST TEST="test_resp3:test_info"`
- [x] `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST="test_resp3:test_info"`
- [x] `./build.sh RUN_PYTEST TEST="test_resp3:test_ft_info"`
- [x] `./build.sh RUN_PYTEST TEST="test_index_error"`
- [x] `bin/linux-x64-release/search-community/tests/cpptests/coord_tests/rstest_coord --gtest_filter='FieldDiskMetricsTest.*'`
- [x] `git diff --check`

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: FT.INFO now reports per-field indexing latency counters for preprocess, index, and apply phases.