### PR TITLE
Add Enterprise flow-test review skill discovery

### DIFF
--- a/.agents/skills/review-enterprise-flow-tests
+++ b/.agents/skills/review-enterprise-flow-tests
@@ -1,0 +1,1 @@
+../../.skills/review-enterprise-flow-tests

--- a/.skills/review-changes/SKILL.md
+++ b/.skills/review-changes/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: review-changes
+description: General review process for pull requests, commits, diffs, working-tree changes, tests, workflows, docs, and code. Use as the baseline review skill before domain-specific review skills such as code-review, rust-review, or review-enterprise-flow-tests.
+---
+
+# Review Changes
+
+Use this skill as the review baseline for any diff, pull request, commit range,
+or local change. It owns review mechanics, duplicate-comment handling, finding
+quality, and output format. Apply domain-specific review skills after this
+baseline when the changed files need specialized checks.
+
+## Route Specialized Reviews
+
+- Use this baseline first for every review.
+- Use [`/code-review`](../code-review/SKILL.md) when the change touches C or C
+  headers, including C/C++ module tests that exercise C behavior.
+- Use [`/rust-review`](../rust-review/SKILL.md) when the change touches Rust,
+  Rust docs, Rust tests, FFI crates, or C-to-Rust porting.
+- Use
+  [`/review-enterprise-flow-tests`](../review-enterprise-flow-tests/SKILL.md)
+  when the change touches Redis Enterprise flow tests, `re-tests/`, Enterprise
+  fixtures, lifecycle/profile coverage, or CI workflows that run Enterprise
+  tests.
+- For mixed changes, apply every relevant specialized skill after this baseline.
+
+## Collect Context
+
+- Identify the review target: PR, commit, commit range, path, or working-tree
+  diff. Let specialized skills define language-specific path defaults and diff
+  commands.
+- For a PR, inspect existing PR comments, review threads, and prior bot comments
+  before adding findings.
+- Read full relevant files, not only diff hunks. Include nearby tests, shared
+  fixtures, helper modules, workflow files, and configuration when they affect
+  the changed behavior.
+- Check the PR description when reviewing a PR. Exactly one release-notes
+  checkbox from the repo template must be checked. User-facing behavior changes,
+  bug fixes, performance changes, or new commands require release notes.
+
+## Finding Standards
+
+- Report only actionable, non-duplicate findings.
+- Treat an issue as already reported if an existing comment identifies the same
+  root cause, even if it points to a different line.
+- If a previous comment is still accurate, do not restate it. Mention it only
+  when the new diff changes the issue, invalidates the previous fix, or adds
+  materially new evidence.
+- If the same root cause appears in multiple places, report it once on the
+  clearest example and mention that the same pattern may apply elsewhere.
+- Prioritize correctness, crashes, memory safety, undefined behavior, data loss,
+  security, broken CI, and behavioral regressions.
+- Report style, naming, formatting, or preference comments only when explicitly
+  requested, when an explicit repo rule is violated, or when the issue blocks
+  maintainability. Nits must still be actionable and grouped by root cause.
+- For test or coverage changes, treat removing an assertion, relaxing an oracle,
+  accepting a less restrictive check, or narrowing the scenario matrix as a
+  coverage reduction unless justified otherwise. Do not suggest or accept such
+  changes without explicit rationale and reviewer approval.
+
+## Review Output
+
+For each finding, include:
+
+- Severity: `blocking` or `suggestion`
+- File and line
+- Rule or expectation violated
+- Why it matters
+- Suggested fix
+
+Omit checklist sections with no findings. Do not emit repeated "No issues found"
+sections.
+
+End with a short summary:
+
+- Total blocking findings
+- Total suggestions
+- Whether the change is ready to merge or needs revision

--- a/.skills/review-changes/agents/openai.yaml
+++ b/.skills/review-changes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Changes"
+  short_description: "Review diffs and PRs without duplicate findings."
+  default_prompt: "Use $review-changes to review this diff or PR."

--- a/.skills/review-enterprise-flow-tests/SKILL.md
+++ b/.skills/review-enterprise-flow-tests/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: review-enterprise-flow-tests
+description: Review or implement Redis Enterprise re-tests and CI workflow changes. Use when working on `re-tests/`, Enterprise lifecycle/profile fixtures, Redis Enterprise integration tests, compatibility coverage, or GitHub Actions that run Redis Enterprise tests for PR/nightly validation.
+---
+
+# Review Enterprise Flow Tests
+
+Use this skill for Redis Enterprise flow-test changes, especially `re-tests/`
+fixtures, lifecycle events, survival scenarios, database profiles, and workflows
+that run Enterprise tests.
+
+Treat the checks below as pre-review implementation guidance and as a focused
+review checklist.
+
+First apply [`/review-changes`](../review-changes/SKILL.md) for review target
+handling, duplicate-comment checks, finding quality, nit policy, PR description
+checks, generic test coverage-reduction policy, and output format. Then apply
+the Enterprise-specific checks below.
+
+## First Pass
+
+- Identify whether the change touches a workflow, fixture/plugin registration,
+  database/profile setup, lifecycle event, survival/noise scenario, or assertion
+  oracle.
+- Identify the Enterprise test scenario matrix affected by the change: Redis
+  version, Search module source, topology, DB profile, lifecycle event, auth/TLS
+  mode, or query/index type.
+
+## Enterprise Workflow Checks
+
+- Never run PR-controlled `re-tests` code with secrets, cloud credentials, OIDC
+  roles, Docker logins, private checkout material, or deploy tokens already
+  exposed. Gate untrusted PR triggers before credentialed steps, or run them only
+  on trusted events.
+- For `workflow_dispatch` inputs, remember defaults do not automatically apply
+  to other events. Add explicit env fallbacks for `pull_request`, `push`, and
+  scheduled paths.
+- Keep PR and nightly workflows separate when their scope differs. Use explicit
+  markers or test subsets instead of one overloaded workflow with ambiguous
+  defaults.
+- Keep image tags, node counts, RAMP source selection, and feature-set defaults
+  defined in one place or wired through shared env variables. The workflow,
+  conftest defaults, and README must agree.
+- If an S3/RAMP path downloads artifacts, verify the workflow configures the
+  correct AWS credentials for that path, not only credentials for unrelated
+  setup such as sccache.
+- Ensure log collection follows configurable env/container names and captures
+  all nodes in multi-node clusters.
+- Remove development-only branch triggers, debug comments, and stale TODOs before
+  merge.
+
+## Pytest Fixtures And Imports
+
+- Shared fixtures must be discoverable from the actual pytest invocation. Put
+  shared fixtures in `conftest.py` or register fixture modules with
+  `pytest_plugins`; importing constants from a fixture module is not enough to
+  register its fixtures.
+- Do not make shared fixtures depend on module-local fixtures. If a fixture such
+  as `db` needs `search_module`, that dependency must be shared as well.
+- Avoid plain `import conftest`; use package-qualified helpers or move reusable
+  helper code out of conftest files.
+- Align `pyproject.toml` tooling targets with the CI Python runtime before adding
+  lint or type-check gates. Do not enable strict checks unless the existing tree
+  is already compliant or the gate is scoped to compliant files.
+- Register cleanup as soon as resources can exist. If deploy or DB creation can
+  partially succeed before raising, finalizers must still destroy the cluster or
+  delete any created databases.
+- Continue cleanup after one delete failure and surface unrecoverable cleanup
+  failures instead of only logging them.
+
+## Enterprise API Semantics
+
+- Do not assume OSS Redis commands are valid against Redis Enterprise database
+  endpoints. For RE-managed settings such as persistence, memory quota, eviction
+  policy, and TLS/auth, assert BDB metadata, rladmin state, or shard-level state
+  rather than `CONFIG GET`.
+- Do not create or delete Enterprise ACL users with database-level `ACL SETUSER`
+  or `ACL DELUSER`. Use the RE access-control helpers for users, roles, ACLs,
+  and database role assignment.
+- In bundled-module mode, resolve the Search module by semantic Redis version and
+  feature set. Do not create a DB with an empty module list when tests require
+  `FT.*` commands.
+- For in-place upgrades, distinguish Redis-version upgrades from Search module
+  swaps. A custom module may already be loaded while the Redis version still
+  needs to upgrade.
+- Compare Redis versions semantically, usually at major/minor granularity, when
+  RE exposes patch/build suffixes in one source but normalized values elsewhere.
+- Assert the post-upgrade Redis and Search module versions that the test claims
+  to exercise.
+
+## Lifecycle And Concurrency
+
+- Replace sleeps with deterministic convergence checks when possible: shard
+  counts, slot distribution, module version, lifecycle completion, index
+  readiness, GC counters, or other state-specific signals.
+- Expected lifecycle transients must be narrow and lifecycle-specific. Do not
+  swallow broad `Exception` or every `ResponseError`; distinguish transient
+  proxy/connection errors from real command/query failures.
+- Background readers, writers, and validators must report unexpected exceptions.
+  A test that ignores worker errors can pass without validating the failure
+  window it was written for.
+- Always stop and join worker threads in `finally` blocks. After a timed join,
+  assert no worker is still alive.
+- Validate after the lifecycle completes, not only before or during it.
+- If a tolerated transient can interrupt a multi-step updater, restore or clean
+  transient keys before final validation.
+- When forcing GC, verify the force operation actually succeeded unless the test
+  deliberately and narrowly tolerates that failure.
+- For replica-of tests, wait for the RediSearch index on the replica before
+  searching. Link sync does not guarantee index build completion.
+- For ASM tests, build migration plans after enabling flexible shards and ASM
+  tuning. Do not cache plans before the lifecycle mutates cluster settings.
+
+## Assertion Quality
+
+- Apply the coverage-reduction rule from `/review-changes` especially strictly
+  to Enterprise scenario matrices. Removing a lifecycle event, database profile,
+  topology, auth/TLS mode, Redis/Search version, query/index type, or assertion
+  needs explicit rationale and reviewer approval.
+- Assertions must prove the specific axis under test. Positive defaults are weak
+  oracles: for example, `memory_size > 0` does not prove a quota overlay applied
+  if the default DB is already positive, and a default eviction policy does not
+  prove an eviction-profile override.
+- Prefer non-default profile values, exact expected metadata, or explicit
+  postcondition checks over assertions that would pass without the new config.
+- Tests that claim search survival should verify content and result identities,
+  not only nonzero counts.
+- If updates are meant to exercise TEXT/TAG/vector membership, update documents
+  across those indexed terms; do not repeatedly update only documents that share
+  the same term bucket.
+- Check Redis command return values when they reveal data loss. For example,
+  `HSET` on an existing hash should not silently recreate a lost document.
+- For cursor tests, use a cursor count that forces actual follow-up reads and
+  assert expected read counts or uniqueness when that is the behavior under test.
+- For vector reload/upgrade tests, preserve and compare vector index parameters
+  such as HNSW `M`, `EF_CONSTRUCTION`, and `EF_RUNTIME` when those parameters are
+  part of the contract.
+- For TAG filters containing punctuation such as `sci-fi`, escape according to
+  RediSearch TAG query syntax in every SEARCH or VSIM filter path.
+- Handle the RESP protocol shape used by the existing test client. Do not parse
+  only RESP3 maps if the suite commonly runs through RESP2 list replies.
+
+## Xfail, Skip, And Comments
+
+- Prefer `pytest.mark.xfail(..., raises=AssertionError)` or a narrower exception
+  when the known failure is an assertion mismatch. A broad xfail hides setup,
+  Redis, rladmin, provisioning, and import regressions.
+- Keep new assertions outside an existing xfailed path when they are meant to
+  protect different behavior. Otherwise unrelated failures become expected.
+- Remove stale skips/xfails once the underlying issue has been fixed or prove the
+  failure still reproduces.
+- Do not place raw Jira/PR/conversation context in source comments unless it is a
+  real tracked follow-up such as `TODO(<ticket-id>)`. Put narrative ticket context
+  in the PR description or commit message.
+- Avoid duplicating helper functions that already exist under `re-tests/utils`
+  or rl-automation helpers. Search first, then add one shared helper if needed.
+
+## Review Output
+
+Use the output format from `/review-changes`. Add Enterprise-specific findings
+only when they identify a distinct workflow, fixture, lifecycle, API semantic,
+coverage, or assertion-quality problem.

