### PR TITLE
[MOD-16400] Trie - lend term keys across the term dictionary FFI boundary

### DIFF
--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -684,9 +684,10 @@ pub unsafe extern "C" fn TermDictionary_IterateFuzzy<'td>(
 /// - `term` and `len` must be valid, non-NULL pointers to writable
 ///   locations; `score` and `num_docs` must each be NULL or point to a
 ///   writable location.
-/// - The out-pointers must not overlap each other or the
-///   [`TermDictionaryIterator`] `it` points to: this call writes through
-///   them while holding exclusive access to the iterator.
+/// - The out-pointers must not overlap each other, the
+///   [`TermDictionaryIterator`] `it` points to, or the buffer that iterator
+///   lends the term from: this call writes through them while holding
+///   exclusive access to the iterator.
 /// - The [`TermDictionary`] the iterator was obtained from must still be
 ///   alive and unmodified since the iterator was created.
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -52,7 +52,7 @@ use std::ffi::{c_char, c_int};
 use std::slice;
 
 use term_dictionary::{
-    DecrResult as DecrResultImpl, InsertOutcome as InsertOutcomeImpl, TermEntry,
+    DecrResult as DecrResultImpl, InsertOutcome as InsertOutcomeImpl, LendingStrIter, TermEntry,
 };
 
 /// Opaque to C; obtained from [`NewTermDictionary`] and freed with
@@ -68,10 +68,7 @@ pub use term_dictionary::TermDictionary;
 /// functions, advanced with [`TermDictionaryIterator_Next`], and freed
 /// with [`TermDictionaryIterator_Free`].
 pub struct TermDictionaryIterator<'td> {
-    iter: Box<dyn Iterator<Item = (String, f32, usize)> + 'td>,
-    /// Keeps the most recently yielded term alive so the pointer handed
-    /// to C stays valid until the next advance (or free).
-    current: Option<String>,
+    iter: Box<dyn LendingStrIter<'td, Data = TermEntry> + 'td>,
 }
 
 /// Outcome of [`TermDictionary_AddTerm`] and
@@ -198,16 +195,15 @@ unsafe fn storable_term<'a>(ptr: *const c_char, len: usize, what: &'static str) 
     storable.then_some(term)
 }
 
-/// Box a term iterator into the C-facing [`TermDictionaryIterator`],
-/// mapping each `(term, entry)` pair to owned `(term, score, num_docs)`
-/// so no borrow escapes across the FFI boundary.
+/// Box a term iterator into the C-facing [`TermDictionaryIterator`].
+///
+/// Each term is lent out of the iterator's own traversal buffer, so
+/// walking a dictionary allocates nothing per term.
 fn wrap_iter<'td>(
-    iter: impl Iterator<Item = (String, &'td TermEntry)> + 'td,
+    iter: impl LendingStrIter<'td, Data = TermEntry> + 'td,
 ) -> *mut TermDictionaryIterator<'td> {
-    let iter = iter.map(|(term, entry)| (term, entry.score, entry.num_docs));
     Box::into_raw(Box::new(TermDictionaryIterator {
         iter: Box::new(iter),
-        current: None,
     }))
 }
 
@@ -709,22 +705,21 @@ pub unsafe extern "C" fn TermDictionaryIterator_Next(
     // live TermDictionaryIterator.
     let iterator = unsafe { &mut *it };
 
-    let Some((next_term, next_score, next_num_docs)) = iterator.iter.next() else {
+    let Some((next_term, entry)) = iterator.iter.next() else {
         return 0;
     };
-    let stored = iterator.current.insert(next_term);
 
     // SAFETY: caller is to ensure `term` points to a writable location.
-    unsafe { *term = stored.as_ptr().cast::<c_char>() };
+    unsafe { *term = next_term.as_ptr().cast::<c_char>() };
     // SAFETY: caller is to ensure `len` points to a writable location.
-    unsafe { *len = stored.len() };
+    unsafe { *len = next_term.len() };
     if !score.is_null() {
         // SAFETY: caller is to ensure `score` is writable when non-null.
-        unsafe { *score = next_score };
+        unsafe { *score = entry.score };
     }
     if !num_docs.is_null() {
         // SAFETY: caller is to ensure `num_docs` is writable when non-null.
-        unsafe { *num_docs = next_num_docs };
+        unsafe { *num_docs = entry.num_docs };
     }
     1
 }

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -706,7 +706,7 @@ pub unsafe extern "C" fn TermDictionaryIterator_Next(
     // live TermDictionaryIterator.
     let iterator = unsafe { &mut *it };
 
-    let Some((next_term, entry)) = iterator.iter.next() else {
+    let Some((next_term, entry)) = iterator.iter.next_borrowed() else {
         return 0;
     };
 

--- a/src/redisearch_rs/headers/term_dictionary_ffi.h
+++ b/src/redisearch_rs/headers/term_dictionary_ffi.h
@@ -141,9 +141,10 @@ void TermDictionaryIterator_Free(struct TermDictionaryIterator *it);
  * - `term` and `len` must be valid, non-NULL pointers to writable
  *   locations; `score` and `num_docs` must each be NULL or point to a
  *   writable location.
- * - The out-pointers must not overlap each other or the
- *   [`TermDictionaryIterator`] `it` points to: this call writes through
- *   them while holding exclusive access to the iterator.
+ * - The out-pointers must not overlap each other, the
+ *   [`TermDictionaryIterator`] `it` points to, or the buffer that iterator
+ *   lends the term from: this call writes through them while holding
+ *   exclusive access to the iterator.
  * - The [`TermDictionary`] the iterator was obtained from must still be
  *   alive and unmodified since the iterator was created.
  */

--- a/src/redisearch_rs/term_dictionary/src/lib.rs
+++ b/src/redisearch_rs/term_dictionary/src/lib.rs
@@ -59,6 +59,11 @@ use trie_rs::str_trie_map::{
     },
 };
 
+/// Lending iteration over a dictionary, implemented by every iterator the
+/// `*_iter` methods return. Re-exported so a caller can name the protocol
+/// without depending on [`trie_rs`] itself.
+pub use trie_rs::str_trie_map::iter::LendingStrIter;
+
 /// Per-term metadata stored at each terminal in the term dictionary.
 ///
 /// Holds the subset of fields the FT.SEARCH terms trie actually reads.

--- a/src/redisearch_rs/term_dictionary/tests/integration/lending.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/lending.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Every walk the dictionary exposes can be driven through
+//! [`LendingStrIter`], which is how the C entry points erase them behind one
+//! trait object.
+
+use term_dictionary::{LendingStrIter, TermDictionary, TermEntry};
+
+fn seeded() -> TermDictionary {
+    let mut dict = TermDictionary::new();
+    for (i, term) in ["apple", "banana", "grape", "pineapple"]
+        .into_iter()
+        .enumerate()
+    {
+        dict.insert(
+            term,
+            TermEntry {
+                score: i as f32,
+                num_docs: i,
+            },
+        );
+    }
+    dict
+}
+
+/// Drain a lending iterator, copying each lent term so the result can be
+/// compared with [`owned`].
+fn lent<'td, I: LendingStrIter<'td, Data = TermEntry>>(mut iter: I) -> Vec<(String, TermEntry)> {
+    let mut out = Vec::new();
+    while let Some((term, entry)) = iter.next() {
+        out.push((term.to_owned(), entry.clone()));
+    }
+    out
+}
+
+fn owned<'td>(iter: impl Iterator<Item = (String, &'td TermEntry)>) -> Vec<(String, TermEntry)> {
+    iter.map(|(term, entry)| (term, entry.clone())).collect()
+}
+
+#[test]
+fn lending_and_owning_views_agree() {
+    let dict = seeded();
+
+    assert_eq!(lent(dict.iter()), owned(dict.iter()));
+    assert_eq!(
+        lent(dict.prefixed_iter("apple")),
+        owned(dict.prefixed_iter("apple"))
+    );
+    assert_eq!(
+        lent(dict.suffixed_iter("apple")),
+        owned(dict.suffixed_iter("apple"))
+    );
+    assert_eq!(
+        lent(dict.contains_iter("nan")),
+        owned(dict.contains_iter("nan"))
+    );
+    assert_eq!(
+        lent(dict.wildcard_iter("*apple")),
+        owned(dict.wildcard_iter("*apple"))
+    );
+    assert_eq!(
+        lent(dict.fuzzy_iter("aple", 1)),
+        owned(dict.fuzzy_iter("aple", 1))
+    );
+}
+
+/// The empty-pattern guards return an iterator that never starts a walk; it
+/// still has to lend nothing rather than lend an unvisited key.
+#[test]
+fn empty_patterns_lend_nothing() {
+    let dict = seeded();
+
+    assert_eq!(lent(dict.contains_iter("")), Vec::new());
+    assert_eq!(lent(dict.suffixed_iter("")), Vec::new());
+}

