### PR TITLE
Fix off-by-one in FT.PROFILE "Results processed" under early termination

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -80,7 +80,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     double deltaTime = totalRPTime - upstreamTime;
     printProfileTime(deltaTime);
   }
-  printProfileRPCounter(RPProfile_GetCount(rp) - 1);
+  printProfileRPCounter(RPProfile_GetCount(rp));
   // RP_PROFILE appends timing/counter fields to the map opened by its upstream RP.
   // Emit loader field details here so RESP2 keeps Type, Time, Results processed order.
   if (printProfileClock && rp->upstream &&

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -286,7 +286,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/result_processor.h",
-        fns: &["RPProfile_IncrementCount"],
+        fns: &[],
         types: &["RPStatus"],
         vars: &[],
     },

--- a/src/redisearch_rs/result_processor/src/counter.rs
+++ b/src/redisearch_rs/result_processor/src/counter.rs
@@ -41,30 +41,6 @@ impl ResultProcessor for Counter {
             res.clear();
         }
 
-        // In profiling mode, RPProfile is interleaved into the result processor chain: A chain of
-        // processors A -> B -> C becomes A -> RPProfile -> B -> RPProfile -> C -> RPProfile, to
-        // profile each of the individual result processors.
-        //
-        // Because the Counter result processor returns Ok(None), this is equivalent to returning
-        // ffi::RPStatus_RS_RESULT_EOF (see ResultProcessorWrapper::result_processor_next). This
-        // apparently (in a way enricozb cannot figure out) prevents the very last RPProfile from
-        // appropriately counting, so this patches that by manually incrementing the counter.
-        if upstream.ty() == ffi::ResultProcessorType_RP_PROFILE {
-            // Safety: We trust that the result processor parent structure (QueryProcessingCtx) was
-            // constructed correctly, and thus has a valid pointer to the end processor.
-            let end_proc = unsafe {
-                *cx.parent()
-                    .expect("This processor has no parent.")
-                    .endProc
-                    .get()
-            };
-
-            // Safety: If the previous (upstream) result processor is a profiling result processor,
-            // then we are in profiling mode, and every other result processor is an RPProfile.
-            // Thus, the last result processor is also an RPProfile.
-            unsafe { ffi::RPProfile_IncrementCount(end_proc) };
-        }
-
         Ok(None)
     }
 }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1690,7 +1690,11 @@ static int rpprofileNext(ResultProcessor *base, SearchResult *r) {
   rs_wall_clock_init(&start);
   int rc = base->upstream->Next(base->upstream, r);
   self->profileTime += rs_wall_clock_elapsed_ns(&start);
-  self->profileCount++;
+  // Count the results the upstream processor yielded, rather than the calls made to it. A call that
+  // ends the stream (EOF), or that fails, yielded nothing and must not be counted.
+  if (rc == RS_RESULT_OK) {
+    self->profileCount++;
+  }
   return rc;
 }
 
@@ -1725,11 +1729,6 @@ rs_wall_clock_ns_t RPProfile_GetTime(ResultProcessor *rp) {
 uint64_t RPProfile_GetCount(ResultProcessor *rp) {
   RPProfile *self = (RPProfile *)rp;
   return self->profileCount;
-}
-
-void RPProfile_IncrementCount(ResultProcessor *rp) {
-  RPProfile *self = (RPProfile *)rp;
-  self->profileCount++;
 }
 
 void Profile_AddRPs(QueryProcessingCtx *qctx) {

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -246,7 +246,6 @@ ResultProcessor *RPProfile_New(ResultProcessor *rp, QueryProcessingCtx *qctx);
 
 rs_wall_clock_ns_t RPProfile_GetTime(ResultProcessor *rp);
 uint64_t RPProfile_GetCount(ResultProcessor *rp);
-void RPProfile_IncrementCount(ResultProcessor *rp);
 
 void Profile_AddRPs(QueryProcessingCtx *qctx);
 

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -397,20 +397,20 @@ def _test_profile(protocol):
 
         # WITHCOUNT + LIMIT 0 0
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LIMIT', 0, 0],
-         [('Index', 3100), ('Counter', 1)],
+         [('Index', 3100), ('Counter', 0)],
          [[[('Index', 1027), ('Depleter', 1027)],
            [('Index', 1032), ('Depleter', 1032)],
            [('Index', 1041), ('Depleter', 1041)]],
-           [('Network', 3100), ('Counter', 1)]]),
+           [('Network', 3100), ('Counter', 0)]]),
 
         # WITHCOUNT + LIMIT
         # No sorter, limit results
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LIMIT', 0, 50],
-         [('Index', 3100), ('Depleter', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 1027), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1032), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1041), ('Depleter', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 3100), ('Depleter', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 1027), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1032), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1041), ('Depleter', 50), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Depleter', 50), ('Pager/Limiter', 50)]]),
 
         # WITHCOUNT + SORTBY 0
         # Sorter without keys, default limit