--- a/.skills/review-enterprise-flow-tests/agents/openai.yaml
+++ b/.skills/review-enterprise-flow-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Enterprise Flow Tests"
+  short_description: "Review Enterprise re-tests and CI workflows."
+  default_prompt: "Use $review-enterprise-flow-tests to review this Redis Enterprise re-tests or CI workflow change."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,6 +322,14 @@ than the finding.
 - If your earlier finding was addressed and the fix draws a new finding in the same hunk, do not post a third variation of the same concern. Say once that the hunk needs a design decision, name the trade-off, and leave it to the human reviewer.
 - Prefer confirming that earlier findings are resolved over finding new material. A re-review that reports nothing is a good outcome.
 
+## Code Review Rules
+
+### Redis Enterprise Flow Tests
+
+For changes under `re-tests/`, Enterprise lifecycle/profile fixtures, or workflows
+that run Enterprise integration tests, apply
+[review-enterprise-flow-tests](.agents/skills/review-enterprise-flow-tests/SKILL.md).
+
 ## Common Workflows
 
 When implementing changes that may become a PR, first check the current checkout. If it is on an


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Enterprise-specific re-tests review criteria are not discoverable from the checked-in agent skill paths on master.
2. Change: Add the Enterprise flow-test review skill, its review-changes baseline dependency, a `.agents/skills` symlink for agent discovery, and a short AGENTS.md rule for relevant diffs.
3. Outcome: Internal-only review agents can consistently apply the Enterprise flow-test checklist when reviewing `re-tests`, Enterprise lifecycle/profile fixtures, and Enterprise integration-test workflows.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. Review skills: add the generic review baseline and Enterprise flow-test review instructions.
2. Agent discovery: expose the Enterprise review skill through `.agents/skills`.
3. AGENTS.md review guidance: direct agents to apply the Enterprise skill for Redis Enterprise flow-test changes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.