--- a/src/redisearch_rs/term_dictionary/tests/integration/lending.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/lending.rs
@@ -34,7 +34,7 @@ fn seeded() -> TermDictionary {
 /// compared with [`owned`].
 fn lent<'td, I: LendingStrIter<'td, Data = TermEntry>>(mut iter: I) -> Vec<(String, TermEntry)> {
     let mut out = Vec::new();
-    while let Some((term, entry)) = iter.next() {
+    while let Some((term, entry)) = iter.next_borrowed() {
         out.push((term.to_owned(), entry.clone()));
     }
     out

--- a/src/redisearch_rs/term_dictionary/tests/integration/main.rs
+++ b/src/redisearch_rs/term_dictionary/tests/integration/main.rs
@@ -10,3 +10,4 @@
 mod bookkeeping;
 mod case_folding;
 mod empty_pattern;
+mod lending;

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/case_insensitive.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/case_insensitive.rs
@@ -8,8 +8,10 @@
 */
 
 use crate::{
-    TrieMap, automaton::CaseFoldExact, iter::AutomatonIter,
-    str_trie_map::iter::unfiltered::key_to_string,
+    TrieMap,
+    automaton::CaseFoldExact,
+    iter::AutomatonIter,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Iterator over the entries of a
@@ -25,10 +27,20 @@ impl<'tm, Data: 'tm> CaseInsensitiveIter<'tm, Data> {
     }
 }
 
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for CaseInsensitiveIter<'tm, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.0.advance()?;
+        Some((key_to_str(self.0.key()), data))
+    }
+}
+
 impl<'tm, Data: 'tm> Iterator for CaseInsensitiveIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (key_to_string(k), v))
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/case_insensitive.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/case_insensitive.rs
@@ -30,7 +30,7 @@ impl<'tm, Data: 'tm> CaseInsensitiveIter<'tm, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for CaseInsensitiveIter<'tm, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.0.advance()?;
         Some((key_to_str(self.0.key()), data))
     }
@@ -40,7 +40,7 @@ impl<'tm, Data: 'tm> Iterator for CaseInsensitiveIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -7,7 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{TrieMap, iter, str_trie_map::iter::unfiltered::key_to_string};
+use crate::{
+    TrieMap, iter,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
+};
 
 /// Substring-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
 /// in lexicographical key order.
@@ -37,10 +40,20 @@ impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
     }
 }
 
-impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for ContainsIter<'tm, '_, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.0.advance()?;
+        Some((key_to_str(self.0.key()), data))
+    }
+}
+
+impl<'tm, Data: 'tm> Iterator for ContainsIter<'tm, '_, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (key_to_string(k), v))
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -43,7 +43,7 @@ impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for ContainsIter<'tm, '_, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.0.advance()?;
         Some((key_to_str(self.0.key()), data))
     }
@@ -53,7 +53,7 @@ impl<'tm, Data: 'tm> Iterator for ContainsIter<'tm, '_, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/fuzzy.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/fuzzy.rs
@@ -70,7 +70,7 @@ impl<'tm, Data: 'tm> FuzzyIter<'tm, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for FuzzyIter<'tm, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.advance()?;
         Some((self.key(), data))
     }
@@ -80,7 +80,7 @@ impl<'tm, Data: 'tm> Iterator for FuzzyIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/fuzzy.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/fuzzy.rs
@@ -11,7 +11,7 @@ use crate::{
     TrieMap,
     automaton::{CaseFoldLevenshtein, CaseFoldLevenshteinNfa},
     iter::AutomatonIter,
-    str_trie_map::iter::unfiltered::key_to_string,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Iterator over the entries of a
@@ -47,14 +47,40 @@ impl<'tm, Data: 'tm> FuzzyIter<'tm, Data> {
     }
 }
 