@@ -423,19 +423,19 @@ def _test_profile(protocol):
 
         # WITHCOUNT + SORTBY 0 + MAX
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', '0', 'MAX', 3],
-         [('Index', 3100), ('Depleter', 2), ('Pager/Limiter', 3)],
-         [[[('Index', 1027), ('Depleter', 2), ('Pager/Limiter', 3)],
-           [('Index', 1032), ('Depleter', 2), ('Pager/Limiter', 3)],
-           [('Index', 1041), ('Depleter', 2), ('Pager/Limiter', 3)]],
-           [('Network', 9), ('Depleter', 2), ('Pager/Limiter', 3)]]),
+         [('Index', 3100), ('Depleter', 3), ('Pager/Limiter', 3)],
+         [[[('Index', 1027), ('Depleter', 3), ('Pager/Limiter', 3)],
+           [('Index', 1032), ('Depleter', 3), ('Pager/Limiter', 3)],
+           [('Index', 1041), ('Depleter', 3), ('Pager/Limiter', 3)]],
+           [('Network', 9), ('Depleter', 3), ('Pager/Limiter', 3)]]),
 
         # WITHCOUNT + SORTBY 0 + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', '0', 'LIMIT', 0, 50],
-         [('Index', 3100), ('Depleter', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 1027), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1032), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1041), ('Depleter', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 3100), ('Depleter', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 1027), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1032), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1041), ('Depleter', 50), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Depleter', 50), ('Pager/Limiter', 50)]]),
 
         # WITHCOUNT + SORTBY
         # Sorter, limit results to DEFAULT_LIMIT
@@ -472,11 +472,11 @@ def _test_profile(protocol):
 
         # WITHCOUNT + LOAD + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@title', 'LIMIT', 0, 50],
-         [('Index', 3100), ('Loader', 3100), ('Depleter', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 1027), ('Loader', 1027), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1032), ('Loader', 1032), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1041), ('Loader', 1041), ('Depleter', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 3100), ('Loader', 3100), ('Depleter', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 1027), ('Loader', 1027), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1032), ('Loader', 1032), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1041), ('Loader', 1041), ('Depleter', 50), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Depleter', 50), ('Pager/Limiter', 50)]]),
 
         # WITHCOUNT + GROUPBY
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'GROUPBY', 1, '@brand'],
@@ -504,11 +504,11 @@ def _test_profile(protocol):
 
         # WITHCOUNT + GROUPBY + LIMIT (stop calling before EOF)
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'GROUPBY', 1, '@brand', 'LIMIT', 0, 25],
-         [('Index', 3100), ('Grouper', 24), ('Pager/Limiter', 25)],
+         [('Index', 3100), ('Grouper', 25), ('Pager/Limiter', 25)],
          [[[('Index', 1027), ('Grouper', 25)],
            [('Index', 1032), ('Grouper', 25)],
            [('Index', 1041), ('Grouper', 25)]],
-           [('Network', 75), ('Grouper', 24), ('Pager/Limiter', 25)]]),
+           [('Network', 75), ('Grouper', 25), ('Pager/Limiter', 25)]]),
 
         # WITHCOUNT + GROUPBY + SORTBY + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'GROUPBY', 1, '@brand', 'SORTBY', 1, '@brand', 'LIMIT', 0, 50],
@@ -536,11 +536,11 @@ def _test_profile(protocol):
 
         # WITHCOUNT + ADDSCORES + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'ADDSCORES', 'LIMIT', 0, 50],
