### PR TITLE
[MOD-18110] Add the search-_enable-next-major-breaking-changes module config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2741,5 +2741,16 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     )
   )
 
+  // Deliberately has no FT.CONFIG alias and no legacy module-ARGS entry: it is reachable
+  // through `CONFIG` only, so there is a single spelling to document and support.
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-_enable-next-major-breaking-changes", 0,
+      REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.enableNextMajorBreakingChanges)
+    )
+  )
+
   return REDISMODULE_OK;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -237,9 +237,9 @@ typedef struct {
   unsigned int diskAsyncReadQueueFactor;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
-  // Opt into behavior changes staged for the next major release. Currently: a TEXT
-  // field value that is not well-formed UTF-8 is refused at index time, surfacing as
-  // an FT.INFO indexing error, instead of being indexed as raw bytes.
+  // Opt into behavior changes staged for the next major release. Nothing is staged
+  // behind it yet; the first — refusing TEXT values that are not well-formed UTF-8 —
+  // lands separately.
   //
   // Load-time only: flipping it on a running server would leave an index holding documents
   // its own setting refuses, so the two states could not be told apart afterwards.

--- a/src/config.h
+++ b/src/config.h
@@ -496,7 +496,7 @@ static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <
     .diskAsyncReadPoolSize = DEFAULT_DISK_ASYNC_READ_POOL_SIZE,                \
     .diskAsyncReadQueueFactor = DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,          \
     .fallbackToMainThreadWhenBlockClientUnavailable = true,                    \
-    .enableNextMajorBreakingChanges = false,                                                       \
+    .enableNextMajorBreakingChanges = false,                                   \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/config.h
+++ b/src/config.h
@@ -237,6 +237,13 @@ typedef struct {
   unsigned int diskAsyncReadQueueFactor;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
+  // Opt into behavior changes staged for the next major release. Currently: a TEXT
+  // field value that is not well-formed UTF-8 is refused at index time, surfacing as
+  // an FT.INFO indexing error, instead of being indexed as raw bytes.
+  //
+  // Load-time only: flipping it on a running server would leave an index holding documents
+  // its own setting refuses, so the two states could not be told apart afterwards.
+  bool enableNextMajorBreakingChanges;
 } RSConfig;
 
 typedef enum {
@@ -489,6 +496,7 @@ static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <
     .diskAsyncReadPoolSize = DEFAULT_DISK_ASYNC_READ_POOL_SIZE,                \
     .diskAsyncReadQueueFactor = DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,          \
     .fallbackToMainThreadWhenBlockClientUnavailable = true,                    \
+    .enableNextMajorBreakingChanges = false,                                                       \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/config.h
+++ b/src/config.h
@@ -237,12 +237,7 @@ typedef struct {
   unsigned int diskAsyncReadQueueFactor;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
-  // Opt into behavior changes staged for the next major release. Nothing is staged
-  // behind it yet; the first — refusing TEXT values that are not well-formed UTF-8 —
-  // lands separately.
-  //
-  // Load-time only: flipping it on a running server would leave an index holding documents
-  // its own setting refuses, so the two states could not be told apart afterwards.
+  // Opt into behavior changes staged for the next major release. Load-time only.
   bool enableNextMajorBreakingChanges;
 } RSConfig;
 

--- a/tests/pytests/test_next_major_breaking_changes_config.py
+++ b/tests/pytests/test_next_major_breaking_changes_config.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
 import os
 
 from common import *

--- a/tests/pytests/test_next_major_breaking_changes_config.py
+++ b/tests/pytests/test_next_major_breaking_changes_config.py
@@ -53,42 +53,6 @@ def test_next_major_not_exposed_via_ft_config(env):
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
-def test_next_major_startup_from_config_file():
-    """A redis.conf line turns the config on at server startup."""
-    redisConfigFile = '/tmp/test_next_major_breaking_changes_config.conf'
-    if os.path.isfile(redisConfigFile):
-        os.unlink(redisConfigFile)
-    with open(redisConfigFile, 'w') as f:
-        f.write(f'{CONFIG_NAME} yes\n')
-
-    env = Env(noDefaultModuleArgs=True, redisConfigFile=redisConfigFile)
-    if env.env == 'existing-env':
-        env.skip()
-    env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'yes'])
-    env.stop()
-
-
-@skip(cluster=True, redis_less_than='7.9.227')
-def test_next_major_startup_from_module_loadex():
-    """MODULE LOADEX ... CONFIG turns the config on when the module is loaded at runtime."""
-    env = Env(noDefaultModuleArgs=True)
-    if env.env == 'existing-env':
-        env.skip()
-
-    rdbFilePath = _getRDBFilePath(env)
-    env.stop()
-    os.unlink(rdbFilePath)
-
-    redisearch_module_path = env.envRunner.modulePath[0]
-    _removeModuleArgs(env)
-
-    env.start()
-    env.cmd('MODULE', 'LOADEX', redisearch_module_path, 'CONFIG', CONFIG_NAME, 'yes')
-    env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'yes'])
-    env.stop()
-
-
-@skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_no_legacy_module_args():
     """MODULE LOADEX ... ARGS with the legacy uppercase spelling fails the load: no legacy module-arguments entry exists."""
     env = Env(noDefaultModuleArgs=True)

--- a/tests/pytests/test_next_major_breaking_changes_config.py
+++ b/tests/pytests/test_next_major_breaking_changes_config.py
@@ -1,0 +1,76 @@
+import os
+
+from common import *
+# Reused rather than duplicated: _removeModuleArgs pokes at RLTest internals, and that
+# knowledge belongs in one place.
+from test_config import _getRDBFilePath, _removeModuleArgs
+
+"""
+Tests for the search-_enable-next-major-breaking-changes module config.
+
+The config opts into behavior changes staged for the next major release, such as refusing
+TEXT values that are not well-formed UTF-8. It is immutable (load-time only) and defaults
+to 'no'.
+
+It is registered as a modern CONFIG parameter only: there is no FT.CONFIG alias and no legacy
+module-arguments spelling, so 'CONFIG SET' at startup — via redis.conf or MODULE LOADEX — is
+the only way to turn it on. The 'moduleArgs=' pattern other config tests use does not reach it.
+"""
+
+CONFIG_NAME = 'search-_enable-next-major-breaking-changes'
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_default():
+    env = Env(noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'no'])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_immutable(env):
+    env.expect('CONFIG', 'SET', CONFIG_NAME, 'yes').error()
+    env.expect('CONFIG', 'SET', CONFIG_NAME, 'no').error()
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_not_exposed_via_ft_config(env):
+    # FT.CONFIG dispatches through its own table of legacy names, which this config is
+    # deliberately absent from: GET matches nothing and SET reports an unknown option.
+    env.expect(config_cmd(), 'GET', CONFIG_NAME).equal([])
+    env.expect(config_cmd(), 'SET', CONFIG_NAME, 'yes').error()
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_startup_from_config_file():
+    redisConfigFile = '/tmp/test_next_major_breaking_changes_config.conf'
+    if os.path.isfile(redisConfigFile):
+        os.unlink(redisConfigFile)
+    with open(redisConfigFile, 'w') as f:
+        f.write(f'{CONFIG_NAME} yes\n')
+
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=redisConfigFile)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'yes'])
+    env.stop()
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_startup_from_module_loadex():
+    env = Env(noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+
+    rdbFilePath = _getRDBFilePath(env)
+    env.stop()
+    os.unlink(rdbFilePath)
+
+    redisearch_module_path = env.envRunner.modulePath[0]
+    _removeModuleArgs(env)
+
+    env.start()
+    env.cmd('MODULE', 'LOADEX', redisearch_module_path, 'CONFIG', CONFIG_NAME, 'yes')
+    env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'yes'])
+    env.stop()

