### PR TITLE
[MOD-17795] Improve vector index correctness and CPU compatibility

### DIFF
--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -20,8 +20,8 @@ use ffi::{
     QueryRequestTimeoutKind_QUERY_REQUEST_TIMEOUT_UNARMED, VecSearchMode, VecSearchMode_EMPTY_MODE,
     VecSimAlgo_VecSimAlgo_BF, VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex, VecSimIndex_AddVector,
     VecSimIndex_Free, VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine,
-    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
-    t_docId,
+    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQuantType_VecSimQuant_NONE,
+    VecSimQueryParams, VecSimType_VecSimType_FLOAT32, t_docId,
 };
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use top_k::Ascending;
@@ -105,6 +105,8 @@ impl TestIndex {
                     efConstruction: 100,
                     efRuntime: 0,
                     epsilon: 0.0,
+                    quantType: VecSimQuantType_VecSimQuant_NONE,
+                    quantParams: ptr::null(),
                 },
             },
             logCtx: ptr::null_mut(),

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -47,7 +47,8 @@ use ffi::{
     HNSWParams, QueryRequestTimeout, QueryRequestTimeoutKind_QUERY_REQUEST_TIMEOUT_UNARMED,
     VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES, VecSimAlgo_VecSimAlgo_HNSWLIB,
     VecSimIndex, VecSimIndex_AddVector, VecSimIndex_Free, VecSimIndex_New,
-    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
+    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQuantType_VecSimQuant_NONE,
+    VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
 };
 use rqe_iterators::{IdList, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
@@ -102,6 +103,8 @@ unsafe fn make_index(n: usize) -> *mut VecSimIndex {
                 efConstruction: 200,
                 efRuntime: 10,
                 epsilon: 0.01,
+                quantType: VecSimQuantType_VecSimQuant_NONE,
+                quantParams: std::ptr::null(),
             },
         },
         logCtx: std::ptr::null_mut(),


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: RediSearch pins VectorSimilarity before several correctness and CPU-dispatch fixes that precede the tiered-result deduplication change.
2. Change: Advance the dependency through [`5bd11d1e`](https://github.com/RedisAI/VectorSimilarity/commit/5bd11d1e7419953829706625948759734fab49a3) and initialize its new HNSW fields in Rust test and benchmark fixtures, keeping these prerequisite updates separate from MOD-17795 itself.
3. Outcome: Supported UINT8 and HNSW searches receive the upstream correctness fixes, and affected CPUs no longer select unsupported SIMD implementations. RediSearch does not yet expose the new SQ8 HNSW configuration.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. VectorSimilarity dependency — establishes the reviewed baseline immediately before the MOD-17795 fix.
2. Rust VecSim fixtures — select unquantized HNSW defaults for the new parameters.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
