### PR TITLE
[MOD-16709] Disable SonarQube Cloud analysis for this repository

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+# SonarQube Cloud analysis is disabled for this repository.
+# To re-enable it, delete this file.
+
+sonar.exclusions=**/*


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: SonarQube Cloud runs on every PR via org-level automatic analysis, with no repo-side config. Across the 200 most recent PRs it produced 6 inline comments, and 138 of its 150 open alerts on master are in vendored `deps/`.
2. Change: adds `sonar-project.properties` excluding every path, which takes the repo out of analysis. Delete the file to re-enable.
3. Outcome: internal-only, no user-visible change.

#### Which additional issues this PR fixes

1. MOD-16709

#### Main objects this PR modified

1. `sonar-project.properties` (new)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
