### PR TITLE
[8.6] CI: containerize the default ubuntu:latest test/coverage/sanitize job

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -109,9 +109,13 @@ jobs:
               },
               "ubuntu:latest": {
                   "x86_64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }
               },

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -109,12 +109,12 @@ jobs:
               },
               "ubuntu:latest": {
                   "x86_64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }


### PR DESCRIPTION
## What
The `"ubuntu:latest"` platform entry in `task-get-config.yml` is missing `container`/`setup_script` fields that every other named platform in the same table has (and that 8.8/8.8-rse/8.10 already have for this exact key). As a result, `basic-test`/`coverage`/`sanitize` jobs for the default platform silently run directly on the runner's bare OS instead of inside a container.

## Why this matters
This is invisible on GitHub-hosted runners (Ubuntu 24.04, GCC 13's libstdc++). On this org's self-hosted EC2 pool (Ubuntu 22.04, GCC 12's libstdc++), it can surface as a link failure for ASan-instrumented C++ code:
```
/usr/bin/ld: ../../redisearch.so: undefined reference to `std::__cxx11::basic_string<...>::_M_replace_cold(...)'
/usr/bin/ld: ../../redisearch.so: undefined reference to `std::ios_base_library_init()'
```
These are libstdc++ hot/cold function-splitting symbols that don't exist before GCC 13. Discovered while backporting #11075 (self-hosted runner support) to this branch — that PR made these jobs eligible to actually land on the self-hosted pool for the first time, exposing this pre-existing gap. Root-caused via job logs on this branch and cross-referenced against 8.8/8.8-rse/8.10 (which already have the fix) and a passing GitHub-hosted run of an earlier PR to this branch.

## Change
Copy the already-proven-working `"ubuntu:latest"` entry from 8.8/8.8-rse/8.10 verbatim:
```python
'container': 'ubuntu:latest',
'setup_script': 'apt update && apt install -y git',
```

## Release Notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes