### PR TITLE
[8.8-rse] Enable using self-hosted runners

### DIFF
--- a/.github/actions/github-hosted-runner-cleanup/action.yml
+++ b/.github/actions/github-hosted-runner-cleanup/action.yml
@@ -1,0 +1,52 @@
+name: GitHub-hosted runner cleanup
+description: Free disk space by removing large preinstalled GitHub-hosted runner directories.
+
+runs:
+  using: composite
+  steps:
+    - name: Free runner disk space
+      shell: bash -l -eo pipefail {0}
+      env:
+        RUNNER_ENVIRONMENT_CONTEXT: ${{ runner.environment }}
+        RUNNER_OS_CONTEXT: ${{ runner.os }}
+      run: |
+        if [ "$RUNNER_ENVIRONMENT_CONTEXT" != "github-hosted" ]; then
+          echo "Skipping cleanup on $RUNNER_ENVIRONMENT_CONTEXT runner."
+          exit 0
+        fi
+
+        if [ "$RUNNER_OS_CONTEXT" != "Linux" ]; then
+          echo "Skipping cleanup on $RUNNER_OS_CONTEXT runner."
+          exit 0
+        fi
+
+        echo "Before cleanup:"
+        df -h
+
+        mount_prefix=
+        if [ -d /host/usr/share/dotnet ] || [ -d /host/usr/local/lib/android ] || [ -d /host/opt/ghc ]; then
+          mount_prefix=/host
+        fi
+
+        for path in \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost
+        do
+          target="${mount_prefix}${path}"
+          [ -e "$target" ] || continue
+
+          echo "Removing $target"
+          if [ "$(id -u)" -eq 0 ]; then
+            find "$target" -mindepth 1 -delete || true
+          else
+            sudo find "$target" -mindepth 1 -delete || true
+          fi
+        done
+
+        [ -n "$mount_prefix" ] || docker system prune -af 2>/dev/null || true
+
+        echo "After cleanup:"
+        df -h

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -53,7 +53,7 @@ jobs:
     name: "Benchmark ${{ inputs.arch }} ${{ inputs.allowed_setups }} (${{ inputs.benchmark_runner_group_member_id }}/${{ inputs.benchmark_runner_group_total }}) filter=${{ inputs.benchmark_glob }}${{ inputs.benchmark_filter && format(' narrowed={0}', inputs.benchmark_filter) || '' }}"
     # Match the orchestrator runner arch to inputs.arch because tests/deps/setup_rejson.sh
     # builds rejson.so here and it must be ABI-compatible with the target EC2 DB.
-    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'aarch64' && (vars.RUNS_ON_ARM64_MEDIUM || vars.RUNS_ON_ARM || 'ubuntu-24.04-arm') || (vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04') }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -13,7 +13,7 @@ on:
       arch:
         type: string
         default: x86_64
-        description: "CPU arch to build for. `x86_64` (default) runs on GitHub's ubuntu-24.04; `aarch64` runs on ubuntu-24.04-arm. Must match the target EC2 DB architecture at benchmark time."
+        description: "CPU arch to build for. `x86_64` runs on the medium x64 runner; `aarch64` runs on the medium ARM64 runner. Must match the target EC2 DB architecture at benchmark time."
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
     # the target EC2 instance. build.sh derives the output dir from `uname -m`,
     # so we run the build natively on the matching-arch runner instead of
     # cross-compiling.
-    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'aarch64' && (vars.RUNS_ON_ARM64_MEDIUM || vars.RUNS_ON_ARM || 'ubuntu-24.04-arm') || (vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-24.04') }}
     permissions:
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions:
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ${{ needs.get-config.outputs.container }}
-      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
   build:
@@ -59,7 +59,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.get-config.result == 'success'
-    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions:
       id-token: write # Required for OIDC role assumption during upload
       contents: read  # Required for actions/checkout
@@ -72,7 +72,7 @@ jobs:
         && fromJSON(
           format('{{"image":"{0}","options":"--user root {1}"}}',
             needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '')
         )
       || null }}
 

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -74,8 +74,8 @@ jobs:
 
           # Default environment per architecture
           # Use GitHub variables if available, otherwise use fallback values