-         [('Index', 3100), ('Scorer', 3100), ('Depleter', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 1027), ('Scorer', 1027), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1032), ('Scorer', 1032), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1041), ('Scorer', 1041), ('Depleter', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 3100), ('Scorer', 3100), ('Depleter', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 1027), ('Scorer', 1027), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1032), ('Scorer', 1032), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1041), ('Scorer', 1041), ('Depleter', 50), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Depleter', 50), ('Pager/Limiter', 50)]]),
 
         # WITHCOUNT + FILTER
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@price', 'FILTER', '@price < 200'],
@@ -552,11 +552,11 @@ def _test_profile(protocol):
 
         # WITHCOUNT + FILTER + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@price', 'FILTER', '@price < 200', 'LIMIT', 0, 50],
-         [('Index', 3100), ('Loader', 3100), ('Filter - Predicate <', 200), ('Depleter', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 1027), ('Loader', 1027), ('Filter - Predicate <', 64), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1032), ('Loader', 1032), ('Filter - Predicate <', 68), ('Depleter', 49), ('Pager/Limiter', 50)],
-           [('Index', 1041), ('Loader', 1041), ('Filter - Predicate <', 68), ('Depleter', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 3100), ('Loader', 3100), ('Filter - Predicate <', 200), ('Depleter', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 1027), ('Loader', 1027), ('Filter - Predicate <', 64), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1032), ('Loader', 1032), ('Filter - Predicate <', 68), ('Depleter', 50), ('Pager/Limiter', 50)],
+           [('Index', 1041), ('Loader', 1041), ('Filter - Predicate <', 68), ('Depleter', 50), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Depleter', 50), ('Pager/Limiter', 50)]]),
 
         # WITHCOUNT + SORTBY -> GROUPBY
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title',
@@ -648,19 +648,19 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LIMIT', 0, 50],
-         [('Index', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)]],
-           [('Network', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Pager/Limiter', 50)]],
+           [('Network', 50), ('Pager/Limiter', 50)]]),
 
          # WITHOUTCOUNT (implicit) + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 50],
-         [('Index', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)]],
-           [('Network', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Pager/Limiter', 50)]],
+           [('Network', 50), ('Pager/Limiter', 50)]]),
 
         # WITHOUTCOUNT + SORTBY 0
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', '0'],
@@ -672,16 +672,16 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + SORTBY 0 + MAX
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', '0', 'MAX', 3],
-         [('Index', 2), ('Pager/Limiter', 3)],
-         [[[('Index', 2), ('Pager/Limiter', 3)],
-           [('Index', 2), ('Pager/Limiter', 3)],
-           [('Index', 2), ('Pager/Limiter', 3)]],
-           [('Network', 2), ('Pager/Limiter', 3)]]),
+         [('Index', 3), ('Pager/Limiter', 3)],
+         [[[('Index', 3), ('Pager/Limiter', 3)],
+           [('Index', 3), ('Pager/Limiter', 3)],
+           [('Index', 3), ('Pager/Limiter', 3)]],
+           [('Network', 3), ('Pager/Limiter', 3)]]),
 
         # WITHOUTCOUNT + SORTBY 0 + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', '0', 'LIMIT', 0, 50],
