### PR TITLE
[8.4] CI: containerize the default ubuntu:latest test/coverage/sanitize job

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -107,12 +107,12 @@ jobs:
               },
               "ubuntu:latest": {
                   "x86_64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -107,9 +107,13 @@ jobs:
               },
               "ubuntu:latest": {
                   "x86_64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }
               },

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "build_utils",
  "cbindgen",
+ "chrono",
  "ffi",
  "tracing",
  "tracing_redismodule",

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -52,7 +52,7 @@ static PANIC_STASH: OnceLock<StashedPanic> = OnceLock::new();
 /// Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
 ///
 /// Panic messages will be logged through `tracing` at the `ERROR` level, and
-/// stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+/// stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
 /// the crash report.
 #[unsafe(no_mangle)]
 pub extern "C" fn RustPanicHook_Init() {
@@ -124,7 +124,7 @@ fn info_cstring(value: impl Into<Vec<u8>>) -> CString {
 /// Add the current backtrace as a new section to the report printed
 /// by RediSearch's INFO command.
 ///
-/// When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+/// When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
 /// in the same section, ahead of the backtrace.
 ///
 /// # Safety

--- a/src/redisearch_rs/headers/module_init.h
+++ b/src/redisearch_rs/headers/module_init.h
@@ -17,15 +17,20 @@ extern "C" {
 void TracingRedisModule_Init(RedisModuleCtx *ctx);
 
 /**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ * Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
  *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
+ * Panic messages will be logged through `tracing` at the `ERROR` level, and
+ * stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
+ * the crash report.
  */
 void RustPanicHook_Init(void);
 
 /**
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
+ *
+ * When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
+ * in the same section, ahead of the backtrace.
  *
  * # Safety
  *


### PR DESCRIPTION
## What
The `"ubuntu:latest"` platform entry in `task-get-config.yml` is missing `container`/`setup_script` fields that every other named platform in the same table has (and that 8.8/8.8-rse/8.10 already have for this exact key). As a result, `basic-test`/`coverage`/`sanitize` jobs for the default platform silently run directly on the runner's bare OS instead of inside a container.

## Why this matters
This is invisible on GitHub-hosted runners (Ubuntu 24.04, GCC 13's libstdc++). On this org's self-hosted EC2 pool (Ubuntu 22.04, GCC 12's libstdc++), it can surface as a link failure for ASan-instrumented C++ code:
```
/usr/bin/ld: ../../redisearch.so: undefined reference to `std::__cxx11::basic_string<...>::_M_replace_cold(...)'
/usr/bin/ld: ../../redisearch.so: undefined reference to `std::ios_base_library_init()'
```
These are libstdc++ hot/cold function-splitting symbols that don't exist before GCC 13. Discovered while backporting #11075 (self-hosted runner support) to this branch — that PR made these jobs eligible to actually land on the self-hosted pool for the first time, exposing this pre-existing gap. Root-caused via job logs on this branch and cross-referenced against 8.8/8.8-rse/8.10 (which already have the fix) and a passing GitHub-hosted run of an earlier PR to this branch.

## Change
Copy the already-proven-working `"ubuntu:latest"` entry from 8.8/8.8-rse/8.10 verbatim:
```python
'container': 'ubuntu:latest',
'setup_script': 'apt update && apt install -y git',
```

## Release Notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes