### PR TITLE
[MOD-18172] Fix FT.AGGREGATE cursor with FILTER reporting a wrong result count

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -520,9 +520,21 @@ static int rpevalNext_filter(ResultProcessor *rp, SearchResult *r) {
       return RS_RESULT_OK;
     }
 
-    // Reduce the total number of results
-    RS_ASSERT(rp->parent->totalResults > 0);
-    rp->parent->totalResults--;
+    // Reduce the total number of results, unless there is nothing left to reduce.
+    //
+    // The row being rejected was not necessarily counted into the figure this is
+    // decrementing. A cursor read without WITHCOUNT resets `totalResults` to zero when it
+    // finishes (see the reset in `AREQ_Execute`'s cursor path), while a buffering stage
+    // upstream -- `SORTBY` with `MAX`, which accumulates every row before yielding any --
+    // hands rows counted during one read to this filter during a later one. Those rows were
+    // reported in the earlier read's total and cannot be taken back out of it here.
+    //
+    // Asserting instead of clamping made that a crash in a debug build, and `totalResults`
+    // is unsigned, so a release build wrapped it to ~4.29 billion and reported that as the
+    // result count.
+    if (rp->parent->totalResults > 0) {
+      rp->parent->totalResults--;
+    }
     // Otherwise, the result must be filtered out.
     SearchResult_Clear(r);
   }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -95,13 +95,26 @@ void QITR_PushRP(QueryProcessingCtx *it, struct ResultProcessor *rp);
 void QITR_FreeChain(QueryProcessingCtx *qitr);
 
 // Result count to report to the client: matches minus the rows a loader dropped
-// (deleted/re-indexed/expired mid-load). Invariant: skippedResults <= totalResults
-// — drops are a subset of counted matches, and any stage that transforms or replaces
-// totalResults (grouper, hybrid merge, optimizer offset/limit) folds in and clears
-// skippedResults first. The assert enforces the invariant at every reply site.
+// (deleted/re-indexed/expired mid-load). Saturates at zero.
+//
+// `skippedResults <= totalResults` reads like an invariant — drops are a subset of counted
+// matches, and any stage that transforms or replaces totalResults (grouper, hybrid merge,
+// optimizer offset/limit) folds in and clears skippedResults first. It does not hold across a
+// cursor chunk boundary. A read without WITHCOUNT resets both counters when it finishes, while
+// a buffering stage upstream — `SORTBY` with `MAX`, which accumulates every row before
+// yielding any — hands rows counted during one read to the loader during a later one. A
+// document that vanished in between is counted in `skippedResults` for a read whose
+// `totalResults` no longer includes it.
+//
+// Both counters are unsigned, so subtracting then wrapped: five such rows reported 4294967291
+// as the result count, and the assert this used to carry aborted an assert-enabled build
+// rather than catching anything a caller could act on. Same reasoning, and the same remedy, as
+// the clamp in `rpevalNext_filter` — and needed alongside it, since with both a filter and
+// dropped documents that clamp pins `totalResults` at zero and leaves this subtraction to wrap.
 static inline uint32_t QITR_ReportedTotal(const QueryProcessingCtx *qctx) {
-  RS_LOG_ASSERT(qctx->skippedResults <= qctx->totalResults,
-                "skippedResults must not exceed totalResults");
+  if (qctx->skippedResults >= qctx->totalResults) {
+    return 0;
+  }
   return qctx->totalResults - qctx->skippedResults;
 }
 

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -110,14 +110,27 @@ def testCursorFilterTotalDoesNotUnderflow():
     for x in range(0, count, 2):
         env.cmd('HSET', f'idx_doc{x}', 'foo', 'bar')
 
-    query = f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 SORTBY 1 @f1 MAX {count} LOAD 1 foo FILTER exists(@foo)'
-    resp = env.expect(query).noError().res
+    sortby_filter = f'SORTBY 1 @f1 MAX {count} LOAD 1 foo FILTER exists(@foo)'
+
     # Every read, not just the first: the rows the sorter buffered are handed over later, so