+impl<'tm, Data: 'tm> FuzzyIter<'tm, Data> {
+    /// Advance whichever backend is driving this iteration.
+    fn advance(&mut self) -> Option<&'tm Data> {
+        match &mut self.0 {
+            Backend::Nfa64(it) => it.advance(),
+            Backend::Nfa128(it) => it.advance(),
+            Backend::Dp(it) => it.advance(),
+        }
+    }
+
+    /// The key the backend last stopped on.
+    fn key(&self) -> &str {
+        key_to_str(match &self.0 {
+            Backend::Nfa64(it) => it.key(),
+            Backend::Nfa128(it) => it.key(),
+            Backend::Dp(it) => it.key(),
+        })
+    }
+}
+
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for FuzzyIter<'tm, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.advance()?;
+        Some((self.key(), data))
+    }
+}
+
 impl<'tm, Data: 'tm> Iterator for FuzzyIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            Backend::Nfa64(it) => it.next().map(|(k, v)| (key_to_string(k), v)),
-            Backend::Nfa128(it) => it.next().map(|(k, v)| (key_to_string(k), v)),
-            Backend::Dp(it) => it.next().map(|(k, v)| (key_to_string(k), v)),
-        }
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
@@ -52,7 +52,7 @@ pub trait LendingStrIter<'tm> {
     /// The key is borrowed from the iterator's own traversal buffer, so it
     /// is only valid until the next call to this method (or until the
     /// iterator is dropped).
-    fn next(&mut self) -> Option<(&str, &'tm Self::Data)>;
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Self::Data)>;
 }
 
 /// Read a trie byte key back as a [`str`]. Keys enter the

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
@@ -38,10 +38,11 @@ pub use wildcard::WildcardIter;
 /// each key — comparing it, writing it to a buffer, handing it to C — takes
 /// this trait instead and leaves that allocation unmade.
 ///
-/// It is deliberately not `LendingIterator` from the `lending_iterator`
-/// crate, whose generic associated type buys adapters at the cost of being
-/// usable as a `dyn` type. Here the borrow is tied to `&mut self` by ordinary
-/// elision, so `dyn LendingStrIter` erases the concrete iterator away.
+/// It is deliberately not [`LendingIterator`](lending_iterator::LendingIterator)
+/// from the [`lending_iterator`] crate, whose generic associated type buys
+/// adapters at the cost of being usable as a `dyn` type. Here the borrow is
+/// tied to `&mut self` by ordinary elision, so `dyn LendingStrIter` erases the
+/// concrete iterator away.
 pub trait LendingStrIter<'tm> {
     /// The payload stored alongside each key of the trie being traversed.
     type Data: 'tm;

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
@@ -28,3 +28,37 @@ pub use range::{RangeBoundary, RangeFilter, RangeIter};
 pub use suffixed::SuffixedIter;
 pub use unfiltered::Iter;
 pub use wildcard::WildcardIter;
+
+/// Traversal that lends the key it stopped on, rather than handing out an
+/// owned [`String`].
+///
+/// Every key-yielding iterator in this module implements both this trait and
+/// [`Iterator`], sharing one traversal: the [`Iterator`] impl is this trait
+/// plus a copy of the lent key into a [`String`]. A caller that only reads
+/// each key — comparing it, writing it to a buffer, handing it to C — takes
+/// this trait instead and leaves that allocation unmade.
+///
+/// It is deliberately not `LendingIterator` from the `lending_iterator`
+/// crate, whose generic associated type buys adapters at the cost of being
+/// usable as a `dyn` type. Here the borrow is tied to `&mut self` by ordinary
+/// elision, so `dyn LendingStrIter` erases the concrete iterator away.
+pub trait LendingStrIter<'tm> {
+    /// The payload stored alongside each key of the trie being traversed.
+    type Data: 'tm;
+
+    /// Advance to the next entry, yielding its key and payload.
+    ///
+    /// The key is borrowed from the iterator's own traversal buffer, so it
+    /// is only valid until the next call to this method (or until the
+    /// iterator is dropped).
+    fn next(&mut self) -> Option<(&str, &'tm Self::Data)>;
+}
+
+/// Read a trie byte key back as a [`str`]. Keys enter the
+/// [`StrTrieMap`](crate::str_trie_map::StrTrieMap) exclusively via `&str` so
+/// they are UTF-8 by construction; the validating [`str::from_utf8`] call
+/// here is cheap and protects against any future raw-byte insertion at the
+/// lower layer.
+pub(super) fn key_to_str(bytes: &[u8]) -> &str {
+    str::from_utf8(bytes).expect("StrTrieMap keys are UTF-8 by construction")
+}

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
@@ -10,7 +10,7 @@
 use crate::{
     TrieMap,
     iter::{self, filter},
-    str_trie_map::iter::unfiltered::key_to_string,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Prefix-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
@@ -28,10 +28,20 @@ impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
     }
 }
 
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for PrefixedIter<'tm, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.0.advance()?;
+        Some((key_to_str(self.0.key()), data))
+    }
+}
+
 impl<'tm, Data: 'tm> Iterator for PrefixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (key_to_string(k), v))
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
@@ -31,7 +31,7 @@ impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for PrefixedIter<'tm, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.0.advance()?;
         Some((key_to_str(self.0.key()), data))
     }
