### PR TITLE
[8.6-rse] Remove chronically flaky test_mod4745 (test_async)

### DIFF
--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -40,30 +40,6 @@ def testDeleteIndex(env):
     r.expect('ft.info', 'idx').contains('SEARCH_INDEX_NOT_FOUND Index not found')
     # time.sleep(1)
 
-
-def test_yield_while_bg_indexing_mod4745(env):
-    conn = getConnectionByEnv(env)
-    # Create an index in which each shard has > 1000 docs.
-    n = 1010 * env.shardsCount
-    for i in range(n):
-        res = conn.execute_command('hset', f'doc:{i}', 'name', f'hello world')
-        env.assertEqual(res, 1)
-
-    # Baseline - zero yields before index has created.
-    env.assertEqual(run_command_on_all_shards(env, debug_cmd(), 'YIELDS_COUNTER', 'BG_INDEX'),
-                    [0]*env.shardsCount)
-    env.expect('ft.create', 'idx', 'schema', 'name', 'text').ok()
-    allShards_waitForIndexFinishScan(env)
-    # Validate that we yielded at least once (we should after every 100 bg indexing iterations).
-    # The background scan in Redis may scan keys more than once (see RM_Scan() docs), so we assert that each shard
-    # yields *at least* once for each 100 documents.
-    for shard in env.getOSSMasterNodesConnectionList():
-        env.assertGreaterEqual(shard.execute_command(debug_cmd(), 'YIELDS_COUNTER', 'BG_INDEX'),
-                               int((n/env.shardsCount) // 100))
-    # The yield mechanism was introduced is to make sure cluster will not mark itself as fail since the server is not
-    # responsive and fail to send cluster PING on time before we reach cluster-node-timeout. Every time we yield, we
-    # give the main thread a chance to reply to PINGs.
-
 def test_eval_node_errors_async():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 WORKERS 1 ON_TIMEOUT FAIL')
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
This test has been repeatedly deflaked (#4470, #7540, #7557, #7578, #7580) but continues to be flaky. Removing it rather than continuing to patch it.