### PR TITLE
[8.8] [MOD-18138] Serve queries whose union or intersection has more than 65535 children

### DIFF
--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -85,19 +85,27 @@ typedef struct NumericFilter {
 } NumericFilter;
 
 /**
- * See the crate's top level documentation for a description of this type.
+ * The header of a [`ThinVec`](crate::ThinVec).
  */
-typedef struct ThinVec______RSIndexResult__u16 {
-  Header_u16 *ptr;
-} ThinVec______RSIndexResult__u16;
+typedef struct Header_u32 {
+  uint32_t len;
+  uint32_t cap;
+} Header_u32;
 
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
- *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec______RSIndexResult__u16 SmallThinVecRSIndexResult;
+typedef struct ThinVec______RSIndexResult__u32 {
+  struct Header_u32 *ptr;
+} ThinVec______RSIndexResult__u32;
+
+/**
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
+ *
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
+ */
+typedef struct ThinVec______RSIndexResult__u32 MediumThinVec______RSIndexResult;
 
 /**
  * Represents a set of flags of some type `T`.
@@ -219,17 +227,17 @@ typedef BitFlags_RSResultKind__u8 RSResultKindMask;
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_____RSIndexResult__u16 {
-  Header_u16 *ptr;
-} ThinVec_____RSIndexResult__u16;
+typedef struct ThinVec_____RSIndexResult__u32 {
+  struct Header_u32 *ptr;
+} ThinVec_____RSIndexResult__u32;
 
 /**
- * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
+ * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
  *
- * This is useful when you know the vector will never exceed 65,535 elements
- * and want to minimize header overhead (4 bytes instead of 16).
+ * This is useful when you want a balance between capacity and header size
+ * (8 bytes instead of 16).
  */
-typedef struct ThinVec_____RSIndexResult__u16 SmallThinVecRSIndexResultOwned;
+typedef struct ThinVec_____RSIndexResult__u32 MediumThinVec_____RSIndexResult;
 
 /**
  * Represents an aggregate array of values in an index record.
@@ -268,7 +276,7 @@ typedef struct RSAggregateResult_Borrowed_Body {
    * above, this means `'index: 'static` which is just incorrect since the index data will
    * never be `'static` when decoding.
    */
-  SmallThinVecRSIndexResult records;
+  MediumThinVec______RSIndexResult records;
   /**
    * A map of the aggregate kind of the underlying records
    */