@@ -41,7 +41,7 @@ impl<'tm, Data: 'tm> Iterator for PrefixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/range.rs
@@ -10,7 +10,7 @@
 use crate::{
     TrieMap,
     iter::{self, RangeBoundary as InnerBoundary, RangeFilter as InnerFilter},
-    str_trie_map::iter::unfiltered::key_to_string,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// One of the bounds for a [`RangeFilter`].
@@ -93,10 +93,20 @@ impl<'tm, 'p, Data: 'tm> RangeIter<'tm, 'p, Data> {
     }
 }
 
-impl<'tm, 'p, Data: 'tm> Iterator for RangeIter<'tm, 'p, Data> {
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for RangeIter<'tm, '_, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.0.advance()?;
+        Some((key_to_str(self.0.key()), data))
+    }
+}
+
+impl<'tm, Data: 'tm> Iterator for RangeIter<'tm, '_, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (key_to_string(k), v))
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/range.rs
@@ -96,7 +96,7 @@ impl<'tm, 'p, Data: 'tm> RangeIter<'tm, 'p, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for RangeIter<'tm, '_, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.0.advance()?;
         Some((key_to_str(self.0.key()), data))
     }
@@ -106,7 +106,7 @@ impl<'tm, Data: 'tm> Iterator for RangeIter<'tm, '_, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -64,7 +64,7 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for SuffixedIter<'tm, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.advance()?;
         Some((key_to_str(self.iter.key()), data))
     }
@@ -74,7 +74,7 @@ impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -10,7 +10,7 @@
 use crate::{
     TrieMap,
     iter::{self, filter},
-    str_trie_map::iter::unfiltered::key_to_string,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Suffix-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
@@ -48,15 +48,33 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
     }
 }
 
+impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
+    /// Advance the underlying traversal to the next key ending in the target
+    /// suffix, skipping the keys that do not.
+    fn advance(&mut self) -> Option<&'tm Data> {
+        loop {
+            let data = self.iter.advance()?;
+            if self.iter.key().ends_with(&self.target_bytes) {
+                return Some(data);
+            }
+        }
+    }
+}
+
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for SuffixedIter<'tm, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.advance()?;
+        Some((key_to_str(self.iter.key()), data))
+    }
+}
+
 impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let (k, v) = self.iter.next()?;
-            if k.ends_with(&self.target_bytes) {
-                return Some((key_to_string(k), v));
-            }
-        }
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/unfiltered.rs
@@ -28,7 +28,7 @@ impl<'a, Data> Iter<'a, Data> {
 impl<'a, Data: 'a> LendingStrIter<'a> for Iter<'a, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'a Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'a Data)> {
         let data = self.0.advance()?;
         Some((key_to_str(self.0.key()), data))
     }