-          runs_on = "${{ vars.RUNS_ON || 'ubuntu-latest' }}"
-          runs_on_arm = "${{ vars.RUNS_ON_ARM || 'ubuntu24-arm64-2-8' }}"
+          runs_on = "${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}"
+          runs_on_arm = "${{ vars.RUNS_ON_ARM64_MEDIUM || vars.RUNS_ON_ARM || 'ubuntu24-arm64-2-8' }}"
 
           default_env = {
               'x86_64': runs_on,
@@ -261,19 +261,19 @@ jobs:
                   }
               },
               "alpine:3.23": {
-                # A workaround to get GitHub Actions to work on Alpine in 'post_setup_script'
+                # A workaround to get GitHub Actions JavaScript actions to work on Alpine.
                 # See https://github.com/actions/runner/issues/801#issuecomment-2976165281 for more details
                   "x86_64": {
                       'container': 'alpine:3.23',
                       'setup_script': 'apk add bash git',
-                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -s /usr/bin/node /opt/bin/node',
+                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -sf /usr/bin/node /opt/bin/node',
                       'name': 'Alpine 3.23 x86_64',
                       'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'alpine:3.23',
                       'setup_script': 'apk add bash gcompat libstdc++ libgcc git',
-                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -s /usr/bin/node /opt/bin/node',
+                      'post_setup_script': 'echo RUST_DYN_CRT=1 >> $GITHUB_ENV; sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release; apk add nodejs --update-cache; mkdir -p /opt/bin; ln -sf /usr/bin/node /opt/bin/node',
                       'name': 'Alpine 3.23 ARM64',
                       'enable_lto': '1'
                   }

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -20,13 +20,13 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ubuntu:noble
-      runner-env: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+      runner-env: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
 
   lint:
     name: Linting
     needs: build-image
     if: ${{ !cancelled() }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
     permissions:
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -77,12 +77,16 @@ jobs:
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success')
     runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    # Runner-local env is unavailable while GitHub creates the job container.
+    # Use the resolved runner label as the pre-container signal for GitHub-hosted
+    # mounts; runner-local env is not available yet.
     container: ${{
       needs.get-config.outputs.container
         && fromJSON(
-          format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache {1}"}}',
+          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
             needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
+            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
         )
       || null }}
     permissions:
@@ -96,31 +100,21 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        if: ${{ needs.get-config.outputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
+      - name: Setup platform dependencies
+        if: needs.get-config.outputs.setup_script
+        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
 
-      - name: Free up disk space (non-container)
-        if: ${{ !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo rm -rf /usr/local/share/boost || true
-          docker system prune -af 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
+      - name: Post-setup
+        if: needs.get-config.outputs.post_setup_script
+        env:
+          POST_SETUP_SCRIPT: ${{ needs.get-config.outputs.post_setup_script }}
+        run: ${{ needs.get-config.outputs.post_setup_script }}
+
+      - name: Checkout RediSearch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Free up disk space
+        uses: ./.github/actions/github-hosted-runner-cleanup
 
       - name: Disable automatic apt updates (self-hosted Linux)
         if: ${{ needs.get-config.outputs.ec2_image_id && !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
@@ -131,14 +125,6 @@ jobs:
           sudo systemctl mask apt-daily.service apt-daily-upgrade.service unattended-upgrades.service 2>/dev/null || true
           sudo pkill -f "apt.systemd.daily" || true
           sudo pkill -f "unattended-upgrade" || true
-
-      - name: Setup platform dependencies
-        if: needs.get-config.outputs.setup_script
-        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
-
-      - name: Post-setup
-        if: needs.get-config.outputs.post_setup_script
-        run: ${{ needs.get-config.outputs.post_setup_script }}
 
       - name: Install Redis build-flow prerequisites
         env:

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -129,13 +129,17 @@ jobs:
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
       (inputs.skip-tests || inputs.standalone || inputs.coordinator || inputs.unit-tests)
-    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON_X64_MEDIUM || vars.RUNS_ON || 'ubuntu-latest' }}
+    # Runner-local env is unavailable while GitHub creates the job container.
+    # Use the resolved runner label as the pre-container signal for GitHub-hosted
+    # mounts; runner-local env is not available yet.
     container: ${{
       needs.get-config.outputs.container
         && fromJSON(
-          format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache {1}"}}',
+          format('{{"image":"{0}","options":"--user root {1} {2}"}}',
             needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container,
-            startsWith(needs.get-config.outputs.container, 'alpine:') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+            startsWith(needs.get-config.outputs.container, 'alpine:') && (startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '-v /opt/gha-alpine-node:/opt:rw -v /opt/gha-alpine-node:/__e/node20:ro -v /opt/gha-alpine-node:/__e/node24:ro') || '',
+            startsWith(needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest', 'ubuntu') && '-v /usr/share/dotnet:/host/usr/share/dotnet -v /usr/local/lib/android:/host/usr/local/lib/android -v /opt/ghc:/host/opt/ghc -v /opt/hostedtoolcache:/host/opt/hostedtoolcache' || '')
         )
       || null }}
 
@@ -159,33 +163,23 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        # For container jobs - delete mounted host directories
-        if: ${{ needs.get-config.outputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
-      - name: Free up disk space (non-container)
-        # For non-container jobs - delete directly with sudo
-        # Skip macOS - it doesn't have these directories
-        if: ${{ !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo rm -rf /usr/local/share/boost || true
-          docker system prune -af 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
+      - name: Setup Dependencies
+        if: needs.build-image.outputs.succeeded != 'true' && needs.get-config.outputs.setup_script
+        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
+
+      - name: Post-setup
+        if: needs.get-config.outputs.post_setup_script
+        env:
+          POST_SETUP_SCRIPT: ${{ needs.get-config.outputs.post_setup_script }}
+        run: ${{ needs.get-config.outputs.post_setup_script }}
+
+      - name: Full checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          submodules: recursive
+
+      - name: Free up disk space
+        uses: ./.github/actions/github-hosted-runner-cleanup
       - name: Fix HOME Directory
         if: ${{ needs.build-image.outputs.succeeded == 'true' && needs.get-config.outputs.container }}
         shell: bash
@@ -213,25 +207,6 @@ jobs:
           sudo pkill -f "apt.systemd.daily" || true
           sudo pkill -f "unattended-upgrade" || true
 
-      - name: Setup Dependencies
-        if: needs.build-image.outputs.succeeded != 'true' && needs.get-config.outputs.setup_script
-        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
-
-      - name: Post-setup
-        if: needs.get-config.outputs.post_setup_script
-        run: ${{ needs.get-config.outputs.post_setup_script }}
-      - name: Free up disk space
-        run: |
-          df -h
-          ${{ needs.get-config.outputs.install_mode }} rm -rf /usr/share/dotnet || true
-          ${{ needs.get-config.outputs.install_mode }} rm -rf /usr/local/lib/android || true
-          ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/ghc || true
-          ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
-          df -h
-      - name: Full checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - name: Print CPU information
         env:
           RUNNER_ARCH: ${{ runner.arch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,12 @@ RUN SKIP_BOOST=1 bash retry.sh bash -l -eo pipefail install_script.sh && \
     if [ "$SAN" = "address" ]; then bash retry.sh bash -l -eo pipefail install_llvm.sh; fi
 # Mount the GitHub token as a build secret so cargo-binstall benefits from
 # higher GitHub API rate limits when fetching prebuilt release artifacts.
+# `cargo miri setup` validates MIRI during image build, but its generated
+# sysroot is sensitive to runtime Cargo/rustc settings and can poison CI.
 RUN --mount=type=secret,id=GITHUB_TOKEN \
     if [ -f /run/secrets/GITHUB_TOKEN ]; then export GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN); fi && \
-    bash retry.sh bash -l -eo pipefail test_deps/install_rust_deps.sh
+    bash retry.sh bash -l -eo pipefail test_deps/install_rust_deps.sh && \
+    rm -rf "$HOME/.cache/miri"
 WORKDIR /project
 # Expose newly-installed Rust and Python tools via PATH
 ENV PATH="/usr/local/llvm/bin:/root/.cargo/bin:/root/.local/bin:${PATH}"


### PR DESCRIPTION
Manual backport of #11075 to 8.8-rse.

The auto-backport bot declined this branch: "deleted task workflows and mixed inline/shared test setup make a faithful automatic resolution ambiguous." 8.8-rse keeps the pre-refactor monolithic `task-test.yml`, so this re-derives PR #11075's intent (self-hosted-runner-with-fallback var scheme, the new `github-hosted-runner-cleanup` reusable action, the reordered Alpine/checkout/cleanup steps, and the miri-cache Dockerfile fix) on top of that layout rather than cherry-picking text.

## Original PR
https://github.com/RediSearch/RediSearch/pull/11075

## Changes from original
Adapted to 8.8-rse's monolithic `task-test.yml` (master split this into task-build.yml/task-miri.yml/task-test-unit.yml/task-test-flow.yml/task-build-redis.yml/task-build-rejson.yml, none of which exist on 8.8-rse) and its existing `task-redis-build-sanity.yml`. Functionally equivalent to master's change, applied to 8.8-rse's file structure.

Opened to validate PR-flow CI (build+test across platforms) on this backport; the merge-queue-specific workflow requires actually queuing a merge and is intentionally not exercised here.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes