### PR TITLE
[MOD-18166] Fix build-redis action: use `make deploy` instead of `make install`

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -120,7 +120,11 @@ runs:
         if [[ "$COVERAGE" == "true" ]]; then
           EXTRA+=("REDIS_CFLAGS=-DCOVERAGE_TEST")
         fi
-        make PREFIX="$PREFIX" install "${EXTRA[@]}" SANITIZER="$SAN"
+        # `make install` is an alias for `deploy` with SKIP_BUILD=1 (install
+        # only what's already built); on this fresh, cache-miss checkout
+        # nothing has been built yet, so it must go through `deploy`, which
+        # builds first.
+        make PREFIX="$PREFIX" deploy "${EXTRA[@]}" SANITIZER="$SAN"
 
     - name: Verify redis-server runs
       # Guards both ways into this point: a fresh build and a restored cache


### PR DESCRIPTION
## Summary
- Nightly Flow run [33273446030](https://github.com/RediSearch/RediSearch/actions/runs/33273446030/attempts/1) failed `test-all-platforms / macos-14 (aarch64)` and `test-all-platforms / macos-26 (aarch64)` at "Setup build environment" with `install: cannot stat 'src/redis-server': No such file or directory`.
- `redis/redis`'s top-level `Makefile` was restructured ("modules modernization"): `install` is now a non-building alias for `deploy` (`SKIP_BUILD ?= 1`) — it only copies artifacts already present in the tree, per its own doc comment: *"install is an alias for deploy that does NOT build ... Rebuild with `make install SKIP_BUILD=0`, or just use `make deploy`."*
- `.github/actions/build-redis/action.yml`'s "Build Redis (cache miss)" step calls `make ... install ...`, which used to build+install but no longer does. On any Redis build cache miss (fresh checkout, no artifacts), the copy step fails outright since nothing was built.
- Fix: call `make deploy` instead of `make install`, so the build actually happens before the install/copy phase.

Jira: [MOD-18166](https://redislabs.atlassian.net/browse/MOD-18166)

## Test plan
- [ ] Re-run the Nightly Flow (or a workflow_dispatch of `test-all-platforms`) targeting macOS runners with a guaranteed cache miss (e.g. bump the Redis ref) and confirm "Setup build environment" now builds `redis-server` and proceeds past deploy.
- [ ] Confirm cache-hit path (unaffected by this change) still restores and skips the build step as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOD-18166]: https://redislabs.atlassian.net/browse/MOD-18166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