@@ -38,7 +38,7 @@ impl<'a, Data: 'a> Iterator for Iter<'a, Data> {
     type Item = (String, &'a Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/unfiltered.rs
@@ -10,6 +10,7 @@
 use crate::{
     TrieMap,
     iter::{self, filter},
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Lexicographical-order iterator over a
@@ -24,18 +25,20 @@ impl<'a, Data> Iter<'a, Data> {
     }
 }
 
-impl<'a, Data> Iterator for Iter<'a, Data> {
-    type Item = (String, &'a Data);
+impl<'a, Data: 'a> LendingStrIter<'a> for Iter<'a, Data> {
+    type Data = Data;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (key_to_string(k), v))
+    fn next(&mut self) -> Option<(&str, &'a Data)> {
+        let data = self.0.advance()?;
+        Some((key_to_str(self.0.key()), data))
     }
 }
 
-/// Decode a trie byte key back to a [`String`]. Keys enter the [`crate::str_trie_map::StrTrieMap`]
-/// exclusively via `&str` so they are UTF-8 by construction; the validating
-/// [`String::from_utf8`] call here is cheap and protects against any future raw-byte
-/// insertion at the lower layer.
-pub(super) fn key_to_string(bytes: Vec<u8>) -> String {
-    String::from_utf8(bytes).expect("StrTrieMap keys are UTF-8 by construction")
+impl<'a, Data: 'a> Iterator for Iter<'a, Data> {
+    type Item = (String, &'a Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
+    }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
@@ -93,7 +93,7 @@ impl<'tm, Data: 'tm> WildcardIter<'tm, Data> {
 impl<'tm, Data: 'tm> LendingStrIter<'tm> for WildcardIter<'tm, Data> {
     type Data = Data;
 
-    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+    fn next_borrowed(&mut self) -> Option<(&str, &'tm Data)> {
         let data = self.advance()?;
         Some((self.key(), data))
     }
@@ -103,7 +103,7 @@ impl<'tm, Data: 'tm> Iterator for WildcardIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, data) = LendingStrIter::next(self)?;
+        let (key, data) = self.next_borrowed()?;
         Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/wildcard.rs
@@ -11,7 +11,7 @@ use crate::{
     TrieMap,
     automaton::{CodepointWildcard, CodepointWildcardNfa},
     iter::{self, AutomatonIter, filter},
-    str_trie_map::iter::unfiltered::key_to_string,
+    str_trie_map::iter::{LendingStrIter, key_to_str},
 };
 
 /// Iterator over the entries of a
@@ -60,20 +60,50 @@ impl<'tm, Data: 'tm> WildcardIter<'tm, Data> {
     }
 }
 
+impl<'tm, Data: 'tm> WildcardIter<'tm, Data> {
+    /// Advance whichever backend is driving this iteration; for
+    /// [`Backend::Filter`] that means skipping the candidates the pattern
+    /// rejects.
+    fn advance(&mut self) -> Option<&'tm Data> {
+        match &mut self.0 {
+            Backend::Nfa64(iter) => iter.advance(),
+            Backend::Nfa128(iter) => iter.advance(),
+            Backend::Filter {
+                pattern,
+                candidates,
+            } => loop {
+                let data = candidates.advance()?;
+                if pattern.matches(key_to_str(candidates.key())) {
+                    return Some(data);
+                }
+            },
+        }
+    }
+
+    /// The key the backend last stopped on.
+    fn key(&self) -> &str {
+        key_to_str(match &self.0 {
+            Backend::Nfa64(iter) => iter.key(),
+            Backend::Nfa128(iter) => iter.key(),
+            Backend::Filter { candidates, .. } => candidates.key(),
+        })
+    }
+}
+
+impl<'tm, Data: 'tm> LendingStrIter<'tm> for WildcardIter<'tm, Data> {
+    type Data = Data;
+
+    fn next(&mut self) -> Option<(&str, &'tm Data)> {
+        let data = self.advance()?;
+        Some((self.key(), data))
+    }
+}
+
 impl<'tm, Data: 'tm> Iterator for WildcardIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            Backend::Nfa64(iter) => iter.next().map(|(k, v)| (key_to_string(k), v)),
