### PR TITLE
[8.8-rse] [MOD-18138] Serve queries whose union or intersection has more than 65535 children

### DIFF
--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -31,15 +31,15 @@ typedef struct RLookupKey RLookupKey;
  */
 typedef struct RSOffsetVector RSOffsetSlice;
 
-#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED
+#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_Box_RawIndexResult_Active__u16;
-#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+typedef struct ThinVec_Box_RawIndexResult_Active__u32 {
+  struct Header_u32 *ptr;
+} ThinVec_Box_RawIndexResult_Active__u32;
+#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U32_DEFINED */
 
 #ifndef THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
 #define THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
@@ -70,15 +70,15 @@ typedef struct ThinVec_RawMetricEntry_Active__u64 RawMetricsVec_Active;
  */
 typedef RawMetricsVec_Active MetricsVec;
 
-#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED
+#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
-#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u32 {
+  struct Header_u32 *ptr;
+} ThinVec_SharedPtr_Active__RawIndexResult_Active__u32;
+#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U32_DEFINED */
 
 #ifndef SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
 #define SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
@@ -341,27 +341,27 @@ typedef struct RawMetricsSlice_Active {
  */
 typedef struct RawMetricsSlice_Active MetricsSlice;
 
-#ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
-#define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
+#ifndef MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
+#define MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
  *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
  */
-typedef struct ThinVec_Box_RawIndexResult_Active__u16 SmallThinVec_Box_RawIndexResult_Active;
-#endif /* SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
+typedef struct ThinVec_Box_RawIndexResult_Active__u32 MediumThinVec_Box_RawIndexResult_Active;
+#endif /* MEDIUMTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
 
-#ifndef SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
-#define SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
+#ifndef MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
+#define MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
  *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
  */
-typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 SmallThinVec_SharedPtr_Active__RawIndexResult_Active;
-#endif /* SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u32 MediumThinVec_SharedPtr_Active__RawIndexResult_Active;
+#endif /* MEDIUMTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
 
 #ifndef BITFLAGS_RSRESULTKIND__U8_DEFINED
 #define BITFLAGS_RSRESULTKIND__U8_DEFINED
@@ -519,7 +519,7 @@ typedef struct RawAggregateResult_Active_Borrowed_Body {
    * equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
    * an inert raw pointer that survives lock release/reacquire cycles.
    */
-  SmallThinVec_SharedPtr_Active__RawIndexResult_Active records;
+  MediumThinVec_SharedPtr_Active__RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */
@@ -535,7 +535,7 @@ typedef struct RawAggregateResult_Active_Owned_Body {
    * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
    * own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
    */
-  SmallThinVec_Box_RawIndexResult_Active records;
+  MediumThinVec_Box_RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -8,7 +8,7 @@
 */
 
 use ref_mode::{Active, Ref, SharedPtr};
-use thin_vec::SmallThinVec;
+use thin_vec::MediumThinVec;
 
 use super::core::{RSIndexResult, RawIndexResult};
 use super::kind::RSResultKindMask;
@@ -34,7 +34,7 @@ pub enum RawAggregateResult<R: Ref> {
         /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
         /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
         /// an inert raw pointer that survives lock release/reacquire cycles.
-        records: SmallThinVec<SharedPtr<R, RawIndexResult<R>>>,
+        records: MediumThinVec<SharedPtr<R, RawIndexResult<R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -45,7 +45,7 @@ pub enum RawAggregateResult<R: Ref> {
         /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
         /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
         /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: SmallThinVec<Box<RawIndexResult<R>>>,
+        records: MediumThinVec<Box<RawIndexResult<R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -59,7 +59,7 @@ pub type RSAggregateResult<'a> = RawAggregateResult<Active<'a>>;
 // Compile-time proof that the `Active` and `Suspended` instantiations of
 // `RawAggregateResult` are layout-identical. Only `size_of`/`align_of` are
 // checked: `offset_of!` cannot address `#[repr(u8)]` enum variant fields. Each
-// variant stores its children behind a `SmallThinVec` pointer, so the inline
+// variant stores its children behind a `MediumThinVec` pointer, so the inline
 // layout is pointer-sized regardless of `R`; the child `RawIndexResult<R>`
 // read through that pointer is guarded by the `core/mod.rs` block. Part of the
 // recursive net backing the conversions on `RawIndexResult`.
@@ -111,7 +111,7 @@ impl<R: Ref> RawAggregateResult<R> {
     /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
     pub fn borrowed_with_capacity(cap: usize) -> Self {
         Self::Borrowed {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -119,7 +119,7 @@ impl<R: Ref> RawAggregateResult<R> {
     /// Create a new empty aggregate result (of the owned kind) with the given capacity
     pub fn owned_with_capacity(cap: usize) -> Self {
         Self::Owned {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -247,7 +247,7 @@ impl<'a> RSAggregateResult<'a> {
     pub fn to_owned(&'a self) -> RSAggregateResult<'a> {
         match self {
             Self::Borrowed { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
+                let mut new_records = MediumThinVec::with_capacity(records.len());
 
                 new_records.extend(
                     records
@@ -262,7 +262,7 @@ impl<'a> RSAggregateResult<'a> {
                 }
             }
             Self::Owned { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
+                let mut new_records = MediumThinVec::with_capacity(records.len());
 
                 new_records.extend(
                     records

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1526,3 +1526,24 @@ mod reducer {
         ));
     }
 }
+
+#[test]
+#[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
+fn child_count_is_not_capped_at_16_bits() {
+    // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+    const CHILD_COUNT: usize = 65536;
+
+    let children = create_children(CHILD_COUNT, &[1]);
+    let mut ii = Intersection::new(children, 1.0, false);
+    let result = ii.read().expect("read failed").expect("should have result");
+
+    assert_eq!(result.doc_id, 1);
+    assert_eq!(
+        result
+            .as_aggregate()
+            .expect("an intersection result is an aggregate")
+            .len(),
+        CHILD_COUNT,
+        "every child matches doc 1, so all of them belong to the aggregate"
+    );
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -35,6 +35,33 @@ macro_rules! union_common_tests {
         // Read tests
         // =============================================================================
 
+        /// One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+        const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
+
+        #[test]
+        #[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
+        fn child_count_is_not_capped_at_16_bits() {
+            let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
+                .map(|_| MockVec::new_boxed(vec![1]))
+                .collect();
+
+            let mut union_iter = Union::new(children);
+            let result = union_iter
+                .read()
+                .expect("read failed")
+                .expect("should have result");
+
+            assert_eq!(result.doc_id, 1);
+            assert_eq!(
+                result
+                    .as_aggregate()
+                    .expect("a union result is an aggregate")
+                    .len(),
+                CHILD_COUNT_ABOVE_16_BIT,
+                "every child matches doc 1, so all of them belong to the aggregate"
+            );
+        }
+
         #[rstest::rstest]
         #[case::c2_small(2, &[1u64, 2, 3, 40, 50])]
         #[case::c2_medium(2, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -273,3 +273,94 @@ class TestIteratorsRevalidate:
 
         # No remaining results since we deleted all matching documents
         self.env.assertEqual(remaining_docs, [])
+
+
+def test_union_child_count_is_not_capped_at_16_bits(env):
+    """A union node with more children than a 16-bit count can hold serves the query normally.
+
+    `NOT` branches are used because they are never reduced away as empty, so the union keeps a
+    child per branch without the index needing a matching term for each one.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'h1', 't', 'hello')
+
+    # One past u16::MAX, the widest child count a 16-bit capacity can hold.
+    wide_query = '|'.join(f'-a{i}' for i in range(65536))
+
+    expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a union of negations matches the same documents whatever its width")
+
+
+def test_tag_union_child_count_is_not_capped_at_16_bits(env):
+    """A TAG union node with more children than a 16-bit count can hold serves the query
+    normally.
+
+    Unlike the plain-text union test, the children here all come from values that actually
+    exist on the document, exercising the tag-node evaluation path in `Query_EvalTagNode`
+    rather than the generic union constructor.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+
+    values = [f'v{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ','.join(values))
+
+    wide_query = '@t:{' + '|'.join(values) + '}'
+
+    expected = env.cmd('FT.SEARCH', 'idx', '@t:{v0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a tag union matches the same documents whatever its width")
+
+
+def test_intersection_and_phrase_child_count_is_not_capped_at_16_bits(env):
+    """An intersection node, and a quoted-phrase node built on top of one, both serve a
+    query normally when they have more children than a 16-bit count can hold.
+
+    The same document backs both assertions: it contains every term in order, so the
+    implicit AND of all terms and the exact quoted phrase of all terms both have to match
+    it, and neither can short-circuit on a missing child.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    words = [f'w{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ' '.join(words))
+
+    expected = env.cmd('FT.SEARCH', 'idx', 'w0', 'NOCONTENT', 'DIALECT', 2)
+
+    and_query = ' '.join(words)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', and_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="an intersection of terms matches the same documents whatever its width")
+
+    phrase_query = '"' + ' '.join(words) + '"'
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', phrase_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a quoted phrase matches the same documents whatever its width")
+
+
+def test_prefix_expansion_child_count_is_not_capped_at_16_bits():
+    """Prefix expansion, on both a TEXT and a TAG field, can build a union with more children
+    than a 16-bit count can hold when MAXPREFIXEXPANSIONS allows it.
+
+    Unlike the other wide-node tests, the width here comes from the number of indexed terms
+    a short prefix expands to, not from the query string itself.
+    """
+    env = Env(moduleArgs='MAXPREFIXEXPANSIONS 100000')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
+    text_terms = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'text:1', 't', ' '.join(text_terms))
+
+    expected_text = env.cmd('FT.SEARCH', 'idx_text', 'va0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_text', 'va*', 'NOCONTENT', 'DIALECT', 2), expected_text,
+                    message="a TEXT prefix query matches the same documents whatever its expansion width")
+
+    env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 't', 'TAG').ok()
+    tag_values = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'tag:1', 't', ','.join(tag_values))
+
+    expected_tag = env.cmd('FT.SEARCH', 'idx_tag', '@t:{va0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_tag', '@t:{va*}', 'NOCONTENT', 'DIALECT', 2), expected_tag,
+                    message="a TAG prefix query matches the same documents whatever its expansion width")


### PR DESCRIPTION
Backport of #11238 to `8.8-rse`.

## Original PR

https://github.com/RediSearch/RediSearch/pull/11238 (commit 2aba0b2c35261186253eeff9d844a1c5739bbc9d)

## Changes from original

The automated backport could not cherry-pick this, because the commit's context includes
master-only code. Resolved by keeping this branch's side of every conflict and re-applying
only the additions that belong to this change:

- The capacity widening in `index_result/src/aggregate.rs` is unchanged from master.
- `headers/index_result_rs.h` was regenerated on this branch; the result is byte-identical to
  the master diff.
- The conflicts pulled in unrelated master content (the `Suspended` ref-mode plumbing, an
  `intersection_upholds_current_contract` test, and the `TestIteratorsRevalidateTimeout`
  class). None of it is part of this change and none of it was taken.
- The intersection test does not wrap the iterator in `ContractChecker`, which does not exist
  on this branch; it constructs `Intersection` directly like the other tests in that file.

## Validation

- `./build.sh` passes.
- `cargo nextest -p index_result -p rqe_iterators -E 'test(child_count_is_not_capped)'`: 3 passed
  (union flat, union heap, intersection).
- Header regeneration during the build leaves no diff.
- Flow tests were not run locally (RLTest is unavailable in the build container); CI covers them.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
