### PR TITLE
vector top-k: bind the vector-score key from Rust

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3684,6 +3684,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "ffi",
+ "field",
  "index_result",
  "redis_mock",
  "redis_reply",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -7,30 +7,24 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Rust implementation of the vector top-k iterator and its C accessor functions.
-//!
-//! This module provides [`NewVectorTopKIterator`] together with the accessor
-//! shims that C callers use to bind the iterator's vector-score `RLookupKey`.
+//! Rust implementation of the vector top-k iterator, exposed to C.
 
 use std::{ffi::c_void, ptr::NonNull};
 
-use ffi::{
-    QueryIterator, QueryRequestTimeout, RLookupKey, RLookupKeyHandle, RedisSearchCtx, VecSimIndex,
-    VecSimQueryParams,
-};
+use ffi::{QueryIterator, QueryRequestTimeout, RedisSearchCtx, VecSimIndex, VecSimQueryParams};
 use field::FieldFilterContext;
 use rqe_iterators::{
-    ExpirationChecker, FieldExpirationChecker, IteratorType,
+    ExpirationChecker, FieldExpirationChecker,
     c2rust::CRQEIterator,
     interop::{RQEIteratorWrapper, patch_vtable},
 };
-use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
+use vector_score_source::{NewVectorTopK, new_vector_top_k};
 
 /// Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
 ///
 /// This call can reduce to an `Empty` iterator, whose `type_` is
-/// [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
-/// accessors below must not be called on such a handle.
+/// [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The accessors in
+/// [`vector_score_source::interop`] must not be called on such a handle.
 ///
 /// Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
 /// for a hybrid (filtered) query.
@@ -58,6 +52,8 @@ use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
 /// 7. `timeout` is non-null and remains valid for the returned iterator's lifetime.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+/// [`IteratorType::Empty`]: rqe_iterators::IteratorType::Empty
+/// [`IteratorType::Hybrid`]: rqe_iterators::IteratorType::Hybrid
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewVectorTopKIterator(
     index: *mut VecSimIndex,
@@ -142,71 +138,4 @@ fn box_reduced<'index, E: ExpirationChecker + 'index>(
             ptr
         }
     }
-}
-
-/// Cast a `*mut QueryIterator` back to
-/// its full Rust wrapper so accessors can reach `VectorScoreSource`.
-///
-/// # Safety
-///
-/// 1. `iter` is non-null, [valid], and was returned by [`NewVectorTopKIterator`]
-///    for a query that did not reduce to `Empty`, so its `type_` is
-///    [`IteratorType::Hybrid`].
-/// 2. No other reference to the wrapper is live for the duration of the returned
-///    borrow.
-/// 3. The `index` and `sctx` given to that [`NewVectorTopKIterator`] call are
-///    still alive.
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-unsafe fn wrapper_mut(
-    iter: *mut QueryIterator,
-) -> &'static mut RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: guaranteed by 1.
-    debug_assert!(matches!(unsafe { (*iter).type_ }, IteratorType::Hybrid));
-    // SAFETY: 1 pins the inner type ; `NewVectorTopKIterator` boxes only
-    // `VectorTopKIterator` with a `FieldExpirationChecker` ; 2 gives the unique
-    // handle ; 3 makes the `'static` inner lifetime sound.
-    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(iter) }
-}
-
-/// Return a mutable reference to the `RLookupKey *` stored inside this iterator.
-///
-/// The key is initially `NULL`; the metrics-loader result processor writes
-/// through this pointer to set the iterator's score-output key.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
-///    not reduce to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetOwnKeyRef(it: *mut QueryIterator) -> *mut *mut RLookupKey {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_mut(it) };
-    // `own_key` boxes a `*mut RLookupKey<'static>`; return the address of the
-    // boxed slot (the pointee), not of the `Box` field, so the pointer handed to
-    // C stays valid across iterator moves (e.g. the `FT.PROFILE` rebox). The slot
-    // holds an `RLookupKey<'static>`, whose `#[repr(C)]` prefix is `ffi::RLookupKey`,
-    // so the pointer-to-pointer reinterprets to the C type the caller expects.
-    (&raw mut *wrapper.inner.source_mut().own_key).cast::<*mut RLookupKey>()
-}
-
-/// Set the [`RLookupKeyHandle`] back-reference on this iterator.
-///
-/// The handle is used to invalidate the key pointer when the iterator is freed.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
-///    not reduce to `Empty`, whose `index` and `sctx` are still alive.
-/// 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
-    it: *mut QueryIterator,
-    handle: *mut RLookupKeyHandle,
-) {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_mut(it) };
-    wrapper.inner.source_mut().key_handle = handle;
 }

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -86,14 +86,6 @@ typedef struct NumericFilter NumericFilter;
  */
 typedef struct NumericRangeTree NumericRangeTree;
 
-typedef struct RLookupKey RLookupKey;
-
-/**
- * Smart pointer handle for [`RLookupKey`] that can be
- * invalidated when the iterator that owns the key is freed.
- */
-typedef struct RLookupKeyHandle RLookupKeyHandle;
-
 /**
  * A single term being evaluated at query time.
  *
@@ -586,8 +578,8 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
  * Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
  *
  * This call can reduce to an `Empty` iterator, whose `type_` is
- * [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
- * accessors below must not be called on such a handle.
+ * [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The accessors in
+ * [`vector_score_source::interop`] must not be called on such a handle.
  *
  * Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
  * for a hybrid (filtered) query.
@@ -615,6 +607,8 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
  * 7. `timeout` is non-null and remains valid for the returned iterator's lifetime.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ * [`IteratorType::Empty`]: rqe_iterators::IteratorType::Empty
+ * [`IteratorType::Hybrid`]: rqe_iterators::IteratorType::Hybrid
  */
 QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, QueryRequestTimeout *timeout, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
 
@@ -739,32 +733,6 @@ void RQEIterators_SetMockRevalidateTimeout(bool enabled);
  *    created via [`NewUnionIterator`].
  */
 void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
-
-/**
- * Return a mutable reference to the `RLookupKey *` stored inside this iterator.
- *
- * The key is initially `NULL`; the metrics-loader result processor writes
- * through this pointer to set the iterator's score-output key.
- *
- * # Safety
- *
- * 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
- *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
- */
-RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
-
-/**
- * Set the [`RLookupKeyHandle`] back-reference on this iterator.
- *
- * The handle is used to invalidate the key pointer when the iterator is freed.
- *
- * # Safety
- *
- * 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
- *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
- * 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
- */
-void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);
 
 /**
  *

--- a/src/redisearch_rs/vector_score_source/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source/Cargo.toml
@@ -27,6 +27,7 @@ vecsim.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
+field.workspace = true
 redis_mock.workspace = true
 redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = [
   "mock_allocator",

--- a/src/redisearch_rs/vector_score_source/src/interop.rs
+++ b/src/redisearch_rs/vector_score_source/src/interop.rs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Reach the vector-score [`RLookupKey`] slot through a type-erased iterator
+//! header.
+//!
+//! A vector top-k iterator yields the distance under a lookup key that is only
+//! resolved during pipeline construction, long after the iterator is built. The
+//! query evaluator therefore hands the metric request a pointer to the
+//! iterator's own slot, and hands the iterator back the handle it invalidates
+//! when freed. Both sides hold nothing but the erased [`QueryIterator`] header
+//! by then, hence these two accessors.
+
+use std::ptr::NonNull;
+
+use ffi::QueryIterator;
+use rlookup::{RLookupKey, RLookupKeyHandle};
+use rqe_iterators::{IteratorType, interop::RQEIteratorWrapper};
+
+use crate::VectorTopKIterator;
+
+/// Recover the wrapper around a vector top-k iterator from its header.
+///
+/// # Safety
+///
+/// Same requirements as [`own_key_ref`].
+///
+/// # Panics
+///
+/// Panics unless the header's type tag is [`IteratorType::Hybrid`].
+unsafe fn wrapper_mut<'index>(
+    header: NonNull<QueryIterator>,
+) -> &'index mut RQEIteratorWrapper<VectorTopKIterator<'index>> {
+    // SAFETY: guaranteed by 3.
+    let iterator_type = unsafe { header.as_ref() }.type_;
+    assert_eq!(
+        iterator_type,
+        IteratorType::Hybrid,
+        "expected a vector top-k iterator: unexpected type: {iterator_type}"
+    );
+    // SAFETY: guaranteed by 1 + 2 + 3.
+    unsafe { RQEIteratorWrapper::mut_ref_from_header_ptr(header.as_ptr()) }
+}
+
+/// Return a pointer to the slot holding this iterator's vector-score
+/// [`RLookupKey`], initially null.
+///
+/// The pointer aliases a slot inside the iterator, so writes through it must
+/// not be interleaved with use of the iterator. The slot is boxed, so the
+/// pointer survives moves of the iterator itself (the `FT.PROFILE` rebox, for
+/// one).
+///
+/// `'index` is unconstrained by the erased header, exactly as for
+/// [`rqe_iterators::metric::own_key_ref`]: the caller picks it, and a caller
+/// with no lifetime to offer should discard it rather than name `'static`.
+///
+/// # Safety
+///
+/// 1. `header` points to an iterator boxed from a [`VectorTopKIterator`]
+///    carrying the default [`FieldExpirationChecker`]. Any other
+///    [`ExpirationChecker`] gives the wrapper a different layout, and the type
+///    tag does not tell the two apart — this one rests on the caller alone.
+/// 2. That iterator did not reduce to `Empty`. [`new_vector_top_k`] answers
+///    [`ReducedEmpty`] for an empty child or `k == 0`, and a handle boxed from
+///    that holds no [`VectorScoreSource`] to reach into.
+/// 3. The iterator is alive and held exclusively for the duration of the call,
+///    as are the `index`, `query_vector` and `sctx` it was built from: the
+///    wrapper names them at a lifetime the erased header cannot constrain.
+///
+/// # Panics
+///
+/// Panics unless the header's type tag is [`IteratorType::Hybrid`], which
+/// catches a violation of requirement 2 but never one of requirement 1.
+///
+/// [`FieldExpirationChecker`]: rqe_iterators::FieldExpirationChecker
+/// [`ExpirationChecker`]: rqe_iterators::ExpirationChecker
+/// [`new_vector_top_k`]: crate::new_vector_top_k
+/// [`ReducedEmpty`]: crate::NewVectorTopK::ReducedEmpty
+/// [`VectorScoreSource`]: crate::VectorScoreSource
+pub unsafe fn own_key_ref<'index>(header: NonNull<QueryIterator>) -> *mut *mut RLookupKey<'index> {
+    // SAFETY: guaranteed by the caller.
+    let wrapper = unsafe { wrapper_mut(header) };
+    &raw mut *wrapper.inner.source_mut().own_key
+}
+
+/// Give the iterator the [`RLookupKeyHandle`] it invalidates when freed.
+///
+/// # Safety
+///
+/// 1. Same requirements as [`own_key_ref`].
+/// 2. `handle` is null, or points to a valid [`RLookupKeyHandle`] that outlives
+///    the iterator. The iterator clears the handle's validity flag on its way
+///    out, so freeing the handle first is a use-after-free at a distance: the
+///    write lands whenever the iterator is dropped, not during this call.
+///
+/// # Panics
+///
+/// Panics on any header [`own_key_ref`] would panic on.
+pub unsafe fn set_key_handle<'index>(
+    header: NonNull<QueryIterator>,
+    handle: *mut RLookupKeyHandle<'index>,
+) {
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_mut::<'index>(header) };
+    wrapper.inner.source_mut().key_handle = handle;
+}

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -24,6 +24,7 @@ extern crate redisearch_rs;
 #[cfg(test)]
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
+pub mod interop;
 pub mod reducer;
 pub mod score_batch;
 pub mod source;

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -16,11 +16,11 @@ use std::{
 };
 
 use ffi::{
-    QueryRequestTimeout, RLookupKeyHandle, RS_VecSimCheckTimeout, VecSearchMode,
-    VecSearchMode_HYBRID_BATCHES, VecSimIndex, VecSimQueryParams,
+    QueryRequestTimeout, RS_VecSimCheckTimeout, VecSearchMode, VecSearchMode_HYBRID_BATCHES,
+    VecSimIndex, VecSimQueryParams,
 };
 use index_result::RSIndexResult;
-use rlookup::RLookupKey;
+use rlookup::{RLookupKey, RLookupKeyHandle};
 use rqe_core::DocId;
 use rqe_iterators::{ExpirationChecker, RQEIteratorError};
 use top_k::{BatchStrategy, ScoreSource, ScoredResult};
@@ -119,22 +119,27 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// leaves this clear so a retry re-issues it. Reset by `rewind`.
     unfiltered_consumed: bool,
 
-    /// Score key for this iterator's metric output. The C metrics loader writes
-    /// through the address returned by the own-key accessor. Boxed so that
+    /// Score key for this iterator's metric output. The metrics loader writes
+    /// through the address returned by [`interop::own_key_ref`]. Boxed so that
     /// address stays stable across iterator moves (e.g. the rebox performed
-    /// during `FT.PROFILE`), keeping the C-side key handle valid. Holds a null
-    /// pointer until the loader sets it.
+    /// during `FT.PROFILE`), keeping the key handle valid. Holds a null pointer
+    /// until the loader sets it.
+    ///
+    /// [`interop::own_key_ref`]: crate::interop::own_key_ref
     pub own_key: Box<*mut RLookupKey<'index>>,
-    /// Back-reference to the handle that points to [`own_key`](Self::own_key).
-    /// Set by the C side alongside `own_key`; null until then.
-    pub key_handle: *mut RLookupKeyHandle,
+    /// Back-reference to the handle that points to [`own_key`](Self::own_key),
+    /// so dropping this source can mark the key slot dead. Null until
+    /// [`interop::set_key_handle`] installs one.
+    ///
+    /// [`interop::set_key_handle`]: crate::interop::set_key_handle
+    pub key_handle: *mut RLookupKeyHandle<'index>,
 }
 
 impl<E: ExpirationChecker> Drop for VectorScoreSource<'_, E> {
     fn drop(&mut self) {
         if !self.key_handle.is_null() {
-            // SAFETY: key_handle is non-null only when VectorTopK_SetKeyHandle
-            // stored a valid, live RLookupKeyHandle pointer here.
+            // SAFETY: a non-null `key_handle` is one the setter's contract
+            // requires to outlive this source.
             unsafe {
                 (*self.key_handle).is_valid = false;
             }
@@ -143,8 +148,9 @@ impl<E: ExpirationChecker> Drop for VectorScoreSource<'_, E> {
 }
 
 // SAFETY: VectorScoreSource is used from a single thread (the query execution
-// thread). The `index` and `timeout` pointers are non-owning; the constructor contract requires
-// both to outlive the source. Everything else is owned and managed by the struct itself.
+// thread). The `index`, `timeout`, `own_key` and `key_handle` pointers are non-owning; the
+// constructor contract requires the first two to outlive the source, and the caller keeps the
+// key pointers valid for as long. Everything else is owned and managed by the struct itself.
 unsafe impl<E: ExpirationChecker + Send> Send for VectorScoreSource<'_, E> {}
 
 impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
@@ -580,6 +586,8 @@ mod tests {
     use rqe_iterators::NoOpChecker;
     use top_k::ScoreSource;
 
+    use ffi::QueryRequestTimeout;
+
     use super::refine_child_estimated;
     use crate::{
         VectorScoreSource,
@@ -698,6 +706,29 @@ mod tests {
         source.next_batch().unwrap();
         assert_eq!(source.max_batch_size, grown_size, "re-seed only raises");
         assert_eq!(source.num_iterations, 3, "batches keep accumulating");
+    }
+
+    /// The source borrows the request-owned timeout rather than copying it, and
+    /// hands VecSim that same storage — so a later change to the request's
+    /// timeout state is observed by work already in flight.
+    #[test]
+    #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+    fn borrows_the_request_timeout() {
+        let index = TestIndex::flat(3, 1);
+        let mut source = flat_source(&index, 3, 3);
+
+        assert_eq!(
+            source.timeout.as_ptr(),
+            index.timeout_ptr(),
+            "the source must hold the caller's timeout, not a copy"
+        );
+
+        source.next_batch().unwrap();
+        assert_eq!(
+            source.query_params.timeoutCtx.cast::<QueryRequestTimeout>(),
+            index.timeout_ptr(),
+            "VecSim must be handed the same timeout storage"
+        );
     }
 
     /// A zero seeded child estimate means no doc can match: `next_batch` must

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -151,6 +151,11 @@ impl TestIndex {
         self.dim * size_of::<f32>()
     }
 
+    /// The request timeout every source built from this index is handed.
+    pub fn timeout_ptr(&self) -> *mut QueryRequestTimeout {
+        self.timeout.get()
+    }
+
     /// Build a [`VectorScoreSource`] over this index for the `query` blob, with
     /// no pinned `HYBRID_POLICY`. `ef` seeds HNSW's `efRuntime`; `child_est`
     /// seeds the batch-size heuristic.

--- a/src/redisearch_rs/vector_score_source/tests/integration/interop.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/interop.rs
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! The two accessors reach the vector-score key slot through nothing but the
+//! C-ABI header, so every assertion here goes through that header rather than
+//! through the source it lands on.
+
+use std::{num::NonZeroUsize, ptr::NonNull};
+
+use ffi::QueryIterator;
+use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use rlookup::{RLookupKey, RLookupKeyHandle};
+use rqe_iterators::{FieldExpirationChecker, IdList, interop::RQEIteratorWrapper};
+use rqe_iterators_test_utils::MockContext;
+use vector_score_source::{
+    interop, new_vector_top_k_unfiltered,
+    test_utils::{TestIndex, uniform_blob},
+};
+
+/// A lowered iterator, released through the header's own `Free` callback.
+///
+/// Owning it rather than freeing by hand is what keeps a test that unwinds from
+/// leaking: `drop` runs during the unwind, which is the safe point a panicking
+/// dispatch otherwise leaves no room for.
+struct OwnedHeader(Option<NonNull<QueryIterator>>);
+
+impl OwnedHeader {
+    fn new(raw: *mut QueryIterator) -> Self {
+        Self(Some(
+            NonNull::new(raw).expect("boxed_new returns an owning pointer"),
+        ))
+    }
+
+    fn as_non_null(&self) -> NonNull<QueryIterator> {
+        self.0.expect("iterator has already been released")
+    }
+
+    /// Release now, for a test that has to observe what freeing did — the
+    /// handle invalidation is only visible once the iterator has gone.
+    fn free(&mut self) {
+        let Some(it) = self.0.take() else {
+            return;
+        };
+        // SAFETY: `it` is a live header from `boxed_new`, taken out of the
+        // option so this runs exactly once, and unused afterwards.
+        let free = unsafe { it.as_ref() }.Free.expect("Free must be populated");
+        // SAFETY: `boxed_new` populates every callback, and ownership passes here.
+        unsafe { free(it.as_ptr()) };
+    }
+}
+
+impl Drop for OwnedHeader {
+    fn drop(&mut self) {
+        self.free();
+    }
+}
+
+/// Lower a pure-KNN vector top-k iterator to its header, in the one
+/// parameterisation the accessors accept: the production
+/// [`FieldExpirationChecker`].
+fn header(index: &TestIndex, ctx: &MockContext) -> OwnedHeader {
+    // SAFETY: `ctx` owns a zeroed-but-valid `RedisSearchCtx` and `IndexSpec`,
+    // and outlives the iterator built here.
+    let checker = unsafe {
+        FieldExpirationChecker::new(
+            ctx.sctx(),
+            FieldFilterContext {
+                field: FieldMaskOrIndex::Index(0),
+                predicate: FieldExpirationPredicate::Default,
+            },
+            0,
+        )
+    };
+    let k = NonZeroUsize::new(3).expect("3 is non-zero");
+    let source = index.source_with_expiration(uniform_blob(0.0, 1), 0, k.get(), 3, checker);
+    OwnedHeader::new(RQEIteratorWrapper::boxed_new(new_vector_top_k_unfiltered(
+        source, k,
+    )))
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn own_key_ref_reaches_the_sources_own_slot() {
+    let index = TestIndex::flat(3, 1);
+    let ctx = MockContext::new(3, 3);
+    let it = header(&index, &ctx);
+    // A stand-in for the key the pipeline resolves: never dereferenced.
+    let mut key_storage = 0u64;
+
+    // SAFETY: `it` is a live vector top-k iterator, held exclusively here.
+    let slot = unsafe { interop::own_key_ref(it.as_non_null()) };
+    // SAFETY: `slot` is that iterator's own key slot, live and initialised.
+    let key = unsafe { &mut *slot };
+    assert!(key.is_null(), "a fresh iterator has no key yet");
+    *key = (&raw mut key_storage).cast::<RLookupKey<'_>>();
+
+    // A second dispatch reads the slot back: it belongs to the iterator rather
+    // than to the call.
+    // SAFETY: as above.
+    let slot = unsafe { interop::own_key_ref(it.as_non_null()) };
+    // SAFETY: as above.
+    let key = unsafe { &mut *slot };
+    assert_eq!(
+        *key,
+        (&raw mut key_storage).cast::<RLookupKey<'_>>(),
+        "the slot must survive between dispatches"
+    );
+    // The stand-in is not a real key: clear it before the iterator drops.
+    *key = std::ptr::null_mut();
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn freeing_the_iterator_invalidates_the_handle_it_was_given() {
+    let index = TestIndex::flat(3, 1);
+    let ctx = MockContext::new(3, 3);
+    let mut it = header(&index, &ctx);
+    let mut handle = RLookupKeyHandle {
+        key_ptr: std::ptr::null_mut(),
+        is_valid: true,
+    };
+
+    // SAFETY: `it` is a live vector top-k iterator held exclusively, and
+    // `handle` outlives it — the iterator is freed just below.
+    unsafe { interop::set_key_handle(it.as_non_null(), &raw mut handle) };
+    assert!(handle.is_valid, "wiring a handle must not clear it");
+
+    // Released here rather than left to drop: the invalidation is only
+    // observable once the iterator has gone.
+    it.free();
+    assert!(
+        !handle.is_valid,
+        "freeing the iterator must invalidate its handle"
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+#[should_panic(expected = "expected a vector top-k iterator")]
+fn own_key_ref_rejects_an_iterator_of_another_type() {
+    let it = OwnedHeader::new(RQEIteratorWrapper::boxed_new(IdList::<true>::new(vec![
+        1, 2, 3,
+    ])));
+
+    // SAFETY: the header is a live, exclusively-held wrapper reporting its type
+    // honestly. Being a vector top-k iterator is not a pre-condition but the
+    // documented panic condition, and this asserts it fires: the dispatch reads
+    // the type tag and nothing else, so `it` can still free it as the unwind
+    // passes through.
+    unsafe { interop::own_key_ref(it.as_non_null()) };
+}

--- a/src/redisearch_rs/vector_score_source/tests/integration/main.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/main.rs
@@ -12,6 +12,7 @@
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
 
+mod interop;
 mod policy;
 mod source;
 mod source_pytest_parity;


### PR DESCRIPTION
- Follow up to https://github.com/RediSearch/RediSearch/pull/10904

1. **Current:** `iterators_ffi` exports `VectorTopK_GetOwnKeyRef` and
   `VectorTopK_SetKeyHandle` across the C ABI so that `Query_EvalVectorNode` in
   `src/query.c` can bind the vector-score `RLookupKey` to a metric request.
   That function is Rust now (`query_eval::nodes::vector`), so both symbols have
   no C caller left.

2. **Change:** the binding moves into Rust as
   `vector_score_source::interop::{own_key_ref, set_key_handle}`, and the two
   `no_mangle` shims — plus the `RLookupKey` / `RLookupKeyHandle` typedefs that
   only existed to spell their signatures — leave `iterators_ffi.h`. This is the
   same shape the metric iterators already use via
   `rqe_iterators::metric::{own_key_ref, set_key_handle}`.

3. **Outcome:** internal only — no user-visible behavior change, and nothing
   calls the new accessors yet. It shrinks `iterators_ffi`'s C surface (33 → 31
   exported functions) and drops the two type compromises the C round trip
   forced: an erased-key cast that leaned on `#[repr(C)]` prefix layout, and a
   lifetime-erased handle pointer. It is the preparation step the
   hybrid-to-Rust-top-k swap builds on.

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
