### PR TITLE
[MOD-15680] Prevent GC backlog in async vector update test

### DIFF
--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -317,9 +317,9 @@ def test_async_updates_sanity():
                       query_before_update.tobytes())
         env.assertGreater(float(res[2][1]), float(0))
 
-        # Invoke GC, so we clean zombies for which all their repair jobs are done. We run in background
-        # so in case child process is not receiving cpu time, we do not hang the gc thread in the parent process.
+        # Wait for this cycle so a slow fork cannot accumulate redundant GC requests.
         forceBGInvokeGC(env)
+        env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')
 
         # Number of zombies should decrease from one iteration to another.
         env.assertEqual(run_command_on_all_shards(env, *[debug_cmd(), 'WORKERS', 'PAUSE']), ['OK']*n_shards)

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -318,8 +318,7 @@ def test_async_updates_sanity():
         env.assertGreater(float(res[2][1]), float(0))
 
         # Wait for this cycle so a slow fork cannot accumulate redundant GC requests.
-        forceBGInvokeGC(env)
-        env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')
+        forceInvokeGC(env, timeout=0)
 
         # Number of zombies should decrease from one iteration to another.
         env.assertEqual(run_command_on_all_shards(env, *[debug_cmd(), 'WORKERS', 'PAUSE']), ['OK']*n_shards)


### PR DESCRIPTION
## Describe the changes in the pull request

`test_async_updates_sanity` replaces vectors while workers ingest the replacements and repair the old HNSW nodes. Its cleanup loop resumes workers, runs searches, requests background GC, then pauses workers and checks how many deleted nodes remain.

The GC request returns immediately, without waiting for cleanup. When a fork-GC child is delayed, the deleted-node count stays high and the loop keeps enqueueing more GC requests. Fast runs hide this; a slow cycle lets thousands of redundant requests accumulate on the single GC thread. Even after vector cleanup finishes, the test's final blocking GC request waits behind that backlog and can hit the test timeout. In the reported run, a three-minute fork stall led to 20,581 background GC requests.

Run each GC cycle with `forceInvokeGC(env, timeout=0)` before pausing workers. The Python client waits for that cycle to finish before the loop can request another; Redis and the worker threads continue running. Explicitly disabling the command timeout avoids the default 30-second limit during a slow fork, while the overall test timeout still applies. This preserves all existing assertions and prevents the backlog; it does not fix the underlying occasional fork-child stall. Only the test changes.

#### Validation

Built the originally failing Search revision in Linux Docker and injected a one-shot 17-second delay before GC execution. With a 20-second test budget, the original test timed out twice in its final GC request, after thousands of GC cycles. The fixed test passed twice in 18 seconds with two GC cycles, and passed without the delay in one second. The delay hook is not included in this PR; the final test function matches the tested version apart from comments. This reproduces the backlog mechanism, not the natural macOS fork-child stall.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

