### PR TITLE
[MOD-18159] Remove 3 permanently-skipped functions from tests/pytests that are not tests

### DIFF
--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -8,51 +8,6 @@
 from common import *
 import time
 
-# The output for this test can be used for recreating documentation for `FT.INFO`
-@skip()
-def testInfo(env):
-  count = 345678
-  conn = env.getConnection()
-  pl = conn.pipeline()
-
-  idx = 'wikipedia'
-
-  for i in range(count):
-    geo = '1.23456,1.' + str(i / float(count))
-    pl.execute_command('HSET', 'doc%d' % i, 'title', 'hello%d' % i,
-                                            'body', '%dhello%dworld%dhow%dare%dyou%dtoday%d' % (i, i, i, i, i, i, i),
-                                            'n', i / 17.0,
-                                            'geo', geo)
-    if i % 10000 == 0:
-      pl.execute()
-  pl.execute()
-
-  env.expect('FT.CREATE', idx, 'STOPWORDS', 3, 'TLV', 'summer', '2020',
-                               'SCHEMA', 'title', 'TEXT', 'SORTABLE',
-                                         'body', 'TEXT',
-                                         'id', 'NUMERIC',
-                                         'subject location', 'GEO').ok()
-
-  waitForIndex(env, idx)
-
-  for i in range(count):
-    pl.execute_command('DEL', 'doc%d' % i)
-    if i % 10000 == 0:
-      pl.execute()
-      forceInvokeGC(env, idx)
-  pl.execute()
-
-  #  GC stats
-  for i in range(25):
-    forceInvokeGC(env, idx)
-
-  # cursor stats
-  #query = ['FT.AGGREGATE', idx, '*', 'WITHCURSOR']
-  #res = env.cmd(*query)
-  #env.cmd('FT.CURSOR', 'READ', idx, str(res[1]))
-
-  #print info
-
 def test_vecsim_info():
   env = Env(protocol=3)
   dim = 2

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -131,36 +131,6 @@ def testSearchUpdatedContent(env):
 # TODO: Check arrays
 # TODO: Check Object/Map
 
-@skip()
-def testHandleUnindexedTypes(env):
-    # TODO: Ignore and resume indexing when encountering an Object/Array/null
-    # TODO: Except for array of only scalars which is defined as a TAG in the schema
-    # ... FT.CREATE idx SCHEMA $.arr TAG
-
-    env.expect('JSON.SET', 'doc:1', '$', doc1_content).ok()
-
-    env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
-                        '$.string', 'AS', 'string', 'TEXT',
-                        '$.null', 'AS', 'nil', 'TEXT',
-                        '$.boolT', 'AS', 'boolT', 'TAG',
-                        '$.boolN', 'AS', 'boolN', 'NUMERIC',
-                        '$.int', 'AS', 'int', 'NUMERIC',
-                        '$.flt', 'AS', 'flt', 'NUMERIC',
-                        '$.geo', 'AS', 'geo', 'GEO',
-                        '$.obj', 'AS', 'obj', 'TEXT',
-                        '$.complex_arr', 'AS', 'complex_arr', 'TEXT',
-                        '$.scalar_arr', 'AS', 'scalar_arr', 'TAG',
-                        '$.int_arr', 'AS', 'int_arr', 'TAG',
-                        '$.vector', 'AS', 'vec', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2'
-                        ).ok()
-    waitForIndex(env, 'idx')
-# FIXME: Why does the following search return zero results?
-    env.expect('ft.search', 'idx', '*', 'RETURN', '2', 'string', 'int_arr')\
-        .equal([1, 'doc:1', ['string', '"gotcha1"', 'int_arr', ["a", "b", "c", "d", "e", "f", "gotcha6"]]])
-
-    # TODO: test TAGVALS ?
-    pass
-
 @skip(msan=True, no_json=True)
 def testReturnAllTypes(env):
     # Test returning all JSON types

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -8,7 +8,6 @@
 from includes import *
 from common import *
 from RLTest import Env
-import time
 
 @skip(cluster=True)
 def testSanity_dialect_2(env):
@@ -165,59 +164,6 @@ def dotestSanityTag(env, dialect):
     .contains('Timeout limit was reached')
   env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
