### PR TITLE
CI:  Ignore negative lcov errors in coverage capture

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -338,7 +338,7 @@ prepare_coverage_capture() {
   start_group "Code Coverage Preparation"
   lcov --zerocounters      --directory $BINROOT --base-directory $ROOT
   lcov --capture --initial --directory $BINROOT --base-directory $ROOT -o $BINROOT/base.info \
-    --ignore-errors inconsistent,corrupt,mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch,negative \
     --exclude '*/_deps/*'
   end_group
 }
@@ -359,22 +359,23 @@ capture_coverage() {
   # later command re-reads the affected trace file. Demote these to warnings so
   # coverage post-processing doesn't flake the job. 'mismatch' is kept as well to
   # cover lcov versions that classify the same disagreement under that name.
+  # 'negative' covers the same race producing a corrupted (wrapped-negative) hit count.
   lcov --capture --directory $BINROOT --base-directory $ROOT -o $BINROOT/test.info \
-    --ignore-errors inconsistent,corrupt,mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch,negative \
     --exclude '*/_deps/*'
 
   # Accumulate results with the baseline captured before the test
   lcov --add-tracefile $BINROOT/base.info --add-tracefile $BINROOT/test.info -o $BINROOT/full.info \
-    --ignore-errors inconsistent,corrupt,mismatch
+    --ignore-errors inconsistent,corrupt,mismatch,negative
 
   # Extract only the coverage of the project source files
   lcov --output-file $BINROOT/source.info --extract $BINROOT/full.info \
-    --ignore-errors inconsistent,corrupt,mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch,negative \
     "$ROOT/src/*" \
     "$ROOT/deps/thpool/*" \
 
   # Remove coverage for directories we don't want (ignore if no file matches)
-  lcov -o $BINROOT/$NAME.info --ignore-errors inconsistent,corrupt,mismatch,unused --remove $BINROOT/source.info \
+  lcov -o $BINROOT/$NAME.info --ignore-errors inconsistent,corrupt,mismatch,negative,unused --remove $BINROOT/source.info \
     "*/tests/*" \
 
   end_group


### PR DESCRIPTION
## Description

- Nightly Flow's coordinator coverage capture failed with `lcov: ERROR: (negative) Unexpected negative hit count ... deps/VectorSimilarity/.../hnsw_tiered.h:662` while reading `tiered_factory.cpp.gcda` ([run](https://github.com/RediSearch/RediSearch/actions/runs/33555482848/job/100015676386#step:23:6827)).
- Same root cause `build.sh` already documents and tolerates for the milder `inconsistent/corrupt/mismatch` symptoms: concurrent gcov counter writes from the tiered HNSW index's background indexing threads corrupt the `.gcda` file for `tiered_factory.cpp`. `negative` is a more severe symptom of that same race, just not yet in the ignore list, so it stayed fatal.
- Add `negative` to every `--ignore-errors` list in `prepare_coverage_capture()` and `capture_coverage()` in build.sh, consistent with the existing convention of demoting known threaded-gcov corruption to a warning rather than a build failure.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!--
Keep this description skimmable — a reviewer should get the point in ~30 seconds.

- Title: `[MOD-xyz] concise user-facing summary`
- Write for someone who has not read the diff and will not read all of it
- Describe outcomes and behavior, not an implementation play-by-play — the diff
  is authoritative for *how*; this body owns *what* and *why*
- Link the ticket, design doc, or discussion instead of restating background
- Keep every section, including ones that do not apply — write "N/A" instead of
  deleting them
-->