### PR TITLE
[8.6] Enable using self-hosted runners

### DIFF
--- a/.github/actions/github-hosted-runner-cleanup/action.yml
+++ b/.github/actions/github-hosted-runner-cleanup/action.yml
@@ -1,0 +1,52 @@
+name: GitHub-hosted runner cleanup
+description: Free disk space by removing large preinstalled GitHub-hosted runner directories.
+
+runs:
+  using: composite
+  steps:
+    - name: Free runner disk space
+      shell: bash -l -eo pipefail {0}
+      env:
+        RUNNER_ENVIRONMENT_CONTEXT: ${{ runner.environment }}
+        RUNNER_OS_CONTEXT: ${{ runner.os }}
+      run: |
+        if [ "$RUNNER_ENVIRONMENT_CONTEXT" != "github-hosted" ]; then
+          echo "Skipping cleanup on $RUNNER_ENVIRONMENT_CONTEXT runner."
+          exit 0
+        fi
+
+        if [ "$RUNNER_OS_CONTEXT" != "Linux" ]; then
+          echo "Skipping cleanup on $RUNNER_OS_CONTEXT runner."
+          exit 0
+        fi
+
+        echo "Before cleanup:"
+        df -h
+
+        mount_prefix=
+        if [ -d /host/usr/share/dotnet ] || [ -d /host/usr/local/lib/android ] || [ -d /host/opt/ghc ]; then
+          mount_prefix=/host
+        fi
+
+        for path in \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost
+        do
+          target="${mount_prefix}${path}"
+          [ -e "$target" ] || continue
+
+          echo "Removing $target"
+          if [ "$(id -u)" -eq 0 ]; then
+            find "$target" -mindepth 1 -delete || true
+          else
+            sudo find "$target" -mindepth 1 -delete || true
+          fi
+        done
+
+        [ -n "$mount_prefix" ] || docker system prune -af 2>/dev/null || true
+
+        echo "After cleanup:"
+        df -h

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -38,7 +38,9 @@ on:
 jobs:
   benchmark-steps:
     name: "Benchmark ${{ inputs.allowed_setups }} (${{ inputs.benchmark_runner_group_member_id }}/${{ inputs.benchmark_runner_group_total }}) filter=${{ inputs.benchmark_glob }} "
-    runs-on: ubuntu-24.04  # We need the os to be a match to the base image used in the benchmarks.
+    # 8.6 has no arch input for this job (unlike master's arch-conditional runner
+    # selection); it always targets x64 ubuntu-24.04, so only the x64 fallback applies.
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}  # We need the os to be a match to the base image used in the benchmarks.
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
     env:
       RUST_BACKTRACE: full
     steps:

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ${{ needs.get-config.outputs.container }}
-      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
+      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
   build:
@@ -59,7 +59,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.get-config.result == 'success'
-    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for OIDC role assumption during upload
       contents: read  # Required for actions/checkout
@@ -72,7 +72,7 @@ jobs:
         && fromJSON(
           format('{{"image":"{0}","options":"--user root {1}"}}',
             needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            needs.get-config.outputs.container == 'alpine:3.22' && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+            needs.get-config.outputs.container == 'alpine:3.22' && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '')
         )
       || null }}
 

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -64,8 +64,8 @@ jobs:
 
           # Default environment per architecture
           # Use GitHub variables if available, otherwise use fallback values