-
-@skip()
-def testBenchmark(env):
-  env.expect(config_cmd(), 'set', 'MINPREFIX', 1).ok()
-  env.expect(config_cmd(), 'set', 'DEFAULT_DIALECT', 2).ok()
-  env.expect(config_cmd(), 'set', 'TIMEOUT', 100000).ok()
-  env.expect(config_cmd(), 'set', 'MAXEXPANSIONS', 10000000).equal('OK')
-  item_qty = 1000000
-
-  index_list = ['idx_bf']
-  env.cmd('FT.CREATE', 'idx_bf', 'SCHEMA', 't', 'TEXT')
-  #env.cmd('FT.CREATE', 'idx_suffix', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE')
-
-  conn = getConnectionByEnv(env)
-
-  start = time.time()
-  pl = conn.pipeline()
-  for i in range(item_qty):
-    pl.execute_command('HSET', 'doc%d' % i, 't', 'foo321%dbar312' % i)
-    pl.execute_command('HSET', 'doc%d' % (i + item_qty), 't', 'fooo321%dbar311' % i)
-    pl.execute_command('HSET', 'doc%d' % (i + item_qty * 2), 't', 'foooo312%dbar312' % i)
-    pl.execute_command('HSET', 'doc%d' % (i + item_qty * 3), 't', 'foofo31%dbar312' % i)
-    pl.execute()
-
-  print('----*ooo1*----')
-
-  for i in range(1):
-    #prefix
-    start_time = time.time()
-    env.expect('ft.search', index_list[i], "*ooo3*", 'LIMIT', 0 , 0).equal([2222])
-    print(time.time() - start_time)
-    start_time = time.time()
-    env.expect('ft.search', index_list[i], "w'*o**o3*'", 'LIMIT', 0 , 0).equal([2222])
-    print(time.time() - start_time)
-    start_time = time.time()
-    print('----*ooo1*----')
-
-    env.expect('ft.search', index_list[i], "*555*", 'LIMIT', 0 , 0).equal([76])
-    print(time.time() - start_time)
-    start_time = time.time()
-    env.expect('ft.search', index_list[i], "w'*55*5*'", 'LIMIT', 0 , 0).equal([76])
-    print(time.time() - start_time)
-    start_time = time.time()
-    print('----*555*----')
-
-    # suffix
-    env.expect('ft.search', index_list[i], '*oo2*34', 'LIMIT', 0 , 0).equal([3])
-    print(time.time() - start_time)
-    start_time = time.time()
-    env.expect('ft.search', index_list[i], "w'*oo2*34'", 'LIMIT', 0 , 0).equal([3])
-    print(time.time() - start_time)
-    start_time = time.time()
-    print('----*oo234----')
 
 @skip(cluster=True)
 def testEscape(env):


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: An audit of unconditionally-skipped tests found ten `@skip()`ed functions in `tests/pytests/`. Three of them were never tests — a doc generator, a benchmark, and a placeholder for unimplemented behaviour — so each audit re-triaged them as broken coverage.
2. Change: Delete those three functions rather than annotate them, so they stop resurfacing.
3. Outcome: Internal-only; no user impact and no coverage lost. None of the three asserted anything, so nothing they guarded goes untested. Unblocks MOD-9672 by removing three permanent false positives from the skipped-test audit.

#### Which additional issues this PR fixes

1. MOD-18159
2. Closes the code side of MOD-18127, MOD-18128, MOD-18129 (closed as duplicates of MOD-18159)

#### Main objects this PR modified

1. `tests/pytests/test_info.py` — removed `testInfo`, a documentation generator ("output can be used for recreating documentation for `FT.INFO`"). Its `import time` is kept; two live tests still use it.
2. `tests/pytests/test_wildcard.py` — removed `testBenchmark`, a benchmark printing `time.time()` deltas with no timing assertion, plus the now-unused `import time`.
3. `tests/pytests/test_json.py` — removed `testHandleUnindexedTypes`, TODOs plus one assertion marked `FIXME: Why does the following search return zero results?`, ending in a bare `pass`.

Kept deliberately: the `TODO: Check null values / arrays / Object/Map` notes above the removed `test_json.py` function, which record real JSON coverage gaps independently of the placeholder, and `doc1_content`, still used by live tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