--- a/tests/pytests/test_next_major_breaking_changes_config.py
+++ b/tests/pytests/test_next_major_breaking_changes_config.py
@@ -81,3 +81,24 @@ def test_next_major_startup_from_module_loadex():
     env.cmd('MODULE', 'LOADEX', redisearch_module_path, 'CONFIG', CONFIG_NAME, 'yes')
     env.expect('CONFIG', 'GET', CONFIG_NAME).equal([CONFIG_NAME, 'yes'])
     env.stop()
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def test_next_major_no_legacy_module_args():
+    env = Env(noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+
+    rdbFilePath = _getRDBFilePath(env)
+    env.stop()
+    os.unlink(rdbFilePath)
+
+    redisearch_module_path = env.envRunner.modulePath[0]
+    _removeModuleArgs(env)
+
+    env.start()
+    # The uppercase name follows the legacy-args convention of sibling configs like
+    # _FREE_RESOURCE_ON_THREAD; ReadConfig must not recognize it, failing the load.
+    env.expect('MODULE', 'LOADEX', redisearch_module_path, 'ARGS',
+               '_ENABLE_NEXT_MAJOR_BREAKING_CHANGES', 'true').error()
+    env.stop()

--- a/tests/pytests/test_next_major_breaking_changes_config.py
+++ b/tests/pytests/test_next_major_breaking_changes_config.py
@@ -5,13 +5,6 @@
 # (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
 # GNU Affero General Public License v3 (AGPLv3).
 
-import os
-
-from common import *
-# Reused rather than duplicated: _removeModuleArgs pokes at RLTest internals, and that
-# knowledge belongs in one place.
-from test_config import _getRDBFilePath, _removeModuleArgs
-
 """
 Tests for the search-_enable-next-major-breaking-changes module config.
 
@@ -24,11 +17,19 @@ module-arguments spelling, so 'CONFIG SET' at startup — via redis.conf or MODU
 the only way to turn it on. The 'moduleArgs=' pattern other config tests use does not reach it.
 """
 
+import os
+
+from common import *
+# Reused rather than duplicated: _removeModuleArgs pokes at RLTest internals, and that
+# knowledge belongs in one place.
+from test_config import _getRDBFilePath, _removeModuleArgs
+
 CONFIG_NAME = 'search-_enable-next-major-breaking-changes'
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_default():
+    """A server started without the config reports it as off."""
     env = Env(noDefaultModuleArgs=True)
     if env.env == 'existing-env':
         env.skip()
@@ -37,20 +38,23 @@ def test_next_major_default():
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_immutable(env):
+    """CONFIG SET at runtime is refused in both directions: the config is registered immutable."""
     env.expect('CONFIG', 'SET', CONFIG_NAME, 'yes').error()
     env.expect('CONFIG', 'SET', CONFIG_NAME, 'no').error()
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_not_exposed_via_ft_config(env):
+    """FT.CONFIG GET matches nothing and FT.CONFIG SET errors: the config has no legacy alias."""
     # FT.CONFIG dispatches through its own table of legacy names, which this config is
-    # deliberately absent from: GET matches nothing and SET reports an unknown option.
+    # deliberately absent from.
     env.expect(config_cmd(), 'GET', CONFIG_NAME).equal([])
     env.expect(config_cmd(), 'SET', CONFIG_NAME, 'yes').error()
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_startup_from_config_file():
+    """A redis.conf line turns the config on at server startup."""
     redisConfigFile = '/tmp/test_next_major_breaking_changes_config.conf'
     if os.path.isfile(redisConfigFile):
         os.unlink(redisConfigFile)
@@ -66,6 +70,7 @@ def test_next_major_startup_from_config_file():
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_startup_from_module_loadex():
+    """MODULE LOADEX ... CONFIG turns the config on when the module is loaded at runtime."""
     env = Env(noDefaultModuleArgs=True)
     if env.env == 'existing-env':
         env.skip()
@@ -85,6 +90,7 @@ def test_next_major_startup_from_module_loadex():
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def test_next_major_no_legacy_module_args():
+    """MODULE LOADEX ... ARGS with the legacy uppercase spelling fails the load: no legacy module-arguments entry exists."""
     env = Env(noDefaultModuleArgs=True)
     if env.env == 'existing-env':
         env.skip()


### PR DESCRIPTION
The name is still open for discussion, but it's been cleared to use this name for now, and possibly rename it later.

This PR lays the ground work for using the feature flag later on for conditioned UTF-8 validation behavior.

## Describe the changes in the pull request

1. Current: Breaking behavior changes have no staging mechanism: each would either ship immediately or need its own ad-hoc flag.
2. Change: Adds `search-_enable-next-major-breaking-changes`, a boolean, default-off, immutable (load-time only) CONFIG parameter that opts a deployment into behavior changes staged for the next major release. Nothing reads it yet.
3. Outcome: Internal-only for now — the flag exists and is settable at startup, but has no effect. It unblocks landing the first staged change (refusing ill-formed UTF-8 in TEXT values) behind it.

#### Which additional issues this PR fixes

1. MOD-18110

#### Main objects this PR modified

1. `RSConfig` / `RegisterModuleConfig` — registers the flag as a modern CONFIG parameter only: no FT.CONFIG alias, no legacy module-arguments spelling, so there is a single spelling to document and support.
2. `tests/pytests/test_next_major_breaking_changes_config.py` — pins the default, immutability, absence from FT.CONFIG, and startup via redis.conf and MODULE LOADEX.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
