### PR TITLE
[8.4] [MOD-18138] Serve queries whose union or intersection has more than 65535 children

### DIFF
--- a/src/redisearch_rs/headers/low_memory_thin_vec.h
+++ b/src/redisearch_rs/headers/low_memory_thin_vec.h
@@ -5,7 +5,7 @@
 /**
  * The type used to represent the capacity of a `LowMemoryThinVec`.
  */
-typedef uint16_t SizeType;
+typedef uint32_t SizeType;
 
 /**
  * The header of a LowMemoryThinVec.

--- a/src/redisearch_rs/inverted_index/tests/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/index_result.rs
@@ -257,3 +257,22 @@ fn to_owned_a_term_index_result() {
         "cloned offsets should not have changed"
     );
 }
+
+#[test]
+fn aggregate_child_count_is_not_capped_at_16_bits() {
+    // One past `u16::MAX`, the widest child count a 16-bit capacity can hold.
+    const CHILD_COUNT: usize = 65536;
+
+    let child = RSIndexResult::virt().doc_id(1);
+    let mut agg = RSAggregateResult::with_capacity(CHILD_COUNT);
+    for _ in 0..CHILD_COUNT {
+        agg.push_borrowed(&child);
+    }
+
+    assert_eq!(agg.len(), CHILD_COUNT);
+    assert_eq!(
+        agg.get(CHILD_COUNT - 1),
+        Some(&RSIndexResult::virt().doc_id(1)),
+        "the last child is reachable"
+    );
+}

--- a/src/redisearch_rs/low_memory_thin_vec/src/header.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/header.rs
@@ -6,7 +6,7 @@ pub struct Header {
 }
 
 /// The type used to represent the capacity of a `LowMemoryThinVec`.
-pub(crate) type SizeType = u16;
+pub(crate) type SizeType = u32;
 
 /// The maximum capacity of a `LowMemoryThinVec`.
 pub(crate) const MAX_CAP: usize = SizeType::MAX as usize;
@@ -15,7 +15,7 @@ pub(crate) const MAX_CAP: usize = SizeType::MAX as usize;
 /// Convert a `usize` to a [`SizeType`], panicking if the value is too large to fit.
 pub(crate) const fn assert_size(x: usize) -> SizeType {
     if x > MAX_CAP {
-        panic!("LowMemoryThinVec size may not exceed the capacity of a 16-bit sized int");
+        panic!("LowMemoryThinVec size may not exceed the capacity of a 32-bit sized int");
     }
     x as SizeType
 }
@@ -73,15 +73,15 @@ mod tests {
 
     #[test]
     fn test_max_cap() {
-        Header::new(0, u16::MAX as usize);
+        Header::new(0, u32::MAX as usize);
     }
 
     #[test]
     #[should_panic(
-        expected = "LowMemoryThinVec size may not exceed the capacity of a 16-bit sized int"
+        expected = "LowMemoryThinVec size may not exceed the capacity of a 32-bit sized int"
     )]
     fn test_over_max_cap() {
-        Header::new(0, (u16::MAX as usize) + 1);
+        Header::new(0, (u32::MAX as usize) + 1);
     }
     #[test]
     #[should_panic(expected = "Capacity must be greater than or equal to the current length")]

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -59,25 +59,15 @@ mod tests {
 
     #[test]
     fn test_header_field_padding() {
-        // Zero header padding needed if storing `u8`s,
-        // since the whole allocation is aligned to 2,
-        // the alignment of the header.
+        // The header is 8 bytes long and aligned to 4, so no padding is needed for
+        // any element alignment up to and including 8.
         assert_eq!(header_field_padding::<u8>(), 0);
-
-        // With `u16` elements, both elements and header have the
-        // same alignment, so no padding is needed.
         assert_eq!(header_field_padding::<u16>(), 0);
-
-        // With `u32` elements, the whole allocation is aligned to 4,
-        // but the header is 4 bytes long, so no padding is needed.
         assert_eq!(header_field_padding::<u32>(), 0);
-
-        // With `u64` elements, the whole allocation is aligned to 8,
-        // so the header needs 4 bytes of padding to be aligned.
-        assert_eq!(header_field_padding::<u64>(), 4);
+        assert_eq!(header_field_padding::<u64>(), 0);
 
         // With `u128` elements, the whole allocation is aligned to 16,
-        // so the header needs 12 bytes of padding to be aligned.
-        assert_eq!(header_field_padding::<u128>(), 12);
+        // so the header needs 8 bytes of padding to be aligned.
+        assert_eq!(header_field_padding::<u128>(), 8);
     }
 }

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -61,7 +61,7 @@
 //! - All Gecko-specific code has been removed
 //! - `ThinVec::drain`, `ThinVec::append` and `ThinVec::splice` have been removed, since they aren't
 //!   needed for our purposes and they contribute a significant amount of unsafe-related complexity.
-//! - Maximum capacity is limited to `u16::MAX` elements for non-zero-sized types.
+//! - Maximum capacity is limited to `u32::MAX` elements for non-zero-sized types.
 //!
 //! ## License
 //!
@@ -2066,7 +2066,7 @@ mod tests {
         }
 
         const HEADER_SIZE: usize = core::mem::size_of::<Header>();
-        assert_eq!(2 * core::mem::size_of::<u16>(), HEADER_SIZE);
+        assert_eq!(2 * core::mem::size_of::<u32>(), HEADER_SIZE);
 
         #[repr(C, align(128))]
         struct Funky<T>(T);

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -407,7 +407,7 @@ impl<T> LowMemoryThinVec<T> {
     /// use low_memory_thin_vec::LowMemoryThinVec;
     ///
     /// let vec: LowMemoryThinVec<i32> = LowMemoryThinVec::with_capacity(5);
-    /// assert_eq!(vec.mem_usage(), 24);
+    /// assert_eq!(vec.mem_usage(), 28);
     ///
     /// assert_eq!(LowMemoryThinVec::<u64>::new().mem_usage(), 0);
     /// ```

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -273,3 +273,94 @@ class TestIteratorsRevalidate:
 
         # No remaining results since we deleted all matching documents
         self.env.assertEqual(remaining_docs, [])
+
+
+def test_union_child_count_is_not_capped_at_16_bits(env):
+    """A union node with more children than a 16-bit count can hold serves the query normally.
+
+    `NOT` branches are used because they are never reduced away as empty, so the union keeps a
+    child per branch without the index needing a matching term for each one.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'h1', 't', 'hello')
+
+    # One past u16::MAX, the widest child count a 16-bit capacity can hold.
+    wide_query = '|'.join(f'-a{i}' for i in range(65536))
+
+    expected = env.cmd('FT.SEARCH', 'idx', '-a0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a union of negations matches the same documents whatever its width")
+
+
+def test_tag_union_child_count_is_not_capped_at_16_bits(env):
+    """A TAG union node with more children than a 16-bit count can hold serves the query
+    normally.
+
+    Unlike the plain-text union test, the children here all come from values that actually
+    exist on the document, exercising the tag-node evaluation path in `Query_EvalTagNode`
+    rather than the generic union constructor.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+
+    values = [f'v{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ','.join(values))
+
+    wide_query = '@t:{' + '|'.join(values) + '}'
+
+    expected = env.cmd('FT.SEARCH', 'idx', '@t:{v0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', wide_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a tag union matches the same documents whatever its width")
+
+
+def test_intersection_and_phrase_child_count_is_not_capped_at_16_bits(env):
+    """An intersection node, and a quoted-phrase node built on top of one, both serve a
+    query normally when they have more children than a 16-bit count can hold.
+
+    The same document backs both assertions: it contains every term in order, so the
+    implicit AND of all terms and the exact quoted phrase of all terms both have to match
+    it, and neither can short-circuit on a missing child.
+    """
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    words = [f'w{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'h1', 't', ' '.join(words))
+
+    expected = env.cmd('FT.SEARCH', 'idx', 'w0', 'NOCONTENT', 'DIALECT', 2)
+
+    and_query = ' '.join(words)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', and_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="an intersection of terms matches the same documents whatever its width")
+
+    phrase_query = '"' + ' '.join(words) + '"'
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', phrase_query, 'NOCONTENT', 'DIALECT', 2), expected,
+                    message="a quoted phrase matches the same documents whatever its width")
+
+
+def test_prefix_expansion_child_count_is_not_capped_at_16_bits():
+    """Prefix expansion, on both a TEXT and a TAG field, can build a union with more children
+    than a 16-bit count can hold when MAXPREFIXEXPANSIONS allows it.
+
+    Unlike the other wide-node tests, the width here comes from the number of indexed terms
+    a short prefix expands to, not from the query string itself.
+    """
+    env = Env(moduleArgs='MAXPREFIXEXPANSIONS 100000')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
+    text_terms = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'text:1', 't', ' '.join(text_terms))
+
+    expected_text = env.cmd('FT.SEARCH', 'idx_text', 'va0', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_text', 'va*', 'NOCONTENT', 'DIALECT', 2), expected_text,
+                    message="a TEXT prefix query matches the same documents whatever its expansion width")
+
+    env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 't', 'TAG').ok()
+    tag_values = [f'va{i}' for i in range(65536)]
+    conn.execute_command('HSET', 'tag:1', 't', ','.join(tag_values))
+
+    expected_tag = env.cmd('FT.SEARCH', 'idx_tag', '@t:{va0}', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx_tag', '@t:{va*}', 'NOCONTENT', 'DIALECT', 2), expected_tag,
+                    message="a TAG prefix query matches the same documents whatever its expansion width")


### PR DESCRIPTION
Backport of #11238 to `8.4`.

## Original PR

https://github.com/RediSearch/RediSearch/pull/11238 (commit 2aba0b2c35261186253eeff9d844a1c5739bbc9d)

## Changes from original

This is the branch furthest from master, and the fix has a different shape here.

- `LowMemoryThinVec` on this branch has no capacity type parameter: the width is fixed crate-wide
  by `SizeType` in `low_memory_thin_vec/src/header.rs`. The fix widens that alias to `u32`, which
  is the same widening master performs per type.
- That widens the vector for every user on this branch, which is safe and free here: all three
  (`TrieMapResultBuf` and both aggregate `records` fields) hold pointer-sized, pointer-aligned
  elements, so the larger header is absorbed by alignment padding and no allocation grows. The
  padding table in `layout.rs`, updated in this PR, is the evidence: with an 8-byte header,
  `u64` elements need 0 bytes of padding where they previously needed 4.
- No C code reads `SizeType` or the `Header` struct, so this is ABI-neutral. The generated
  `headers/low_memory_thin_vec.h` now declares `uint32_t`. Note that `./build.sh` alone does not
  regenerate that header; the FFI crate has to be rebuilt for it, which is why it is included
  here explicitly.
- The crate's own boundary tests move with the type: the panic message, the `Header::new`
  overflow cases, `HEADER_SIZE`, and the padding table above.
- This branch has no Rust union iterator, so master's iterator-level tests do not apply; the
  equivalent coverage is an aggregate-level test in `inverted_index/tests/index_result.rs`.
- The four flow tests are taken from master unchanged.

## Validation

- `./build.sh` passes.
- `cargo nextest -p low_memory_thin_vec -p inverted_index`: 170 passed, 0 failed. The whole
  crate suite was run rather than just the new test, because the change is crate-wide.
- End to end against `redis:8.4` with this build loaded: a 65536-branch `NOT` union, a
  65536-value tag union, a 65536-term intersection and a 65536-word phrase all return results,
  with no panic in the log. The same queries abort the shard with the stock 8.4 module.
- Flow tests were not run locally (RLTest is unavailable in the build container); CI covers them.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