-    # the underflow lands on a subsequent read. No read may report more rows than exist, and
-    # certainly not the wrapped count.
+    # the underflow lands on a subsequent read. No read may claim more rows than exist -- the
+    # wrap presented as a count of ~4.29 billion.
+    resp = env.expect(f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 {sortby_filter}').noError().res
     for results, _cursor in exhaustCursor(env, 'idx', resp):
         env.assertLessEqual(results[0], count,
                             message=f'reported total {results[0]} exceeds the {count} documents indexed')
+
+    # Without WITHCOUNT the total is per-read and resets, so reads after the first declare 0
+    # while still returning buffered rows. That predates this fix and holds for a buffering
+    # SORTBY with no FILTER at all, so it is not asserted here. WITHCOUNT is the mode that
+    # promises a total across reads, and it is where the accounting has to be right: the
+    # filter removes the half of the documents without `foo`, so the total must converge on
+    # exactly that half and never dip below it.
+    resp = env.expect(f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 WITHCOUNT {sortby_filter}').noError().res
+    totals = [results[0] for results, _cursor in exhaustCursor(env, 'idx', resp)]
+    env.assertLessEqual(max(totals), count, message=f'totals {totals} exceed the {count} indexed')
+    env.assertEqual(totals[-1], count // 2,
+                    message=f'WITHCOUNT should settle on the {count // 2} matching documents, got {totals}')
 
 def testMultipleIndexes(env):
     loadDocs(env, idx='idx2', text='goodbye')
@@ -1145,3 +1158,4 @@ def testCursorReadsDocumentsWrittenBetweenReads(env):
     # already indexed when it started must all come back.
     env.assertEqual(sorted(f'doc:{i}' for i in range(seeded)),
                     sorted(k for k in keys if not k.startswith('doc:new')))
+

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -138,6 +138,51 @@ def testCursorFilterTotalDoesNotUnderflow():
     env.assertEqual(totals[-1], count // 2,
                     message=f'WITHCOUNT should settle on the {count // 2} matching documents, got {totals}')
 
+@skip(cluster=True)
+def testCursorTotalIsPerReadWithoutWithcount():
+    """Pin how a cursor read reports its total, so any change to it is a deliberate one.
+
+    Without WITHCOUNT the total is per-read: `finishSendChunk` zeroes it when a read finishes,
+    so a buffering `SORTBY ... MAX` hands rows to later reads that return them while declaring
+    a total of 0. Raised on #11230 against the FILTER clamp, but the clamp is not its cause --
+    the first case here has no FILTER in the pipeline at all and behaves identically. WITHCOUNT
+    is the mode that carries a total across reads, and the second case pins that it stays
+    correct.
+
+    Nobody has decided whether the zero totals should change. This records what they do today,
+    so a change shows up as a failing test rather than passing unnoticed.
+
+    Standalone only: the totals are one shard's, and a cluster spreads the documents.
+    """
+    env = Env(moduleArgs='WORKERS 1')
+    count = 100
+    loadDocs(env, count=count)
+    # Half the documents get a field outside the schema, for the FILTER below to reject on.
+    for x in range(0, count, 2):
+        env.cmd('HSET', f'idx_doc{x}', 'foo', 'bar')
+
+    sortby = f'SORTBY 1 @f1 MAX {count}'
+
+    # No FILTER: the zero totals are already here, so the clamp cannot be producing them.
+    resp = env.cmd(*f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 {sortby} LOAD 1 irrelevant'.split())
+    reads = [(results[0], len(results) - 1) for results, _cursor in exhaustCursor(env, 'idx', resp)]
+    env.assertEqual(reads[0][0], count,
+                    message=f'first read should declare every match, got {reads}')
+    later = reads[1:]
+    env.assertTrue(all(total == 0 for total, _rows in later),
+                   message=f'reads after the first declare a per-read total of 0, got {reads}')
+    env.assertTrue(any(rows > 0 for _total, rows in later),
+                   message=f'and they do return rows while declaring it, got {reads}')
+
+    # WITHCOUNT keeps the total across reads, and the FILTER brings it down to the documents
+    # it keeps -- the half carrying `foo`.
+    resp = env.cmd(
+        *f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 WITHCOUNT {sortby} LOAD 1 foo FILTER exists(@foo)'.split())
+    totals = [results[0] for results, _cursor in exhaustCursor(env, 'idx', resp)]
+    env.assertEqual(totals[0], count, message=f'totals {totals}')
+    env.assertEqual(totals[-1], count // 2,
+                    message=f'WITHCOUNT should settle on the {count // 2} matching documents, got {totals}')
+
 def testMultipleIndexes(env):
     loadDocs(env, idx='idx2', text='goodbye')
     loadDocs(env, idx='idx1', text='hello')

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -86,6 +86,39 @@ def testCursorsBGEdgeCasesSanity():
         resp = env.expect(query).noError().res
         resp = exhaustCursor(env, 'idx', resp)
 
+def testCursorFilterTotalDoesNotUnderflow():
+    """A FILTER may reject a row that a previous cursor read already counted.
+
+    `SORTBY ... MAX` buffers every row during the first read, then hands them to the FILTER
+    across later reads -- by which point a read without WITHCOUNT has reset the running total
+    to zero. Rejecting one of those rows used to decrement from zero: a failed assertion in a
+    debug build, and an unsigned wrap to ~4.29 billion reported as the result count in a
+    release one.
+
+    Only reachable when the writes below are not reindexed, which is what
+    PARTIAL_INDEXED_DOCS switches on -- the same reason this went unnoticed, since it
+    defaults to off. The reported total is asserted, not just the absence of a crash, so a
+    release build is covered too.
+    """
+    env = Env(moduleArgs='WORKERS 1 PARTIAL_INDEXED_DOCS 1')
+    if env.env == 'existing-env':
+        env.skip()
+    count = 100
+    loadDocs(env, count=count)
+    # `foo` is outside the schema, so with PARTIAL_INDEXED_DOCS these writes are not
+    # reindexed and the documents keep their doc-ids.
+    for x in range(0, count, 2):
+        env.cmd('HSET', f'idx_doc{x}', 'foo', 'bar')
+
+    query = f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 SORTBY 1 @f1 MAX {count} LOAD 1 foo FILTER exists(@foo)'
+    resp = env.expect(query).noError().res
+    # Every read, not just the first: the rows the sorter buffered are handed over later, so
+    # the underflow lands on a subsequent read. No read may report more rows than exist, and
+    # certainly not the wrapped count.
+    for results, _cursor in exhaustCursor(env, 'idx', resp):
+        env.assertLessEqual(results[0], count,
+                            message=f'reported total {results[0]} exceeds the {count} documents indexed')
+
 def testMultipleIndexes(env):
     loadDocs(env, idx='idx2', text='goodbye')
     loadDocs(env, idx='idx1', text='hello')

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -86,6 +86,7 @@ def testCursorsBGEdgeCasesSanity():
         resp = env.expect(query).noError().res
         resp = exhaustCursor(env, 'idx', resp)
 
+@skip(cluster=True)
 def testCursorFilterTotalDoesNotUnderflow():
     """A FILTER may reject a row that a previous cursor read already counted.
 
@@ -99,6 +100,11 @@ def testCursorFilterTotalDoesNotUnderflow():
     PARTIAL_INDEXED_DOCS switches on -- the same reason this went unnoticed, since it
     defaults to off. The reported total is asserted, not just the absence of a crash, so a
     release build is covered too.
+
+    Standalone only, like `testCursorsBGEdgeCasesSanity` next door: the totals asserted here
+    are one shard's, and in a cluster the documents are spread across shards while the
+    coordinator sums their counts, so neither the convergence on half the documents nor the
+    per-read bound describes what any single reply carries.
     """
     env = Env(moduleArgs='WORKERS 1 PARTIAL_INDEXED_DOCS 1')
     if env.env == 'existing-env':

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -179,7 +179,11 @@ def testCursorTotalIsPerReadWithoutWithcount():
     resp = env.cmd(
         *f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 WITHCOUNT {sortby} LOAD 1 foo FILTER exists(@foo)'.split())
     totals = [results[0] for results, _cursor in exhaustCursor(env, 'idx', resp)]
-    env.assertEqual(totals[0], count, message=f'totals {totals}')
+    # Only the endpoint and the bound are invariants. How the total gets there depends on
+    # where the filter's rejections land across the reads, which moves with the doc-id layout:
+    # `[100, 90, ..., 50]` when the writes above were skipped, a flat `[50, ...]` when they
+    # were reindexed. Asserting the first read's value would pin one of those two.
+    env.assertLessEqual(max(totals), count, message=f'totals {totals} exceed the {count} indexed')
     env.assertEqual(totals[-1], count // 2,
                     message=f'WITHCOUNT should settle on the {count // 2} matching documents, got {totals}')
 

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -187,6 +187,44 @@ def testCursorTotalIsPerReadWithoutWithcount():
     env.assertEqual(totals[-1], count // 2,
                     message=f'WITHCOUNT should settle on the {count // 2} matching documents, got {totals}')
 
+@skip(cluster=True)
+def testCursorTotalDoesNotUnderflowOnDroppedDocuments():
+    """`QITR_ReportedTotal` must not wrap when the loader drops buffered rows.
+
+    Same shape as the FILTER underflow, one function over and with no FILTER involved. A read
+    without WITHCOUNT resets both counters when it finishes, while `SORTBY ... MAX` hands rows
+    counted during the first read to the loader during later ones. A document that disappeared
+    in between is counted in `skippedResults` for a read whose `totalResults` is zero, so
+    `totalResults - skippedResults` underflowed: five such rows reported 4294967291, and an
+    assert-enabled build aborted on the `skippedResults <= totalResults` invariant instead.
+
+    Reported by Ofir on #11262. Note the clamp in `rpevalNext_filter` alone moves this rather
+    than fixing it: with both a filter and dropped documents, the total pins at zero and the
+    subtraction still wraps.
+
+    Standalone only: the totals are one shard's.
+    """
+    env = Env(moduleArgs='WORKERS 1')
+    count = 100
+    loadDocs(env, count=count)
+
+    resp = env.cmd(*f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 SORTBY 1 @f1 MAX {count} LOAD 1 foo'.split())
+    results, cid = resp
+    totals = [results[0]]
+    env.assertTrue(cid, message='need an open cursor for the buffered rows to be read later')
+
+    # The sorter has already buffered every row. Removing the documents now means the loader
+    # meets rows whose documents are gone, on reads where the total has been reset.
+    for i in range(0, count, 2):
+        env.cmd('DEL', f'idx_doc{i}')
+
+    while cid:
+        results, cid = env.cmd('FT.CURSOR', 'READ', 'idx', cid)
+        totals.append(results[0])
+
+    env.assertLessEqual(max(totals), count,
+                        message=f'a read reported more rows than exist -- wrapped total: {totals}')
+
 def testMultipleIndexes(env):
     loadDocs(env, idx='idx2', text='goodbye')
     loadDocs(env, idx='idx1', text='hello')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** an `FT.AGGREGATE` cursor read can drive the running result total below zero,
   by two independent routes. On a release build the asserts are compiled out and the counters
   are unsigned, so the arithmetic wraps and roughly 4.29 billion is reported to the client as
   the result count; on an assert-enabled build the server aborts.
2. **Change:** both places that arithmetic can go negative now saturate at zero instead of
   asserting, because the asserts' premise does not hold across a cursor chunk boundary.
3. **Outcome:** the abort and the bogus count are gone. No change for any query that was not
   already hitting this.

#### Which additional issues this PR fixes

1. MOD-18172

#### Main objects this PR modified

1. `rpevalNext_filter` (`aggregate/expr/expression.c`) — the decrement, and a comment saying
   what the fix does and does not cover.
2. `QITR_ReportedTotal` (`result_processor.h`) — the reported total, `totalResults -
   skippedResults`, which wrapped the same way when the loader dropped a buffered row. Needed
   alongside the first: with both a filter and dropped documents, clamping only the decrement
   pins `totalResults` at zero and leaves this subtraction to wrap.
3. `tests/pytests/test_cursors.py` — a regression test per route, and one pinning what a cursor
   read declares as its total.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

#### For the release note

An `FT.AGGREGATE` cursor read could report a result count of roughly 4.29 billion, or abort a
server built with assertions enabled. Two independent ways in, both fixed: a `FILTER` rejecting
a row that an earlier read had counted, and a document disappearing between being buffered and
being loaded. The second needs no `FILTER` at all.

#### Why the assertion was wrong

`rpevalNext_filter` decrements the running total for each row the `FILTER` rejects, and
asserted the total was positive first. That assumes the rejected row was counted into the total
being decremented, which is false across a cursor chunk boundary:

- a read without `WITHCOUNT` resets the total to zero when it finishes;
- `SORTBY ... MAX` accumulates every row during the first read and hands them to the filter
  during later ones.

Those rows were counted, and reported, in the earlier read. Nothing at the point of rejection
can retract them, so clamping is the honest remedy: it stops the abort and the wrap without
pretending the per-read total is now exact. Making it exact would mean tracking rows buffered
across chunk boundaries, which is a larger change than a crash fix should carry.

#### Two routes to the same wrap

Both share a root cause: a cursor read without `WITHCOUNT` resets the counters when it
finishes, while `SORTBY ... MAX` buffers every row during the first read and hands them
downstream during later ones. Anything decrementing or subtracting on a later read is talking
about rows the current read never counted.

- `rpevalNext_filter` — a `FILTER` rejecting one of those rows decremented a total of zero.
- `QITR_ReportedTotal` — a document that vanished between buffering and load is counted in
  `skippedResults`, and `totalResults - skippedResults` underflowed. Reachable with **no
  `FILTER` in the pipeline**, so the first fix does not cover it; and when both apply, the
  first fix relocates the wrap here rather than removing it.

The second was found by review after the first landed on this branch. Each has a regression
test verified in both directions — the loader-drop one takes the server down without the change.

#### What a reviewer would otherwise miss

- **Reachable only when a document's reindex is skipped**, which today means
  `PARTIAL_INDEXED_DOCS`. That defaults to off, which is why no CI lane has ever run this. The
  regression test therefore enables it explicitly.
- **Confirmed pre-existing, not introduced.** The failing test aborts on an unmodified `master`
  build with `PARTIAL_INDEXED_DOCS 1` and passes on the same binary with the config off.
- **The tests are sabotage-verified.** Against a build that keeps the assert,
  `testCursorFilterTotalDoesNotUnderflow` fails; against the clamp it passes. Asserting only
  "no crash" would not have covered the release-build symptom, so it asserts the reported total.
- **A cursor read without `WITHCOUNT` already declares a total of zero while returning rows**,
  and did before this change. `SORTBY ... MAX ... LOAD 1 irrelevant` — no `FILTER`, so a
  pipeline that never enters the clamped function — reports `(rows 10, total 100)` then
  `(rows 10, total 0)` for every later read, because the total is reset per read by design.
  `testCursorTotalIsPerReadWithoutWithcount` pins that, so altering it becomes a deliberate
  choice rather than a silent one. Whether it *should* change is a semantics question this PR
  does not settle.
- **Split out of #11230 at review request.** That PR makes reindex skipping the default and so
  makes this reachable with no configuration at all, which is how it surfaced. Separated so it
  can be reviewed, reverted and backported on its own.