@@ -284,7 +292,7 @@ typedef struct RSAggregateResult_Owned_Body {
    * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
    * own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
    */
-  SmallThinVecRSIndexResultOwned records;
+  MediumThinVec_____RSIndexResult records;
   /**
    * A map of the aggregate kind of the underlying records
    */

--- a/src/redisearch_rs/inverted_index/src/index_result/aggregate.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result/aggregate.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use thin_vec::SmallThinVec;
+use thin_vec::MediumThinVec;
 
 use super::core::RSIndexResult;
 use super::kind::RSResultKindMask;
@@ -36,7 +36,7 @@ pub enum RSAggregateResult<'index> {
         /// any aggregate results so `'refs == 'static` when decoding. Because of the requirement
         /// above, this means `'index: 'static` which is just incorrect since the index data will
         /// never be `'static` when decoding.
-        records: SmallThinVec<&'index RSIndexResult<'index>>,
+        records: MediumThinVec<&'index RSIndexResult<'index>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -47,7 +47,7 @@ pub enum RSAggregateResult<'index> {
         /// The `RSAggregateResult` is part of a union in [`super::result_data::RSResultData`], so it needs to have a
         /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
         /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: SmallThinVec<Box<RSIndexResult<'index>>>,
+        records: MediumThinVec<Box<RSIndexResult<'index>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -58,7 +58,7 @@ impl<'index> RSAggregateResult<'index> {
     /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
     pub fn borrowed_with_capacity(cap: usize) -> Self {
         Self::Borrowed {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -66,7 +66,7 @@ impl<'index> RSAggregateResult<'index> {
     /// Create a new empty aggregate result (of the owned kind) with the given capacity
     pub fn owned_with_capacity(cap: usize) -> Self {
         Self::Owned {
-            records: SmallThinVec::with_capacity(cap),
+            records: MediumThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
     }
@@ -192,7 +192,7 @@ impl<'index> RSAggregateResult<'index> {
     pub fn to_owned<'a>(&'a self) -> RSAggregateResult<'a> {
         match self {
             RSAggregateResult::Borrowed { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
+                let mut new_records = MediumThinVec::with_capacity(records.len());
 
                 new_records.extend(
                     records
@@ -207,7 +207,7 @@ impl<'index> RSAggregateResult<'index> {
                 }
             }
             RSAggregateResult::Owned { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
+                let mut new_records = MediumThinVec::with_capacity(records.len());
 
                 new_records.extend(
                     records

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -1526,3 +1526,24 @@ mod reducer {
         ));
     }
 }
+
+#[test]
+#[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
+fn child_count_is_not_capped_at_16_bits() {
+    // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+    const CHILD_COUNT: usize = 65536;
+
+    let children = create_children(CHILD_COUNT, &[1]);
+    let mut ii = Intersection::new(children, 1.0, false);
+    let result = ii.read().expect("read failed").expect("should have result");
+
+    assert_eq!(result.doc_id, 1);
+    assert_eq!(
+        result
+            .as_aggregate()
+            .expect("an intersection result is an aggregate")
+            .len(),
+        CHILD_COUNT,
+        "every child matches doc 1, so all of them belong to the aggregate"
+    );
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -35,6 +35,33 @@ macro_rules! union_common_tests {
         // Read tests
         // =============================================================================
 
+        /// One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+        const CHILD_COUNT_ABOVE_16_BIT: usize = 65536;
+
+        #[test]
+        #[cfg_attr(miri, ignore = "65536 children is too slow under miri")]
+        fn child_count_is_not_capped_at_16_bits() {
+            let children: Vec<Box<dyn RQEIterator<'static>>> = (0..CHILD_COUNT_ABOVE_16_BIT)
+                .map(|_| MockVec::new_boxed(vec![1]))
+                .collect();
+
+            let mut union_iter = Union::new(children);
+            let result = union_iter
+                .read()
+                .expect("read failed")
+                .expect("should have result");
+
+            assert_eq!(result.doc_id, 1);
+            assert_eq!(
+                result
+                    .as_aggregate()
+                    .expect("a union result is an aggregate")
+                    .len(),
+                CHILD_COUNT_ABOVE_16_BIT,
+                "every child matches doc 1, so all of them belong to the aggregate"
+            );
+        }
+
         #[rstest::rstest]
         #[case::c2_small(2, &[1u64, 2, 3, 40, 50])]
         #[case::c2_medium(2, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -273,3 +273,94 @@ class TestIteratorsRevalidate:
 
         # No remaining results since we deleted all matching documents
         self.env.assertEqual(remaining_docs, [])
+
+
+def test_union_child_count_is_not_capped_at_16_bits(env):
+    """A union node with more children than a 16-bit count can hold serves the query normally.
+
+    `NOT` branches are used because they are never reduced away as empty, so the union keeps a
+    child per branch without the index needing a matching term for each one.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'h1', 't', 'hello')
+
+    # One past u16::MAX, the widest child count a 16-bit capacity can hold.
+    wide_query = '|'.join(f'-a{i}' for i in range(65536))
+
+    expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a union of negations matches the same documents whatever its width")
+
+
+def test_tag_union_child_count_is_not_capped_at_16_bits(env):
+    """A TAG union node with more children than a 16-bit count can hold serves the query
+    normally.
+
+    Unlike the plain-text union test, the children here all come from values that actually
+    exist on the document, exercising the tag-node evaluation path in `Query_EvalTagNode`
+    rather than the generic union constructor.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+
+    values = [f'v{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ','.join(values))
+
+    wide_query = '@t:{' + '|'.join(values) + '}'
+
+    expected = env.cmd('FT.SEARCH', 'idx', '@t:{v0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a tag union matches the same documents whatever its width")
+
+
+def test_intersection_and_phrase_child_count_is_not_capped_at_16_bits(env):
+    """An intersection node, and a quoted-phrase node built on top of one, both serve a
+    query normally when they have more children than a 16-bit count can hold.
+
+    The same document backs both assertions: it contains every term in order, so the
+    implicit AND of all terms and the exact quoted phrase of all terms both have to match
+    it, and neither can short-circuit on a missing child.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    words = [f'w{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ' '.join(words))
+
+    expected = env.cmd('FT.SEARCH', 'idx', 'w0', 'NOCONTENT', 'DIALECT', 2)
+
+    and_query = ' '.join(words)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', and_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="an intersection of terms matches the same documents whatever its width")
+
+    phrase_query = '"' + ' '.join(words) + '"'
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', phrase_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a quoted phrase matches the same documents whatever its width")
+
+
+def test_prefix_expansion_child_count_is_not_capped_at_16_bits():
+    """Prefix expansion, on both a TEXT and a TAG field, can build a union with more children
+    than a 16-bit count can hold when MAXPREFIXEXPANSIONS allows it.
+
+    Unlike the other wide-node tests, the width here comes from the number of indexed terms
+    a short prefix expands to, not from the query string itself.
+    """
+    env = Env(moduleArgs='MAXPREFIXEXPANSIONS 100000')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
+    text_terms = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'text:1', 't', ' '.join(text_terms))
+
+    expected_text = env.cmd('FT.SEARCH', 'idx_text', 'va0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_text', 'va*', 'NOCONTENT', 'DIALECT', 2), expected_text,
+                    message="a TEXT prefix query matches the same documents whatever its expansion width")
+
+    env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 't', 'TAG').ok()
+    tag_values = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'tag:1', 't', ','.join(tag_values))
+
+    expected_tag = env.cmd('FT.SEARCH', 'idx_tag', '@t:{va0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_tag', '@t:{va*}', 'NOCONTENT', 'DIALECT', 2), expected_tag,
+                    message="a TAG prefix query matches the same documents whatever its expansion width")


### PR DESCRIPTION
Backport of #11238 to `8.8`.

## Original PR

https://github.com/RediSearch/RediSearch/pull/11238 (commit 2aba0b2c35261186253eeff9d844a1c5739bbc9d)

## Changes from original

The automated backport could not cherry-pick this, because the commit's context includes
master-only code. Resolved by keeping this branch's side of every conflict and re-applying
only the additions that belong to this change:

- The aggregate result lives in `inverted_index::index_result` on this branch rather than in
  its own crate, so the capacity widening lands in
  `inverted_index/src/index_result/aggregate.rs`. Master's `index_result/src/aggregate.rs` and
  `headers/index_result_rs.h` do not exist here and were dropped from the cherry-pick.
- `headers/types_rs.h` was regenerated by the build; the type names differ from master's
  because this branch's cbindgen config aliases them.
- The conflicts pulled in unrelated master content (the `Suspended` ref-mode plumbing, an
  `intersection_upholds_current_contract` test, and the `TestIteratorsRevalidateTimeout`
  class). None of it is part of this change and none of it was taken.
- The intersection test does not wrap the iterator in `ContractChecker`, which does not exist
  on this branch; it constructs `Intersection` directly like the other tests in that file.

## Validation

- `./build.sh` passes.
- `cargo nextest -p inverted_index -p rqe_iterators -E 'test(child_count_is_not_capped)'`: 3 passed
  (union flat, union heap, intersection).
- `headers/types_rs.h` regenerated by the build and committed as generated.
- Flow tests were not run locally (RLTest is unavailable in the build container); CI covers them.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
