### PR TITLE
[8.4] Fix rustdoc private-intra-doc-link lint failure in module_init_ffi

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 name = "module_init_ffi"
 version = "0.0.1"
 dependencies = [
- "chrono",
  "build_utils",
  "cbindgen",
+ "chrono",
  "ffi",
  "tracing",
  "tracing_redismodule",

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -52,7 +52,7 @@ static PANIC_STASH: OnceLock<StashedPanic> = OnceLock::new();
 /// Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
 ///
 /// Panic messages will be logged through `tracing` at the `ERROR` level, and
-/// stashed in [`PANIC_STASH`] for [`AddToInfo_RustBacktrace`] to include in
+/// stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
 /// the crash report.
 #[unsafe(no_mangle)]
 pub extern "C" fn RustPanicHook_Init() {
@@ -124,7 +124,7 @@ fn info_cstring(value: impl Into<Vec<u8>>) -> CString {
 /// Add the current backtrace as a new section to the report printed
 /// by RediSearch's INFO command.
 ///
-/// When a Rust panic was stashed in [`PANIC_STASH`], its details are emitted
+/// When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
 /// in the same section, ahead of the backtrace.
 ///
 /// # Safety

--- a/src/redisearch_rs/headers/module_init.h
+++ b/src/redisearch_rs/headers/module_init.h
@@ -17,15 +17,20 @@ extern "C" {
 void TracingRedisModule_Init(RedisModuleCtx *ctx);
 
 /**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ * Initialize RediSearch's panic hook, without replacing the pre-existing panic hook (if any).
  *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
+ * Panic messages will be logged through `tracing` at the `ERROR` level, and
+ * stashed in `PANIC_STASH` for [`AddToInfo_RustBacktrace`] to include in
+ * the crash report.
  */
 void RustPanicHook_Init(void);
 
 /**
  * Add the current backtrace as a new section to the report printed
  * by RediSearch's INFO command.
+ *
+ * When a Rust panic was stashed in `PANIC_STASH`, its details are emitted
+ * in the same section, ahead of the backtrace.
  *
  * # Safety
  *


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `make lint` fails on `8.4` (independent of any other PR — reproduces at branch tip) because doc comments in `module_init_ffi` intra-doc-link to the private `PANIC_STASH` static, which `rustdoc::private-intra-doc-links` rejects under `-D warnings`. The checked-in `module_init.h` header had also drifted out of sync with those doc comments since the `PANIC_STASH` backport (#11157), independently failing CI's post-lint `git diff --exit-code` check.
2. Change: Drop the intra-doc-link brackets around `PANIC_STASH` in the two affected doc comments (plain code-span instead of a link), and regenerate `module_init.h` to match. `master` fixes the same lint category by passing `--document-private-items` to `cargo doc`, but adopting that flag on `8.4` surfaces a large, unrelated pile of pre-existing broken doc links in other crates that are normally invisible to `cargo doc` — out of scope for this fix.
3. Outcome: Internal-only. `make lint` and the CI `Lint` job pass again on `8.4` at HEAD.

#### Which additional issues this PR fixes

1. N/A
2. N/A

#### Main objects this PR modified

1. `src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs` — doc comments on `RustPanicHook_Init` and `AddToInfo_RustBacktrace` no longer link to the private `PANIC_STASH` static.
2. `src/redisearch_rs/headers/module_init.h` — regenerated to match the corrected doc comments and fix an unrelated stale typo.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
