### PR TITLE
[8.6] [MOD-18138] Serve queries whose union or intersection has more than 65535 children

### DIFF
--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -85,11 +85,19 @@ typedef struct NumericFilter {
 } NumericFilter;
 
 /**
+ * The header of a `LowMemoryThinVec`.
+ */
+typedef struct Header_u32 {
+  uint32_t len;
+  uint32_t cap;
+} Header_u32;
+
+/**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct LowMemoryThinVecRSIndexResult {
-  Header_u16 *ptr;
-} LowMemoryThinVecRSIndexResult;
+typedef struct LowMemoryThinVec______RSIndexResult__u32 {
+  struct Header_u32 *ptr;
+} LowMemoryThinVec______RSIndexResult__u32;
 
 /**
  * Represents a set of flags of some type `T`.
@@ -211,9 +219,9 @@ typedef BitFlags_RSResultKind__u8 RSResultKindMask;
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct LowMemoryThinVecRSIndexResultOwned {
-  Header_u16 *ptr;
-} LowMemoryThinVecRSIndexResultOwned;
+typedef struct LowMemoryThinVec_____RSIndexResult__u32 {
+  struct Header_u32 *ptr;
+} LowMemoryThinVec_____RSIndexResult__u32;
 
 /**
  * Represents an aggregate array of values in an index record.
@@ -252,7 +260,7 @@ typedef struct RSAggregateResult_Borrowed_Body {
    * above, this means `'index: 'static` which is just incorrect since the index data will
    * never be `'static` when decoding.
    */
-  struct LowMemoryThinVecRSIndexResult records;
+  struct LowMemoryThinVec______RSIndexResult__u32 records;
   /**
    * A map of the aggregate kind of the underlying records
    */
@@ -268,7 +276,7 @@ typedef struct RSAggregateResult_Owned_Body {
    * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
    * own `LowMemoryThinVec` type which is `#[repr(C)]` and has a known size instead.
    */
-  struct LowMemoryThinVecRSIndexResultOwned records;
+  struct LowMemoryThinVec_____RSIndexResult__u32 records;
   /**
    * A map of the aggregate kind of the underlying records
    */

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -373,7 +373,7 @@ pub enum RSAggregateResult<'index> {
         /// any aggregate results so `'refs == 'static` when decoding. Because of the requirement
         /// above, this means `'index: 'static` which is just incorrect since the index data will
         /// never be `'static` when decoding.
-        records: LowMemoryThinVec<&'index RSIndexResult<'index>>,
+        records: LowMemoryThinVec<&'index RSIndexResult<'index>, u32>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -384,7 +384,7 @@ pub enum RSAggregateResult<'index> {
         /// The `RSAggregateResult` is part of a union in [`RSResultData`], so it needs to have a
         /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
         /// own `LowMemoryThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: LowMemoryThinVec<Box<RSIndexResult<'static>>>,
+        records: LowMemoryThinVec<Box<RSIndexResult<'static>>, u32>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,

--- a/src/redisearch_rs/inverted_index/tests/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/index_result.rs
@@ -257,3 +257,22 @@ fn to_owned_a_term_index_result() {
         "cloned offsets should not have changed"
     );
 }
+
+#[test]
+fn aggregate_child_count_is_not_capped_at_16_bits() {
+    // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+    const CHILD_COUNT: usize = 65536;
+
+    let child = RSIndexResult::virt().doc_id(1);
+    let mut agg = RSAggregateResult::with_capacity(CHILD_COUNT);
+    for _ in 0..CHILD_COUNT {
+        agg.push_borrowed(&child);
+    }
+
+    assert_eq!(agg.len(), CHILD_COUNT);
+    assert_eq!(
+        agg.get(CHILD_COUNT - 1),
+        Some(&RSIndexResult::virt().doc_id(1)),
+        "the last child is reachable"
+    );
+}

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -273,3 +273,94 @@ class TestIteratorsRevalidate:
 
         # No remaining results since we deleted all matching documents
         self.env.assertEqual(remaining_docs, [])
+
+
+def test_union_child_count_is_not_capped_at_16_bits(env):
+    """A union node with more children than a 16-bit count can hold serves the query normally.
+
+    `NOT` branches are used because they are never reduced away as empty, so the union keeps a
+    child per branch without the index needing a matching term for each one.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'h1', 't', 'hello')
+
+    # One past u16::MAX, the widest child count a 16-bit capacity can hold.
+    wide_query = '|'.join(f'-a{i}' for i in range(65536))
+
+    expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a union of negations matches the same documents whatever its width")
+
+
+def test_tag_union_child_count_is_not_capped_at_16_bits(env):
+    """A TAG union node with more children than a 16-bit count can hold serves the query
+    normally.
+
+    Unlike the plain-text union test, the children here all come from values that actually
+    exist on the document, exercising the tag-node evaluation path in `Query_EvalTagNode`
+    rather than the generic union constructor.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+
+    values = [f'v{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ','.join(values))
+
+    wide_query = '@t:{' + '|'.join(values) + '}'
+
+    expected = env.cmd('FT.SEARCH', 'idx', '@t:{v0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a tag union matches the same documents whatever its width")
+
+
+def test_intersection_and_phrase_child_count_is_not_capped_at_16_bits(env):
+    """An intersection node, and a quoted-phrase node built on top of one, both serve a
+    query normally when they have more children than a 16-bit count can hold.
+
+    The same document backs both assertions: it contains every term in order, so the
+    implicit AND of all terms and the exact quoted phrase of all terms both have to match
+    it, and neither can short-circuit on a missing child.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    words = [f'w{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ' '.join(words))
+
+    expected = env.cmd('FT.SEARCH', 'idx', 'w0', 'NOCONTENT', 'DIALECT', 2)
+
+    and_query = ' '.join(words)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', and_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="an intersection of terms matches the same documents whatever its width")
+
+    phrase_query = '"' + ' '.join(words) + '"'
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', phrase_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a quoted phrase matches the same documents whatever its width")
+
+
+def test_prefix_expansion_child_count_is_not_capped_at_16_bits():
+    """Prefix expansion, on both a TEXT and a TAG field, can build a union with more children
+    than a 16-bit count can hold when MAXPREFIXEXPANSIONS allows it.
+
+    Unlike the other wide-node tests, the width here comes from the number of indexed terms
+    a short prefix expands to, not from the query string itself.
+    """
+    env = Env(moduleArgs='MAXPREFIXEXPANSIONS 100000')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
+    text_terms = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'text:1', 't', ' '.join(text_terms))
+
+    expected_text = env.cmd('FT.SEARCH', 'idx_text', 'va0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_text', 'va*', 'NOCONTENT', 'DIALECT', 2), expected_text,
+                    message="a TEXT prefix query matches the same documents whatever its expansion width")
+
+    env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 't', 'TAG').ok()
+    tag_values = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'tag:1', 't', ','.join(tag_values))
+
+    expected_tag = env.cmd('FT.SEARCH', 'idx_tag', '@t:{va0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_tag', '@t:{va*}', 'NOCONTENT', 'DIALECT', 2), expected_tag,
+                    message="a TAG prefix query matches the same documents whatever its expansion width")


### PR DESCRIPTION
Backport of #11238 to `8.6`.

## Original PR

https://github.com/RediSearch/RediSearch/pull/11238 (commit 2aba0b2c35261186253eeff9d844a1c5739bbc9d)

## Changes from original

The automated backport could not cherry-pick this, and the change had to be adapted rather than
applied: none of the files master touches exist in the same form on this branch.

- The aggregate result is `inverted_index/src/index_result.rs` here, and its vector type is
  `LowMemoryThinVec`, which carries the capacity as a type parameter defaulting to `u16`. The fix
  is to pass `u32` for the two `records` fields, which is the same widening master performs by
  switching `SmallThinVec` to `MediumThinVec`.
- `headers/types_rs.h` was regenerated by the build. The vec typedefs keep a single pointer, so
  the layout C sees is unchanged; their generated names change because the u16 instantiation is
  what the cbindgen config aliased.
- This branch has no Rust union iterator, so master's iterator-level tests do not apply. The
  equivalent coverage is an aggregate-level test in `inverted_index/tests/index_result.rs` that
  fills an `RSAggregateResult` past 65535 children.
- The four flow tests are taken from master unchanged.

## Validation

- `./build.sh` passes.
- `cargo nextest -p inverted_index -E 'test(child_count_is_not_capped)'`: 1 passed.
- End to end against `redis:8.6` with this build loaded: a 65536-branch `NOT` union, a
  65536-value tag union, a 65536-term intersection and a 65536-word phrase all return results,
  with no panic in the log. The same queries abort the shard with the stock 8.6 module.
- Flow tests were not run locally (RLTest is unavailable in the build container); CI covers them.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