-         [('Index', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 49), ('Pager/Limiter', 50)], [('Index', 49), ('Pager/Limiter', 50)], [('Index', 49), ('Pager/Limiter', 50)]], [('Network', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 50), ('Pager/Limiter', 50)], [('Index', 50), ('Pager/Limiter', 50)], [('Index', 50), ('Pager/Limiter', 50)]], [('Network', 50), ('Pager/Limiter', 50)]]),
 
         # WITHOUTCOUNT + SORTBY
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', '1', '@title'],
@@ -709,11 +709,11 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + GROUPBY + LIMIT (stop calling before EOF)
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'GROUPBY', 1, '@brand', 'LIMIT', 0, 25],
-         [('Index', 3100), ('Grouper', 24), ('Pager/Limiter', 25)],
+         [('Index', 3100), ('Grouper', 25), ('Pager/Limiter', 25)],
          [[[('Index', 1027), ('Grouper', 25)],
            [('Index', 1032), ('Grouper', 25)],
            [('Index', 1041), ('Grouper', 25)]],
-           [('Network', 75), ('Grouper', 24), ('Pager/Limiter', 25)]]),
+           [('Network', 75), ('Grouper', 25), ('Pager/Limiter', 25)]]),
 
          # WITHOUTCOUNT + LOAD
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@title'],
@@ -773,11 +773,11 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + ADDSCORES + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'ADDSCORES', 'LIMIT', 0, 50],
-         [('Index', 49), ('Scorer', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 49), ('Scorer', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Scorer', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Scorer', 49), ('Pager/Limiter', 50)]],
-           [('Network', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 50), ('Scorer', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 50), ('Scorer', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Scorer', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Scorer', 50), ('Pager/Limiter', 50)]],
+           [('Network', 50), ('Pager/Limiter', 50)]]),
 
         # WITHOUTCOUNT + FILTER
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@price', 'FILTER', '@price < 200'],
@@ -789,16 +789,16 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + FILTER + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@price', 'FILTER', '@price < 200', 'LIMIT', 0, 50],
-         [('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)],
-         [[[('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)]],
-           [('Network', 49), ('Pager/Limiter', 50)]]),
+         [('Index', 50), ('Loader', 50), ('Filter - Predicate <', 50), ('Pager/Limiter', 50)],
+         [[[('Index', 50), ('Loader', 50), ('Filter - Predicate <', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Loader', 50), ('Filter - Predicate <', 50), ('Pager/Limiter', 50)],
+           [('Index', 50), ('Loader', 50), ('Filter - Predicate <', 50), ('Pager/Limiter', 50)]],
+           [('Network', 50), ('Pager/Limiter', 50)]]),
 
         # WITHOUTCOUNT + SORTBY + MAX -> GROUPBY
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
           'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
-         [('Index', 49), ('Pager/Limiter', 50), ('Grouper', 25)],
+         [('Index', 50), ('Pager/Limiter', 50), ('Grouper', 25)],
          [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
            [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
            [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
@@ -819,7 +819,7 @@ def _test_profile(protocol):
           'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
           'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
           'FILTER', '@cnt > 5'],
-         [('Index', 199), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
+         [('Index', 200), ('Loader', 200), ('Pager/Limiter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
          [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
            [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -178,7 +178,7 @@ def testOptimizer(env):
                         ['Type', 'NUMERIC', 'Term', '0 - 14', 'Number of reading operations', 19, 'Estimated number of matches', 3200],
                         ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 13, 'Estimated number of matches', 10000]]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
     env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
@@ -217,7 +217,7 @@ def testOptimizer(env):
     profiler =  {'Iterators profile':
                     ['Type', 'NUMERIC', 'Term', '0 - 14', 'Number of reading operations', 10, 'Estimated number of matches', 3200],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
     env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
@@ -301,7 +301,7 @@ def testOptimizer(env):
     profiler =  {'Iterators profile':
                     ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 10, 'Estimated number of matches', 10000],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
     env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
@@ -341,7 +341,7 @@ def testOptimizer(env):
     profiler =  {'Iterators profile':
                     ['Type', 'WILDCARD', 'Number of reading operations', 10],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
     env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -613,8 +613,9 @@ def testResultProcessorCounter(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
   env.assertEqual(actual_res[0], [2])
+  # The counter swallows every result it is given and yields none of its own, so it reports zero.
   res = [['Type', 'Index', 'Results processed', 2],
-         ['Type', 'Counter', 'Results processed', 1]]
+         ['Type', 'Counter', 'Results processed', 0]]
   env.assertEqual(actual_res[1][1][0][5], res)
 
 @skip(cluster=True)


### PR DESCRIPTION
Okay so I believe I just found out what is essentially a bug (probably unintended, an oversight) in the process of writing some tests with assertions against `Results processed` counts.

## Describe the changes in the pull request

1. **Current:** `FT.PROFILE` reports `Results processed` one lower than the truth for whichever result processor is short-circuited by a downstream one. `FT.PROFILE idx AGGREGATE QUERY '*' LIMIT 0 1 LOAD 1 $` over a populated index reports `Index` → `0`, while the loader behind it reports `1` and the document is returned.
2. **Change:** `rpprofileNext` counts the results the upstream yielded (`RS_RESULT_OK`) rather than the calls made to it, and `_recursiveProfilePrint` no longer subtracts one.
3. **Outcome:** every processor's `Results processed` equals what it passed on, whether or not the pipeline drains. `RPProfile_IncrementCount` and its one caller go away, being a workaround for this same defect.

#### Which additional issues this PR fixes

None filed; found while comparing `Number of reading operations` against `Results processed` on windowed queries.

#### Main objects this PR modified

1. **`src/result_processor.c`**: `rpprofileNext` increments only on `RS_RESULT_OK`. `RPProfile_IncrementCount` deleted.
2. **`src/profile/profile.c`**: `printProfileRPCounter(RPProfile_GetCount(rp) - 1)` → `printProfileRPCounter(RPProfile_GetCount(rp))`.
3. **`src/redisearch_rs/result_processor/src/counter.rs`**: the manual increment and its `unsafe` block deleted; **`ffi/build.rs`** drops the now-unused binding.
4. **`tests/pytests/`**: expectations that encoded the old values, standalone and cluster.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

`FT.PROFILE` output changes, but only where it was wrong. No command surface, persisted state or replicated state is touched.

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Anyone asserting on `Results processed` for a query with a `LIMIT` sees those numbers increase by one, and `Counter` drop from 1 to 0.

---

### The defect

`rpprofileNext` counted every call, EOF included:

```c
int rc = base->upstream->Next(base->upstream, r);
self->profileTime += rs_wall_clock_elapsed_ns(&start);
self->profileCount++;              // every call, whatever rc was
```

and the printer removed one to discount that EOF call:

```c
printProfileRPCounter(RPProfile_GetCount(rp) - 1);
```

Together those are correct only when the pipeline runs to exhaustion, where `calls = results + 1`. A `Pager/Limiter` that has filled its window returns EOF to its own caller **without** calling upstream again, so `calls = results` and the subtraction removes a real result.

Measured on 20 documents, before this change:

| query | iterator read | `Index` reported |
|---|---|---|
| no limit | 20 | 20 |
| `LIMIT 0 100` (never fills) | 20 | 20 |
| `LIMIT 0 20` (fills at the last) | 20 | **19** |
| `LIMIT 2 3` | 5 | **4** |
| `LIMIT 0 1` | 1 | **0** |
| `SORTBY … MAX 3` (drains, no early stop) | 20 | 20 |

`LIMIT 0 1` is the clearest case: `Index` claims to have emitted nothing, while the `Threadsafe-Loader` behind it reports 1 and the document comes back. After the change every row above matches the iterator.

It is not specific to `Index`, it lands on whichever processor is short-circuited. With `SORTBY … LIMIT 2 1` over 5 documents the sorter must hand the pager 3 results for it to skip 2 and emit 1, and the sorter reported 2.

### Why `RPProfile_IncrementCount` goes

It was introduced to correct this EXACT off-by-one bug for `Counter`, and its comment says as much:

> Because the Counter result processor returns `Ok(None)` … this apparently (in a way enricozb cannot figure out) prevents the very last RPProfile from appropriately counting, so this patches that by manually incrementing the counter.

The cause was the unconditional `- 1`. With counting fixed the workaround is not just unnecessary but wrong: `Counter` swallows every result and yields none, so it reports `0`, consistent with every other processor that emits nothing. `tests/pytests/test_profile.py:testResultProcessorCounter` and the `WITHCOUNT + LIMIT 0 0` case in `test_aggregate_count.py` are updated accordingly; this is the one expectation change that is not simply `n → n+1`, and the one worth a reviewer's attention.

### Testing

Built `DEBUG=1` and run against `master` as a control, standalone and OSS-cluster (3 shards):

| suite | baseline | with this change |
|---|---|---|
| `test_profile.py` | 1 failed / 48 | 1 failed / 48 |
| `test_optimizer.py` | 1 failed / 15 | 1 failed / 15 |
| `test_resp3.py` | 0–1 failed / 38 | 0–1 failed / 38 |
| `test_aggregate_count.py` | 1 failed / 12 | 1 failed / 12 |
| `RUN_UNIT_TESTS` | 3 failed / 859 | 3 failed / 859 |
| `cargo nextest` (workspace) | — | 3453 passed / 3453 |

Every remaining failure reproduces on unmodified `master`: `IORuntimeCtxCommonTest.UpdateNodes*` segfault in the C unit tests, and one flaky `Index already exists` per Python file that lands on a different test each run (`test_resp3.py` was run three times each way to establish that). `make lint` and `make fmt CHECK=1` are clean.