-          runs_on = "${{ vars.RUNS_ON || 'ubuntu-24.04' }}"
-          runs_on_arm = "${{ vars.RUNS_ON_ARM || 'ubuntu24-arm64-2-8' }}"
+          runs_on = "${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}"
+          runs_on_arm = "${{ vars.RUNS_ON_ARM64_MEDIUM || vars.RUNS_ON_ARM || 'ubuntu24-arm64-2-8' }}"
 
           default_env = {
               'x86_64': runs_on,
@@ -193,13 +193,13 @@ jobs:
                   "x86_64": {
                       'container': 'alpine:3.22',
                       'setup_script': 'apk add bash git',
-                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -s /usr/bin/node /opt/bin/node',
+                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -sf /usr/bin/node /opt/bin/node',
                       'name': 'Alpine 3 x86_64'
                   },
                   "aarch64": {
                       'container': 'alpine:3.22',
                       'setup_script': 'apk add bash gcompat libstdc++ libgcc git',
-                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -s /usr/bin/node /opt/bin/node',
+                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -sf /usr/bin/node /opt/bin/node',
                       'name': 'Alpine 3 ARM64'
                   }
               },

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -20,13 +20,13 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ubuntu:noble
-      runner-env: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+      runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
 
   lint:
     name: Linting
     needs: build-image
     if: ${{ !cancelled() }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -151,13 +151,17 @@ jobs:
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
       (inputs.standalone || inputs.coordinator || inputs.unit-tests)
-    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04' }}
+    # Runner-local env is unavailable while GitHub creates the job container.
+    # Use the resolved runner label as the pre-container signal for GitHub-hosted
+    # mounts; runner-local env is not available yet.
     container: ${{
       needs.get-config.outputs.container
         && fromJSON(
-          format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache {1}"}}',
+          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
             needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            needs.get-config.outputs.container == 'alpine:3.22' && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+            needs.get-config.outputs.container == 'alpine:3.22' && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
+            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
         )
       || null }}
 
@@ -169,50 +173,6 @@ jobs:
         if: needs.get-config.outputs.container == 'alpine:3.22'
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
-
-      - name: Free up disk space (container)
-        # For container jobs - delete mounted host directories
-        if: ${{ needs.get-config.outputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
-      - name: Free up disk space (non-container)
-        # For non-container jobs - delete directly with sudo
-        # Skip macOS - it doesn't have these directories
-        if: ${{ !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo rm -rf /usr/local/share/boost || true
-          docker system prune -af 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
-      - name: Fix HOME Directory
-        if: ${{ needs.build-image.outputs.succeeded == 'true' && needs.get-config.outputs.container }}
-        shell: bash
-        run: |
-          # Issue [HOME is overridden for containers](https://github.com/actions/runner/issues/863)
-          h=$(getent passwd "$(id -un)" | cut -d: -f6)
-          if [ "$h" = "$HOME" ]; then
-            echo "HOME fine: $HOME"
-            exit 0
-          fi
-          echo "HOME=$HOME was broken. Setting it to $h"
-          ls -ld "$HOME"
-          ls -ld "$h"
-          echo "USER: $USER"
-          echo "id: $(id)"
-          echo "HOME=$h" >> "$GITHUB_ENV"
 
       - name: Setup Dependencies
         if: needs.build-image.outputs.succeeded != 'true' && needs.get-config.outputs.setup_script
@@ -237,14 +197,6 @@ jobs:
             fi
           done
           echo "supported=true" >> $GITHUB_OUTPUT
-      - name: Free up disk space
-        run: |
-          df -h
-          ${{ steps.mode.outputs.mode }} rm -rf /usr/share/dotnet || true
-          ${{ steps.mode.outputs.mode }} rm -rf /usr/local/lib/android || true
-          ${{ steps.mode.outputs.mode }} rm -rf /opt/ghc || true
-          ${{ steps.mode.outputs.mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
-          df -h
       - name: Full checkout (node20)
         if: steps.node20.outputs.supported == 'true'
         uses: actions/checkout@v6
@@ -287,6 +239,26 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Free up disk space
+        uses: ./.github/actions/github-hosted-runner-cleanup
+      - name: Fix HOME Directory
+        if: ${{ needs.build-image.outputs.succeeded == 'true' && needs.get-config.outputs.container }}
+        shell: bash
+        run: |
+          # Issue [HOME is overridden for containers](https://github.com/actions/runner/issues/863)
+          h=$(getent passwd "$(id -un)" | cut -d: -f6)
+          if [ "$h" = "$HOME" ]; then
+            echo "HOME fine: $HOME"
+            exit 0
+          fi
+          echo "HOME=$HOME was broken. Setting it to $h"
+          ls -ld "$HOME"
+          ls -ld "$h"
+          echo "USER: $USER"
+          echo "id: $(id)"
+          echo "HOME=$h" >> "$GITHUB_ENV"
+
       - name: Print CPU information
         env:
           RUNNER_ARCH: ${{ runner.arch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ COPY . .
 WORKDIR /project/.install
 RUN bash retry.sh bash -l -eo pipefail install_script.sh
 WORKDIR /project
-RUN bash .install/retry.sh bash -l -eo pipefail .install/test_deps/install_rust_deps.sh
+# `cargo miri setup` validates MIRI during image build, but its generated
+# sysroot is sensitive to runtime Cargo/rustc settings and can poison CI.
+RUN bash .install/retry.sh bash -l -eo pipefail .install/test_deps/install_rust_deps.sh && \
+    rm -rf "$HOME/.cache/miri"
 # Expose newly-installed Rust and Python tools via PATH
 ENV PATH="/root/.cargo/bin:/root/.local/bin:${PATH}"
 


### PR DESCRIPTION
Manual backport of #11075 to 8.6.

The auto-backport bot declined this branch: "The cherry-pick conflicts across all 15 modified workflow/Dockerfile paths; target-specific CI behavior requires manual backporting." 8.6 keeps the pre-refactor monolithic `task-test.yml`, so this re-derives PR #11075's intent (self-hosted-runner-with-fallback var scheme, the new `github-hosted-runner-cleanup` reusable action, the reordered Alpine/checkout/cleanup steps, and the miri-cache Dockerfile fix) on top of that layout rather than cherry-picking text.

## Original PR
https://github.com/RediSearch/RediSearch/pull/11075

## Changes from original
Adapted to 8.6's monolithic `task-test.yml` and existing runner conventions (no `inputs.arch` conditional exists in `benchmark-flow.yml` on this branch, so only the x64 fallback was wrapped). Functionally equivalent to master's change.

Opened to validate PR-flow CI (build+test across platforms) on this backport; the merge-queue-specific workflow requires actually queuing a merge and is intentionally not exercised here.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes