### PR TITLE
Trie - reference constants instead of redeclaring

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3117,6 +3117,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "cheadergen",
+ "ffi",
  "redis_mock",
  "redisearch_rs",
  "term_dictionary",

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/Cargo.toml
@@ -16,6 +16,7 @@ build_utils = { path = "../../build_utils" }
 
 [dependencies]
 cheadergen.workspace = true
+ffi.workspace = true
 term_dictionary = { workspace = true }
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -160,10 +160,10 @@ unsafe fn term_arg<'a>(ptr: *const c_char, len: usize, what: &'static str) -> &'
 /// codepoints can fall under the rune bound and still exceed this one.
 pub const MAX_TERM_BYTES: usize = 512;
 
-/// Codepoint bound the C terms trie applies, `TRIE_INITIAL_STRING_LEN`.
-/// Structural there — its iterator carries fixed `rune` and `stackNode`
-/// arrays of that size, so a longer key cannot be walked.
-pub const MAX_TERM_RUNES: usize = 256;
+/// Codepoint bound the C terms trie applies. Structural there — its
+/// iterator carries fixed `rune` and `stackNode` arrays of that size, so
+/// a longer key cannot be walked.
+pub const MAX_TERM_RUNES: usize = ffi::TRIE_INITIAL_STRING_LEN as usize;
 
 /// Borrow `(ptr, len)` as a term, or `None` for one the C terms trie
 /// would have rejected: empty, over [`MAX_TERM_BYTES`], or at

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -154,11 +154,11 @@ unsafe fn term_arg<'a>(ptr: *const c_char, len: usize, what: &'static str) -> &'
     std::str::from_utf8(bytes).unwrap_or_else(|_| panic!("{what} must be valid UTF-8"))
 }
 
-/// Byte bound the C terms trie's `Trie_InsertStringBuffer` applies,
-/// `TRIE_INITIAL_STRING_LEN * sizeof(rune)`. Coarser than
-/// [`MAX_TERM_RUNES`] rather than implied by it: a term of multi-byte
-/// codepoints can fall under the rune bound and still exceed this one.
-pub const MAX_TERM_BYTES: usize = 512;
+/// Byte bound the C terms trie's `Trie_InsertStringBuffer` applies.
+/// Coarser than [`MAX_TERM_RUNES`] rather than implied by it: a term of
+/// multi-byte codepoints can fall under the rune bound and still exceed
+/// this one.
+pub const MAX_TERM_BYTES: usize = ffi::TRIE_INITIAL_STRING_LEN as usize * size_of::<ffi::rune>();
 
 /// Codepoint bound the C terms trie applies. Structural there — its
 /// iterator carries fixed `rune` and `stackNode` arrays of that size, so

--- a/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/term_dictionary_ffi/src/lib.rs
@@ -155,9 +155,10 @@ unsafe fn term_arg<'a>(ptr: *const c_char, len: usize, what: &'static str) -> &'
 }
 
 /// Byte bound the C terms trie's `Trie_InsertStringBuffer` applies.
-/// Coarser than [`MAX_TERM_RUNES`] rather than implied by it: a term of
-/// multi-byte codepoints can fall under the rune bound and still exceed
-/// this one.
+/// A separate gate from [`MAX_TERM_RUNES`], not a restatement of it:
+/// neither bound subsumes the other, since a term of multi-byte
+/// codepoints can fall under the rune bound and still exceed this one,
+/// while an ASCII term hits the rune bound first.
 pub const MAX_TERM_BYTES: usize = ffi::TRIE_INITIAL_STRING_LEN as usize * size_of::<ffi::rune>();
 
 /// Codepoint bound the C terms trie applies. Structural there — its

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -411,7 +411,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     HeaderAllowlist {
         path: "src/trie/rune_util.h",
         fns: &["runesToStr", "strToLowerRunes", "strToRunes"],
-        types: &[],
+        types: &["rune"],
         vars: &["MAX_RUNE_STR_LEN"],
     },
     HeaderAllowlist {


### PR DESCRIPTION
Trie - reference `MAX_TERM_RUNES` and `MAX_TERM_BYTES` instead of redeclaring

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
