### PR TITLE
[MOD-18138] Serve queries whose union or intersection has more than 65535 children

### DIFF
--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -347,26 +347,26 @@ typedef union RawTermRecord_Active {
  */
 typedef union RawTermRecord_Active RSTermRecord;
 
-#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED
+#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_Box_RawIndexResult_Active__u16;
-#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+typedef struct ThinVec_Box_RawIndexResult_Active__u32 {
+  struct Header_u32 *ptr;
+} ThinVec_Box_RawIndexResult_Active__u32;
+#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED */
 
-#ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
-#define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
+#ifndef MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
+#define MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
  *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
  */
-typedef struct ThinVec_Box_RawIndexResult_Active__u16 SmallThinVec_Box_RawIndexResult_Active;
-#endif /* SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
+typedef struct ThinVec_Box_RawIndexResult_Active__u32 MediumThinVec_Box_RawIndexResult_Active;
+#endif /* MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
 
 #ifndef RAWOWNEDAGGREGATERESULT_ACTIVE_DEFINED
 #define RAWOWNEDAGGREGATERESULT_ACTIVE_DEFINED
@@ -380,7 +380,7 @@ typedef struct RawOwnedAggregateResult_Active {
   /**
    * The records making up this aggregate result, each owned by this aggregate.
    */
-  SmallThinVec_Box_RawIndexResult_Active records;
+  MediumThinVec_Box_RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */
@@ -409,26 +409,26 @@ typedef struct ThinVec_MetricEntry__u64 {
  */
 typedef struct ThinVec_MetricEntry__u64 MetricsVec;
 
-#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED
+#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
-#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u32 {
+  struct Header_u32 *ptr;
+} ThinVec_SharedPtr_Active__RawIndexResult_Active__u32;
+#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED */
 
-#ifndef SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
-#define SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
+#ifndef MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
+#define MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
  *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
  */
-typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 SmallThinVec_SharedPtr_Active__RawIndexResult_Active;
-#endif /* SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u32 MediumThinVec_SharedPtr_Active__RawIndexResult_Active;
+#endif /* MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
 
 #ifndef RAWBORROWEDAGGREGATERESULT_ACTIVE_DEFINED
 #define RAWBORROWEDAGGREGATERESULT_ACTIVE_DEFINED
@@ -447,7 +447,7 @@ typedef struct RawBorrowedAggregateResult_Active {
    * equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
    * an inert raw pointer that survives lock release/reacquire cycles.
    */
-  SmallThinVec_SharedPtr_Active__RawIndexResult_Active records;
+  MediumThinVec_SharedPtr_Active__RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */
@@ -470,7 +470,7 @@ typedef struct RawBorrowedAggregateResult_Active {
  *
  * `RawAggregateResult` is part of a union in
  * [`super::result_data::RawResultData`], so it needs to have a known size. That
- * is why both payloads hold their children in a [`SmallThinVec`] rather than the
+ * is why both payloads hold their children in a [`MediumThinVec`] rather than the
  * std `Vec`, which is not `#[repr(C)]`.
  *
  * The C code should always use `AggregateResult_New` to construct a new instance of this type

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -10,7 +10,7 @@
 use std::ptr::NonNull;
 
 use ref_mode::{Active, Ref, SharedPtr, Suspended};
-use thin_vec::SmallThinVec;
+use thin_vec::MediumThinVec;
 
 use super::core::{RSIndexResult, RawIndexResult};
 use super::kind::RSResultKindMask;
@@ -27,7 +27,7 @@ use super::kind::RSResultKindMask;
 ///
 /// `RawAggregateResult` is part of a union in
 /// [`super::result_data::RawResultData`], so it needs to have a known size. That
-/// is why both payloads hold their children in a [`SmallThinVec`] rather than the
+/// is why both payloads hold their children in a [`MediumThinVec`] rather than the
 /// std `Vec`, which is not `#[repr(C)]`.
 ///
 /// The C code should always use `AggregateResult_New` to construct a new instance of this type
@@ -59,7 +59,7 @@ pub struct RawBorrowedAggregateResult<'query, R: Ref> {
     /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
     /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
     /// an inert raw pointer that survives lock release/reacquire cycles.
-    records: SmallThinVec<SharedPtr<R, RawIndexResult<'query, R>>>,
+    records: MediumThinVec<SharedPtr<R, RawIndexResult<'query, R>>>,
 
     /// A map of the aggregate kind of the underlying records
     kind_mask: RSResultKindMask,
@@ -76,7 +76,7 @@ pub type RSBorrowedAggregateResult<'a> = RawBorrowedAggregateResult<'a, Active<'
 #[repr(C)]
 pub struct RawOwnedAggregateResult<'query, R: Ref> {
     /// The records making up this aggregate result, each owned by this aggregate.
-    records: SmallThinVec<Box<RawIndexResult<'query, R>>>,
+    records: MediumThinVec<Box<RawIndexResult<'query, R>>>,
 
     /// A map of the aggregate kind of the underlying records
     kind_mask: RSResultKindMask,
@@ -154,7 +154,7 @@ impl<'query, R: Ref> RawBorrowedAggregateResult<'query, R> {
     /// Create a new empty borrowed aggregate result with the given capacity
     pub fn with_capacity(cap: usize) -> Self {
         Self {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -230,7 +230,7 @@ impl<'a> RSBorrowedAggregateResult<'a> {
     /// The returned aggregate result will have the same lifetime as the original one,
     /// since it may borrow terms from the original result.
     pub fn to_owned(&'a self) -> RSOwnedAggregateResult<'a> {
-        let mut records = SmallThinVec::with_capacity(self.records.len());
+        let mut records = MediumThinVec::with_capacity(self.records.len());
 
         records.extend(
             self.records
@@ -250,7 +250,7 @@ impl<'query, R: Ref> RawOwnedAggregateResult<'query, R> {
     /// Create a new empty owned aggregate result with the given capacity
     pub fn with_capacity(cap: usize) -> Self {
         Self {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -282,7 +282,7 @@ impl<'query, R: Ref> RawOwnedAggregateResult<'query, R> {
 
     /// Take the children out of this aggregate result, transferring ownership of
     /// each one to the caller.
-    pub fn into_records(self) -> SmallThinVec<Box<RawIndexResult<'query, R>>> {
+    pub fn into_records(self) -> MediumThinVec<Box<RawIndexResult<'query, R>>> {
         self.records
     }
 
@@ -347,7 +347,7 @@ impl<'a> RSOwnedAggregateResult<'a> {
     /// The returned aggregate result will have the same lifetime as the original one,
     /// since it may borrow terms from the original result.
     pub fn to_owned(&'a self) -> RSOwnedAggregateResult<'a> {
-        let mut records = SmallThinVec::with_capacity(self.records.len());
+        let mut records = MediumThinVec::with_capacity(self.records.len());
 
         records.extend(
             self.records

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1540,6 +1540,7 @@ fn intersection_upholds_current_contract() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // 65536 children exceeds the miri timeout
 fn child_count_is_not_capped_at_16_bits() {
     // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
     const CHILD_COUNT: usize = 65536;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1540,7 +1540,7 @@ fn intersection_upholds_current_contract() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // 65536 children exceeds the miri timeout
+#[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
 fn child_count_is_not_capped_at_16_bits() {
     // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
     const CHILD_COUNT: usize = 65536;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1538,3 +1538,23 @@ fn intersection_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [2, 3]);
     assert_current_contract_via_skip_to(&mut it, 10);
 }
+
+#[test]
+fn read_with_more_children_than_a_16_bit_count() {
+    // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+    const CHILD_COUNT: usize = 65536;
+
+    let children = create_children(CHILD_COUNT, &[1]);
+    let mut ii = ContractChecker::new(Intersection::new(children, 1.0, false));
+    let result = ii.read().expect("read failed").expect("should have result");
+
+    assert_eq!(result.doc_id, 1);
+    assert_eq!(
+        result
+            .as_aggregate()
+            .expect("an intersection result is an aggregate")
+            .len(),
+        CHILD_COUNT,
+        "every child matches doc 1, so all of them belong to the aggregate"
+    );
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1540,7 +1540,7 @@ fn intersection_upholds_current_contract() {
 }
 
 #[test]
-fn read_with_more_children_than_a_16_bit_count() {
+fn child_count_is_not_capped_at_16_bits() {
     // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
     const CHILD_COUNT: usize = 65536;
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -40,7 +40,7 @@ macro_rules! union_common_tests {
         const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
 
         #[test]
-        fn read_with_more_children_than_a_16_bit_count() {
+        fn child_count_is_not_capped_at_16_bits() {
             let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
                 .map(|_| MockVec::new_boxed(vec![1]))
                 .collect();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -40,7 +40,7 @@ macro_rules! union_common_tests {
         const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
 
         #[test]
-        #[cfg_attr(miri, ignore)] // 65536 children exceeds the miri timeout
+        #[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
         fn child_count_is_not_capped_at_16_bits() {
             let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
                 .map(|_| MockVec::new_boxed(vec![1]))

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -40,6 +40,7 @@ macro_rules! union_common_tests {
         const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
 
         #[test]
+        #[cfg_attr(miri, ignore)] // 65536 children exceeds the miri timeout
         fn child_count_is_not_capped_at_16_bits() {
             let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
                 .map(|_| MockVec::new_boxed(vec![1]))

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -36,6 +36,32 @@ macro_rules! union_common_tests {
         // Read tests
         // =============================================================================
 
+        /// One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+        const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
+
+        #[test]
+        fn read_with_more_children_than_a_16_bit_count() {
+            let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
+                .map(|_| MockVec::new_boxed(vec![1]))
+                .collect();
+
+            let mut union_iter = Union::new(children);
+            let result = union_iter
+                .read()
+                .expect("read failed")
+                .expect("should have result");
+
+            assert_eq!(result.doc_id, 1);
+            assert_eq!(
+                result
+                    .as_aggregate()
+                    .expect("a union result is an aggregate")
+                    .len(),
+                CHILD_COUNT_ABOVE_16_BIT,
+                "every child matches doc 1, so all of them belong to the aggregate"
+            );
+        }
+
         #[rstest::rstest]
         #[case::c2_small(2, &[1u64, 2, 3, 40, 50])]
         #[case::c2_medium(2, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -385,7 +385,7 @@ class TestIteratorsRevalidateTimeout:
                                  message="the tree was freed, so no further results can arrive")
 
 
-def test_union_with_more_children_than_a_16_bit_count(env):
+def test_union_child_count_is_not_capped_at_16_bits(env):
     """A union node with more children than a 16-bit count can hold serves the query normally.
 
     `NOT` branches are used because they are never reduced away as empty, so the union keeps a
@@ -401,3 +401,76 @@ def test_union_with_more_children_than_a_16_bit_count(env):
     expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
     env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
                     message="a union of negations matches the same documents whatever its width")
+
+
+def test_tag_union_child_count_is_not_capped_at_16_bits(env):
+    """A TAG union node with more children than a 16-bit count can hold serves the query
+    normally.
+
+    Unlike the plain-text union test, the children here all come from values that actually
+    exist on the document, exercising the tag-node evaluation path in `Query_EvalTagNode`
+    rather than the generic union constructor.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+
+    values = [f'v{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ','.join(values))
+
+    wide_query = '@t:{' + '|'.join(values) + '}'
+
+    expected = env.cmd('FT.SEARCH', 'idx', '@t:{v0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a tag union matches the same documents whatever its width")
+
+
+def test_intersection_and_phrase_child_count_is_not_capped_at_16_bits(env):
+    """An intersection node, and a quoted-phrase node built on top of one, both serve a
+    query normally when they have more children than a 16-bit count can hold.
+
+    The same document backs both assertions: it contains every term in order, so the
+    implicit AND of all terms and the exact quoted phrase of all terms both have to match
+    it, and neither can short-circuit on a missing child.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    words = [f'w{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ' '.join(words))
+
+    expected = env.cmd('FT.SEARCH', 'idx', 'w0', 'NOCONTENT', 'DIALECT', 2)
+
+    and_query = ' '.join(words)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', and_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="an intersection of terms matches the same documents whatever its width")
+
+    phrase_query = '"' + ' '.join(words) + '"'
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', phrase_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a quoted phrase matches the same documents whatever its width")
+
+
+def test_prefix_expansion_child_count_is_not_capped_at_16_bits():
+    """Prefix expansion, on both a TEXT and a TAG field, can build a union with more children
+    than a 16-bit count can hold when MAXPREFIXEXPANSIONS allows it.
+
+    Unlike the other wide-node tests, the width here comes from the number of indexed terms
+    a short prefix expands to, not from the query string itself.
+    """
+    env = Env(moduleArgs='MAXPREFIXEXPANSIONS 100000')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
+    text_terms = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'text:1', 't', ' '.join(text_terms))
+
+    expected_text = env.cmd('FT.SEARCH', 'idx_text', 'va0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_text', 'va*', 'NOCONTENT', 'DIALECT', 2), expected_text,
+                    message="a TEXT prefix query matches the same documents whatever its expansion width")
+
+    env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 't', 'TAG').ok()
+    tag_values = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'tag:1', 't', ','.join(tag_values))
+
+    expected_tag = env.cmd('FT.SEARCH', 'idx_tag', '@t:{va0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_tag', '@t:{va*}', 'NOCONTENT', 'DIALECT', 2), expected_tag,
+                    message="a TAG prefix query matches the same documents whatever its expansion width")

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -383,3 +383,21 @@ class TestIteratorsRevalidateTimeout:
             res, cursor = self.env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
             self.env.assertEqual(res['results'], [],
                                  message="the tree was freed, so no further results can arrive")
+
+
+def test_union_with_more_children_than_a_16_bit_count(env):
+    """A union node with more children than a 16-bit count can hold serves the query normally.
+
+    `NOT` branches are used because they are never reduced away as empty, so the union keeps a
+    child per branch without the index needing a matching term for each one.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'h1', 't', 'hello')
+
+    # One past u16::MAX, the widest child count a 16-bit capacity can hold.
+    wide_query = '|'.join(f'-a{i}' for i in range(65536))
+
+    expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a union of negations matches the same documents whatever its width")


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the records vector of `RSAggregateResult` uses the `u16` capacity variant of `ThinVec`, so a union or intersection node is limited to 65535 children. The capacity type came from the vector crate's default rather than from a requirement of this data; the C representation it replaced counted children in two `int` fields.
2. Change: that vector now uses the `u32` capacity variant. For pointer-sized, pointer-aligned elements the 4-byte `u16` header is padded to 8 anyway, so the allocation size is unchanged and the struct stays one pointer wide.
3. Outcome: queries whose union or intersection reaches more than 65535 children are served instead of failing. That covers wide `OR`/`AND` lists, wide tag lists, prefix and wildcard expansion above 65535 terms, and numeric or geo ranges spanning more than 65535 range-tree leaves.

#### Which additional issues this PR fixes

1. MOD-18138
2. #11233

#### Main objects this PR modified

1. `RawBorrowedAggregateResult` / `RawOwnedAggregateResult` (`index_result`) — records vector capacity type.
2. `index_result_rs.h` — regenerated; the C-visible field stays a single pointer, so the layout is unchanged.
3. Union and intersection iterator tests, plus flow tests in `test_iterators.py` — coverage above the 16-bit boundary for the tag-node path, the intersection constructor (directly and via a quoted phrase), and prefix expansion on TEXT and TAG fields. Numeric and geo ranges reach the same constructor but need ~164M distinct values to exceed 65535 range-tree leaves, so they stay uncovered.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

A non-panicking failure path at the FFI boundary is deliberately not part of this PR; a panic in an exported `extern "C"` function still aborts, and that is tracked separately.