-            Backend::Nfa128(iter) => iter.next().map(|(k, v)| (key_to_string(k), v)),
-            Backend::Filter {
-                pattern,
-                candidates,
-            } => candidates.find_map(|(k, v)| {
-                let key = key_to_string(k);
-                pattern.matches(&key).then_some((key, v))
-            }),
-        }
+        let (key, data) = LendingStrIter::next(self)?;
+        Some((key.to_owned(), data))
     }
 }

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`LendingStrIter`] is the same traversal as the [`Iterator`] view of each
+//! [`StrTrieMap`] iterator, so the two must agree entry for entry.
+
+use trie_rs::str_trie_map::{
+    StrTrieMap,
+    iter::{ContainsIter, LendingStrIter, RangeBoundary, RangeFilter, SuffixedIter},
+};
+
+fn seeded() -> StrTrieMap<i32> {
+    let mut trie = StrTrieMap::new();
+    for (i, key) in ["apple", "applesauce", "banana", "grape", "pineapple"]
+        .into_iter()
+        .enumerate()
+    {
+        trie.insert(key, i as i32);
+    }
+    trie
+}
+
+/// Drain a lending iterator, copying each lent key so the result can be
+/// compared with [`owned`].
+fn lent<'tm, I: LendingStrIter<'tm, Data = i32>>(mut iter: I) -> Vec<(String, i32)> {
+    let mut out = Vec::new();
+    while let Some((key, value)) = iter.next() {
+        out.push((key.to_owned(), *value));
+    }
+    out
+}
+
+fn owned<'tm>(iter: impl Iterator<Item = (String, &'tm i32)>) -> Vec<(String, i32)> {
+    iter.map(|(key, value)| (key, *value)).collect()
+}
+
+#[test]
+fn lending_and_owning_views_agree() {
+    let trie = seeded();
+    let range = RangeFilter {
+        min: Some(RangeBoundary::included("b")),
+        max: Some(RangeBoundary::excluded("q")),
+    };
+
+    assert_eq!(lent(trie.iter()), owned(trie.iter()));
+    assert_eq!(
+        lent(trie.prefixed_iter("apple")),
+        owned(trie.prefixed_iter("apple"))
+    );
+    assert_eq!(
+        lent(trie.suffixed_iter("apple")),
+        owned(trie.suffixed_iter("apple"))
+    );
+    assert_eq!(
+        lent(trie.contains_iter("nan")),
+        owned(trie.contains_iter("nan"))
+    );
+    assert_eq!(
+        lent(trie.case_insensitive_iter("APPLE")),
+        owned(trie.case_insensitive_iter("APPLE"))
+    );
+    assert_eq!(
+        lent(trie.wildcard_iter("*apple")),
+        owned(trie.wildcard_iter("*apple"))
+    );
+    assert_eq!(
+        lent(trie.fuzzy_iter("aple", 1)),
+        owned(trie.fuzzy_iter("aple", 1))
+    );
+    assert_eq!(lent(trie.range_iter(range)), owned(trie.range_iter(range)));
+
+    // A walk that finds nothing must lend nothing, rather than lend the key
+    // its traversal stopped on.
+    assert_eq!(lent(trie.prefixed_iter("kiwi")), Vec::new());
+    assert_eq!(lent(SuffixedIter::<i32>::empty()), Vec::new());
+    assert_eq!(lent(ContainsIter::<i32>::empty()), Vec::new());
+}
+
+/// A wildcard pattern past every NFA bitset width falls back to filtering
+/// whole candidate keys, which is an advance path of its own. The pattern
+/// below has 131 atoms (129 literals, `*`, `b`), so its 132 positions clear
+/// the widest bitset.
+#[test]
+fn lending_wildcard_skips_rejected_candidates_on_the_filter_backend() {
+    // Both keys sit under the pattern's literal prefix, so the candidate
+    // walk visits them and only the pattern itself can tell them apart.
+    let prefix = "a".repeat(129);
+    let hit = format!("{prefix}xb");
+    let miss = format!("{prefix}xc");
+    let mut trie = StrTrieMap::new();
+    trie.insert(&hit, 1);
+    trie.insert(&miss, 2);
+    let pattern = format!("{prefix}*b");
+
+    let hits = lent(trie.wildcard_iter(&pattern));
+
+    assert_eq!(hits, vec![(hit, 1)]);
+}
+
+/// The C entry points erase these iterators behind one trait object, so
+/// [`LendingStrIter`] has to stay dyn-compatible.
+#[test]
+fn a_boxed_iterator_still_lends() {
+    let trie = seeded();
+    let mut erased: Box<dyn LendingStrIter<'_, Data = i32>> = Box::new(trie.prefixed_iter("apple"));
+
+    let mut hits = Vec::new();
+    while let Some((key, value)) = erased.next() {
+        hits.push((key.to_owned(), *value));
+    }
+
+    assert_eq!(hits, owned(trie.prefixed_iter("apple")));
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
@@ -8,7 +8,10 @@
 */
 
 //! [`LendingStrIter`] is the same traversal as the [`Iterator`] view of each
-//! [`StrTrieMap`] iterator, so the two must agree entry for entry.
+//! [`StrTrieMap`] iterator, so the two must agree entry for entry. Agreement
+//! alone cannot catch a key the traversal assembled wrongly — both views would
+//! report it identically — so the walks that assemble one from a filtered
+//! traversal are also pinned against literal keys.
 
 use trie_rs::str_trie_map::{
     StrTrieMap,
@@ -80,6 +83,27 @@ fn lending_and_owning_views_agree() {
     assert_eq!(lent(trie.prefixed_iter("kiwi")), Vec::new());
     assert_eq!(lent(SuffixedIter::<i32>::empty()), Vec::new());
     assert_eq!(lent(ContainsIter::<i32>::empty()), Vec::new());
+}
+
+/// The filtering walks pick their key out of a traversal that also visits
+/// non-matching keys, so the key each one lends is pinned here rather than
+/// only compared against the view that shares that traversal.
+#[test]
+fn filtering_walks_lend_the_key_they_matched_on() {
+    let trie = seeded();
+
+    assert_eq!(
+        lent(trie.suffixed_iter("apple")),
+        vec![("apple".to_owned(), 0), ("pineapple".to_owned(), 4)]
+    );
+    assert_eq!(
+        lent(trie.wildcard_iter("*apple")),
+        vec![("apple".to_owned(), 0), ("pineapple".to_owned(), 4)]
+    );
+    assert_eq!(
+        lent(trie.fuzzy_iter("aple", 1)),
+        vec![("apple".to_owned(), 0)]
+    );
 }
 
 /// A wildcard pattern past every NFA bitset width falls back to filtering

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/lending_iter.rs
@@ -33,7 +33,7 @@ fn seeded() -> StrTrieMap<i32> {
 /// compared with [`owned`].
 fn lent<'tm, I: LendingStrIter<'tm, Data = i32>>(mut iter: I) -> Vec<(String, i32)> {
     let mut out = Vec::new();
-    while let Some((key, value)) = iter.next() {
+    while let Some((key, value)) = iter.next_borrowed() {
         out.push((key.to_owned(), *value));
     }
     out
@@ -135,7 +135,7 @@ fn a_boxed_iterator_still_lends() {
     let mut erased: Box<dyn LendingStrIter<'_, Data = i32>> = Box::new(trie.prefixed_iter("apple"));
 
     let mut hits = Vec::new();
-    while let Some((key, value)) = erased.next() {
+    while let Some((key, value)) = erased.next_borrowed() {
         hits.push((key.to_owned(), *value));
     }
 

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
@@ -10,6 +10,7 @@
 mod case_insensitive_iter;
 mod empty_input;
 mod fuzzy_iter;
+mod lending_iter;
 mod range_iter;
 mod return_value_contracts;
 mod suffixed_iter;


### PR DESCRIPTION
## Describe the changes in the pull request

Came up in this thread on #11052: https://github.com/RediSearch/RediSearch/pull/11052#discussion_r3872260864

1. Current: every `StrTrieMap` walk copies the key it stopped on into a fresh `String` before yielding it, so `TermDictionaryIterator` had to park that owned key in a `current` field just to keep the memory alive for the C caller reading through it.
2. Change: the `str_trie_map` iterators also implement a new `LendingStrIter`, which lends the key out of the traversal's own buffer; the owning `Iterator` view is that traversal plus the copy. `TermDictionaryIterator` takes the lending view, so its `current: Option<String>` anchor and the `.map` adapter around the walk both go away; the walks stay erased behind one boxed trait object, now `dyn LendingStrIter`.
3. Outcome: internal-only — the C contract and the generated header are unchanged. Walking a term dictionary over the FFI boundary now allocates nothing per term, and any Rust caller that only reads each key can skip the allocation too.

#### Which additional issues this PR fixes

1. MOD-16400

#### Main objects this PR modified

1. `trie_rs::str_trie_map::iter` — new `LendingStrIter` trait, implemented alongside `Iterator` on all eight walks; `key_to_string` replaced by a borrowing `key_to_str`.
2. `SuffixedIter`, `WildcardIter`, `FuzzyIter` — their filtering moved into a private `advance`, so no borrow of the traversal key escapes the skip loop.
3. `term_dictionary` — re-exports `LendingStrIter` so callers can name the protocol without depending on `trie_rs`.
4. `term_dictionary_ffi::TermDictionaryIterator` — one boxed trait object in place of the per-walk types plus the `current: Option<String>` field.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
