### PR TITLE
Record the vendored libnu snapshot as upstream tag 1.12

### DIFF
--- a/deps/libnu/README.md
+++ b/deps/libnu/README.md
@@ -4,9 +4,9 @@ The files in this folder are taken from the (excellent) **nunicode** library by 
 
 See [https://bitbucket.org/alekseyt/nunicode](https://bitbucket.org/alekseyt/nunicode)
 
-Vendored snapshot: upstream commit `5d3279b` (post-1.11.1, Unicode 17.0
-tables). `NU_VERSION` reads `"custom"` because upstream only stamps a
-version number on release tags.
+Vendored snapshot: upstream tag `1.12` (commit `5d3279b`, Unicode 17.0
+tables). `NU_VERSION` reads `"custom"` verbatim from upstream, which
+carries that placeholder in-tree on tagged releases too.
 
 Local deltas from upstream:
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `deps/libnu/README.md` describes the vendored snapshot as "upstream commit `5d3279b` (post-1.11.1)". Upstream has since tagged that exact commit `1.12`, so the description no longer names the release it actually is.
2. Change: The snapshot is recorded as upstream tag `1.12` (commit `5d3279b`). The `NU_VERSION` note is corrected too — it claimed upstream stamps a version number on release tags, but upstream ships the `"custom"` placeholder in-tree at the `1.12` tag as well.
3. Outcome: Internal-only, documentation. No vendored source changes; the library is byte-identical to what is already in tree. It makes the next libnu refresh start from a version that can be compared against upstream tags.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `deps/libnu/README.md` — vendoring provenance line and the `NU_VERSION` explanation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
