### PR TITLE
[MOD-8666] Fix FT.EXPLAIN showing a multi-word tag value as an INTERSECT

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -798,6 +798,20 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   return NewUnionIterator(its, itsSz, true, weight, QN_WILDCARD_QUERY, qn->pfx.tok.str, q->config);
 }
 
+// Appends the words of `phrase` joined by single spaces, writing the `emptyWord` argument in
+// place of any zero-length word.
+static sds tagPhraseAppendValue(sds buf, const QueryNode *phrase, const char *emptyWord) {
+  for (size_t i = 0; i < QueryNode_NumChildren(phrase); ++i) {
+    const QueryNode *word = phrase->children[i];
+    RS_ASSERT(word->type == QN_TOKEN);
+    if (word->type != QN_TOKEN)
+      continue;  // never reachable from query syntax; keeps release builds safe
+    if (i > 0) buf = sdscatlen(buf, " ", 1);
+    buf = sdscat(buf, word->tn.len ? word->tn.str : emptyWord);
+  }
+  return buf;
+}
+
 static QueryIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, QueryNode *n,
                                               double weight, const FieldSpec *fs) {
   QueryIterator *ret = NULL;
@@ -825,15 +839,11 @@ static QueryIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
 
     case QN_PHRASE: {
-      char *terms[QueryNode_NumChildren(n)];
       for (size_t i = 0; i < QueryNode_NumChildren(n); ++i) {
-        // tag phrase children are always tokens from query syntax
-        RS_ASSERT(n->children[i]->type == QN_TOKEN);
         tag_strtolower(&(n->children[i]->tn.str), &n->children[i]->tn.len, caseSensitive);
-        terms[i] = n->children[i]->tn.str;
       }
 
-      sds s = sdsjoin(terms, QueryNode_NumChildren(n), " ");
+      sds s = tagPhraseAppendValue(sdsempty(), n, "");
 
       ret = TagIndex_OpenReader(idx, q->sctx, s, sdslen(s), effective_weight, fs->index, q->status);
       sdsfree(s);
@@ -1373,7 +1383,16 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       break;
     case QN_TAG:
       s = sdscatprintf(s, "TAG:@%s {\n", HiddenString_GetUnsafe(qs->tag.fs->fieldName, NULL));
-      s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
+      for (size_t ii = 0; ii < QueryNode_NumChildren(qs); ++ii) {
+        const QueryNode *child = qs->children[ii];
+        if (child->type == QN_PHRASE) {
+          s = doPad(s, depth + 1);
+          s = tagPhraseAppendValue(s, child, "\"\"");
+          s = sdscat(s, "\n");
+        } else {
+          s = QueryNode_DumpSds(s, spec, child, depth + 1);
+        }
+      }
       s = doPad(s, depth);
       s = sdscat(s, "}");
       break;

--- a/src/query.c
+++ b/src/query.c
@@ -805,7 +805,7 @@ static sds tagPhraseAppendValue(sds buf, const QueryNode *phrase, const char *em
     const QueryNode *word = phrase->children[i];
     RS_ASSERT(word->type == QN_TOKEN);
     if (word->type != QN_TOKEN)
-      continue;  // never reachable from query syntax; keeps release builds safe
+      continue;  // LCOV_EXCL_LINE — never reachable from query syntax; keeps release builds safe
     if (i > 0) buf = sdscatlen(buf, " ", 1);
     buf = sdscat(buf, word->tn.len ? word->tn.str : emptyWord);
   }

--- a/src/query.c
+++ b/src/query.c
@@ -804,10 +804,8 @@ static sds tagPhraseAppendValue(sds buf, const QueryNode *phrase, const char *em
   for (size_t i = 0; i < QueryNode_NumChildren(phrase); ++i) {
     const QueryNode *word = phrase->children[i];
     RS_ASSERT(word->type == QN_TOKEN);
-    if (word->type != QN_TOKEN)
-      continue;  // LCOV_EXCL_LINE — never reachable from query syntax; keeps release builds safe
     if (i > 0) buf = sdscatlen(buf, " ", 1);
-    buf = sdscat(buf, word->tn.len ? word->tn.str : emptyWord);
+    buf = word->tn.len ? sdscatlen(buf, word->tn.str, word->tn.len) : sdscat(buf, emptyWord);
   }
   return buf;
 }

--- a/src/redisearch_rs/query_eval/tests/integration/tag.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/tag.rs
@@ -1295,6 +1295,18 @@ fn eval_tag_phrase_child_truncates_a_token_at_a_nul() {
     );
 }
 
+#[test]
+fn eval_tag_phrase_child_treats_an_empty_token_as_a_zero_length_word() {
+    let values = values(&[(b"foo ", &[1]), (b"foo", &[2])]);
+    let mut fixture = TagFixture::new(TagOptions {
+        values,
+        children: vec![Child::Phrase(&[b"foo", b""])],
+        ..TagOptions::default()
+    });
+    let mut it = fixture.eval().expect("\"foo \" is indexed");
+    assert_eq!(drain_doc_ids(&mut it), vec![1]);
+}
+
 // ---------------------------------------------------------------------------
 // Escapes, case and binary values
 // ---------------------------------------------------------------------------

--- a/src/redisearch_rs/query_eval/tests/integration/tag.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/tag.rs
@@ -45,12 +45,12 @@ type Indexed = (Vec<u8>, Vec<DocId>);
 const TAG_APPLE: &[u8] = b"apple"; // docs 1, 2
 const TAG_APRICOT: &[u8] = b"apricot"; // docs 2, 3 -- doc 2 is the overlap
 const TAG_BANANA: &[u8] = b"banana"; // docs 3, 4
-const TAG_PHRASE: &[u8] = b"red apple"; // doc 5 -- the `sdsjoin` target
+const TAG_PHRASE: &[u8] = b"red apple"; // doc 5 -- the phrase-join target
 const TAG_BINARY: &[u8] = b"caf\xff"; // doc 6 -- 0xff appears in no UTF-8 sequence
 const TAG_NUL: &[u8] = b"ab\0cd"; // doc 7
 const TAG_NUL_HEAD: &[u8] = b"ab"; // doc 8 -- what a truncated lookup of TAG_NUL hits
-const TAG_NUL_PHRASE_JOINED: &[u8] = b"ab x"; // doc 9 -- what `sdsjoin` builds from TAG_NUL
-const TAG_NUL_PHRASE_WHOLE: &[u8] = b"ab\0cd x"; // doc 10 -- what a binary-safe join would build
+const TAG_NUL_PHRASE_JOINED: &[u8] = b"ab x"; // doc 9 -- what a strlen-based join would build from TAG_NUL
+const TAG_NUL_PHRASE_WHOLE: &[u8] = b"ab\0cd x"; // doc 10 -- what the length-based join builds
 // doc 11 -- the value production indexes for an empty tag field, and the only
 // one the empty wildcard pattern can reach.
 const TAG_EMPTY: &[u8] = b"";
@@ -1279,7 +1279,7 @@ fn eval_tag_phrase_child_joins_its_tokens_with_a_space() {
 }
 
 #[test]
-fn eval_tag_phrase_child_truncates_a_token_at_a_nul() {
+fn eval_tag_phrase_child_keeps_a_token_past_a_nul() {
     let values = values(&[(TAG_NUL_PHRASE_JOINED, &[9]), (TAG_NUL_PHRASE_WHOLE, &[10])]);
     let mut fixture = TagFixture::new(TagOptions {
         values,
@@ -1287,12 +1287,8 @@ fn eval_tag_phrase_child_truncates_a_token_at_a_nul() {
         children: vec![Child::Phrase(&[TAG_NUL, b"x"])],
         ..TagOptions::default()
     });
-    let mut it = fixture.eval().expect("the truncated join is indexed");
-    assert_eq!(
-        drain_doc_ids(&mut it),
-        vec![9],
-        "sdsjoin is strlen-based, even though no lowering step ran"
-    );
+    let mut it = fixture.eval().expect("the whole join is indexed");
+    assert_eq!(drain_doc_ids(&mut it), vec![10]);
 }
 
 #[test]
@@ -1404,7 +1400,7 @@ fn eval_tag_lowercases_the_query_on_a_case_insensitive_field() {
 // `tag_strtolower` is called once per branch, not once ahead of the dispatch:
 // `Query_EvalTagPrefixNode` and `Query_EvalTagWildcardNode` each call it on
 // their own pattern, and the phrase case calls it on each child before the
-// `sdsjoin`. [`eval_tag_lowercases_the_query_on_a_case_insensitive_field`]
+// join. [`eval_tag_lowercases_the_query_on_a_case_insensitive_field`]
 // above only exercises the `Token` branch's call -- every other pattern used
 // so far is already lowercase, so a port that dropped lowering from one of
 // the other three would still pass unnoticed. The three tests below give

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -976,63 +976,30 @@ def testEmptyExplainCli():
         env.assertEqual(res, expected)
 
         res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{foo ""}')
-        if dialect < 5:
-            expected = [
-                'TAG:@tag {',
-                '  INTERSECT {',
-                '    foo',
-                '    ""',
-                '  }',
-                '}',
-                ''
-            ]
-        else:
-            expected = [
-                'TAG:@tag {',
-                '  foo ""',
-                '}',
-                ''
-            ]
+        expected = [
+            'TAG:@tag {',
+            '  foo ""',
+            '}',
+            ''
+        ]
         env.assertEqual(res, expected)
 
         res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{"" bar}')
-        if dialect < 5:
-            expected = [
-                'TAG:@tag {',
-                '  INTERSECT {',
-                '    ""',
-                '    bar',
-                '  }',
-                '}',
-                ''
-            ]
-        else:
-            expected = [
-                'TAG:@tag {',
-                '  "" bar',
-                '}',
-                ''
-            ]
+        expected = [
+            'TAG:@tag {',
+            '  "" bar',
+            '}',
+            ''
+        ]
         env.assertEqual(res, expected)
 
         res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{"" ""}')
-        if dialect < 5:
-            expected = [
-                'TAG:@tag {',
-                '  INTERSECT {',
-                '    ""',
-                '    ""',
-                '  }',
-                '}',
-                ''
-            ]
-        else:
-            expected = [
-                'TAG:@tag {',
-                '  "" ""',
-                '}',
-                ''
-            ]
+        expected = [
+            'TAG:@tag {',
+            '  "" ""',
+            '}',
+            ''
+        ]
         env.assertEqual(res, expected)
 
         # # ------------------------------ TEXT field ----------------------------
@@ -1194,6 +1161,34 @@ def testEmptyExplainCli():
             ''
         ]
         env.assertEqual(res, expected)
+
+@skip(no_json=True)
+def testTagPhraseWithEmptyWordSearch():
+    """An empty word inside a tag phrase such as {foo ""} is a zero-length segment of the
+    joined tag value that gets looked up; hash indexing trims leading/trailing whitespace
+    of a tag value, while a JSON tag field with the default separator does not."""
+
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    # ------------------------------ HASH field -----------------------------
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'INDEXEMPTY').ok()
+    conn.execute_command('HSET', 'h1', 't', 'foo ')
+    conn.execute_command('HSET', 'h2', 't', 'foo  bar')
+
+    env.expect('FT.SEARCH', 'idx', '@t:{foo ""}', 'NOCONTENT').equal([0])
+    env.expect('FT.SEARCH', 'idx', '@t:{foo "" bar}', 'NOCONTENT').equal([1, 'h2'])
+    env.expect('FT.EXPLAIN', 'idx', '@t:{foo "" bar}').equal(r'''
+TAG:@t {
+  foo "" bar
+}
+'''[1:])
+
+    # ------------------------------ JSON field -----------------------------
+    env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TAG', 'INDEXEMPTY').ok()
+    env.expect('JSON.SET', 'j1', '$', '{"t":"foo "}').equal('OK')
+
+    env.expect('FT.SEARCH', 'jidx', '@t:{foo ""}', 'NOCONTENT').equal([1, 'j1'])
 
 def testInvalidUseOfEmptyString():
     """Tests that invalid syntax for empty values is rejected by the parser"""

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1162,16 +1162,15 @@ def testEmptyExplainCli():
         ]
         env.assertEqual(res, expected)
 
-@skip(no_json=True)
+@skip(cluster=True)
 def testTagPhraseWithEmptyWordSearch():
     """An empty word inside a tag phrase such as {foo ""} is a zero-length segment of the
-    joined tag value that gets looked up; hash indexing trims leading/trailing whitespace
-    of a tag value, while a JSON tag field with the default separator does not."""
+    joined value, and hash indexing trims edge whitespace, so {foo ""} matches nothing but
+    {foo "" bar} matches a stored 'foo  bar'."""
 
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
-    # ------------------------------ HASH field -----------------------------
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'INDEXEMPTY').ok()
     conn.execute_command('HSET', 'h1', 't', 'foo ')
     conn.execute_command('HSET', 'h2', 't', 'foo  bar')
@@ -1184,9 +1183,16 @@ TAG:@t {
 }
 '''[1:])
 
-    # ------------------------------ JSON field -----------------------------
+@skip(cluster=True, no_json=True)
+def testTagPhraseWithEmptyWordSearchJSON():
+    """A JSON tag field with the default separator is not trimmed, so {foo ""} matches a
+    stored value of 'foo '."""
+
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
     env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TAG', 'INDEXEMPTY').ok()
-    env.expect('JSON.SET', 'j1', '$', '{"t":"foo "}').equal('OK')
+    conn.execute_command('JSON.SET', 'j1', '$', '{"t":"foo "}')
 
     env.expect('FT.SEARCH', 'jidx', '@t:{foo ""}', 'NOCONTENT').equal([1, 'j1'])
 

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -691,6 +691,7 @@ TAG:@tag {
     env.expect('FT.SEARCH', 'custom_idx', '@tag:{foo bar}', 'NOCONTENT').equal([1, 'doc5'])
     env.expect('FT.SEARCH', 'idx', '@tag:{cat foo dog}', 'NOCONTENT').equal([1, 'doc7'])
 
+@skip(cluster=True)
 def testTagExplainPhrase_MOD8666():
     """A tag phrase such as {bar foo} is a single tag value made of two words, not an
     intersection of two values; FT.EXPLAIN must match how the query is actually evaluated."""

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -666,13 +666,7 @@ def testTagQueryWithStopwords_V2():
     conn.execute_command('HSET', 'doc2', 'tag', 'as,is,the,with,by')
     env.expect('FT.EXPLAIN', 'idx', '@tag:{as is the with by}').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    as
-    is
-    the
-    with
-    by
-  }
+  as is the with by
 }
 '''[1:])
     env.expect('FT.SEARCH', 'idx', '@tag:{as is the with by}', 'NOCONTENT').equal([1, 'doc1'])
@@ -681,11 +675,7 @@ TAG:@tag {
     conn.execute_command('HSET', 'doc4', 'tag', 'cat with dog')
     env.expect('FT.EXPLAIN', 'idx', '@tag:{cat with dog}').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    cat
-    with
-    dog
-  }
+  cat with dog
 }
 '''[1:])
     env.expect('FT.SEARCH', 'idx', '@tag:{cat with dog}', 'NOCONTENT').equal([1, 'doc4'])
@@ -695,14 +685,43 @@ TAG:@tag {
     conn.execute_command('HSET', 'doc7', 'tag', 'cat foo dog')
     env.expect('FT.EXPLAIN', 'custom_idx', '@tag:{foo bar}').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    foo
-    bar
-  }
+  foo bar
 }
 '''[1:])
     env.expect('FT.SEARCH', 'custom_idx', '@tag:{foo bar}', 'NOCONTENT').equal([1, 'doc5'])
     env.expect('FT.SEARCH', 'idx', '@tag:{cat foo dog}', 'NOCONTENT').equal([1, 'doc7'])
+
+def testTagExplainPhrase_MOD8666():
+    """A tag phrase such as {bar foo} is a single tag value made of two words, not an
+    intersection of two values; FT.EXPLAIN must match how the query is actually evaluated."""
+    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:1', 't', 'bar')
+    conn.execute_command('HSET', 'doc:2', 't', 'foo')
+    conn.execute_command('HSET', 'doc:3', 't', 'bar,foo')
+    conn.execute_command('HSET', 'doc:4', 't', 'bar foo')
+
+    expected = r'''
+TAG:@t {
+  bar foo
+}
+'''[1:]
+    env.expect('FT.EXPLAIN', 'idx', '@t:{bar foo}').equal(expected)
+    env.expect('FT.EXPLAIN', 'idx', '@t:{"bar foo"}').equal(expected)
+    env.expect('FT.SEARCH', 'idx', '@t:{bar foo}', 'NOCONTENT').equal([1, 'doc:4'])
+    env.expect('FT.EXPLAIN', 'idx', '@t:{$a $b}', 'PARAMS', 4, 'a', 'bar', 'b', 'foo').equal(expected)
+
+    env.expect('FT.EXPLAIN', 'idx', '@t:{bar foo} | @t:{foo}').equal(r'''
+UNION {
+  TAG:@t {
+    bar foo
+  }
+  TAG:@t {
+    foo
+  }
+}
+'''[1:])
 
 def testTagQueryWithOR_V2():
   env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
@@ -715,10 +734,7 @@ def testTagQueryWithOR_V2():
  # tag_list ::= taglist OR affix (affix is suffix)
   env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | *ple }').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    x
-    y
-  }
+  x y
   SUFFIX{*ple}
 }
 '''[1:])
@@ -727,10 +743,7 @@ TAG:@tag {
   # tag_list ::= taglist OR affix (affix is prefix)
   env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | ba* }').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    x
-    y
-  }
+  x y
   PREFIX{ba*}
 }
 '''[1:])
@@ -739,10 +752,7 @@ TAG:@tag {
  # tag_list ::= taglist OR affix (affix is contains)
   env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | *pl* }').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    x
-    y
-  }
+  x y
   INFIX{*pl*}
 }
 '''[1:])
@@ -751,10 +761,7 @@ TAG:@tag {
 # taglist OR param_term_case
   env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | banana }').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    x
-    y
-  }
+  x y
   banana
 }
 '''[1:])
@@ -768,10 +775,7 @@ def testTagQueryWithStopwords_V1():
     conn.execute_command('HSET', 'doc2', 'tag', 'dog')
     env.expect('FT.EXPLAIN', 'idx', '@tag:{cat dog}').equal(r'''
 TAG:@tag {
-  INTERSECT {
-    cat
-    dog
-  }
+  cat dog
 }
 '''[1:])
     env.expect('FT.SEARCH', 'idx', '@tag:{cat dog}', 'NOCONTENT').equal([0])


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.EXPLAIN` and `FT.EXPLAINCLI` print a multi-word tag value such as `@t:{bar foo}` as `INTERSECT { bar foo }`, although the query runs as one exact lookup of the tag value `bar foo`. The output describes a query that does not exist.
2. Change: The tag value prints on one line, `bar foo`, identical to what the quoted form `@t:{"bar foo"}` already prints. An empty word inside the value prints as `""`, the marker already used for a standalone empty tag.
3. Outcome: `FT.EXPLAIN` output for multi-word tag values now matches what executes, and `FT.EXPLAINCLI` returns one array element for such a value instead of the `INTERSECT` block. Query results are unchanged. As a side effect, a tag query with a very large number of words no longer allocates a stack array sized by that word count, which could overflow the stack and crash the server.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `QueryNode_DumpSds`, `QN_TAG` case: prints a phrase child as one joined value instead of recursing into the generic `INTERSECT` printer.
2. `tagPhraseAppendValue` (new): builds the joined value into an sds. Shared by tag evaluation and the explain printer; it replaces the evaluator's stack array sized by the user-controlled word count (a remotely triggerable stack overflow). Words are appended by their tracked length; every word the parser produces has that length equal to `strlen`, so the value looked up is unchanged for any query.
3. `query_EvalSingleTagNode`, `QN_PHRASE` case: uses the helper; the lookup string is unchanged.
4. Flow tests: stale `INTERSECT` expectations updated in `test_parser.py` and `test_empty.py`; new tests cover the ticket's case, a tag phrase nested under a UNION, and `FT.SEARCH` results for tag phrases containing an empty word on hash and JSON fields.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

