### PR TITLE
Add cluster benchmarks for heavy distributed FT.AGGREGATE GROUPBY

### DIFF
--- a/tests/benchmarks/search-groupby-heavy-dist-1M-enwiki_abstract-hashes-collect-k400.yml
+++ b/tests/benchmarks/search-groupby-heavy-dist-1M-enwiki_abstract-hashes-collect-k400.yml
@@ -1,0 +1,65 @@
+name: "search-groupby-heavy-dist-1M-enwiki_abstract-hashes-collect-k400"
+description: "
+             - name: enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md),
+               English-language Wikipedia:Database page abstracts.
+             - total docs: 1 million
+             - fields per doc: 3 TEXT sortable fields
+             - Type (read/write/mixed): read
+             - Query type: FT.AGGREGATE high-cardinality GROUPBY with TOLIST
+
+             This case targets the coordinator, not the shards. A high-cardinality GROUPBY
+             cannot be reduced away on a shard: each shard ships one partial row per group it
+             saw and the coordinator merges them, so shard-to-coordinator reply volume and
+             per-row reply materialization at the coordinator dominate. Existing aggregate
+             benchmarks do not cover this regime - the SORTBY/LIMIT variants return few rows
+             per shard, and the groupby-collect family runs on 10K documents.
+
+             The term filter is deliberate and is what keeps this benchmark honest. Over the
+             whole keyspace this aggregation cannot finish inside the shipped search-timeout
+             of 500ms, and the default RETURN policy then answers with a partial reply
+             carrying the count and zero groups - the fan-in being measured never happens and
+             the run reports a meaningless number. The five-term union yields 32,308 groups,
+             which measured p50 266ms and p99 365ms on a 4-primary cluster: enough fan-in for
+             the coordinator to dominate, with headroom under the timeout so no reply is
+             silently truncated. That was verified by sampling the returned group count under
+             sustained load and confirming it stayed at 32,308.
+
+             Group count is a property of the fixed dataset rather than of a tuning knob, so
+             it does not drift if the benchmark is re-run. Cluster setups only, deliberately:
+             on a single shard the fan-in effect being measured does not exist.
+             oss-cluster-02-primaries is excluded on purpose - it requests 2 CPUs for 2 shards
+             plus the coordinator and I/O threads, so it saturates CPU before the coordinator
+             becomes the bottleneck.
+             "
+
+metadata:
+  component: "search"
+  query_type: "groupby-heavy-distributed"
+  backend: "hash"
+  window: "0-400"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+
+dbconfig:
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"CONFIG" "GET" "search-internal-row-block-format"'
+    - '"CONFIG" "GET" "search-timeout"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 1000000
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 1 -t 1 --hide-histogram --command 'FT.AGGREGATE enwiki_abstract @abstract:american|county|university|book|district LOAD 2 @title @url GROUPBY 1 @title REDUCE COUNT 0 AS n REDUCE TOLIST 1 @url AS urls SORTBY 2 @n DESC LIMIT 0 400'"

--- a/tests/benchmarks/search-groupby-heavy-dist-1M-enwiki_abstract-hashes-countdistinct-k400.yml
+++ b/tests/benchmarks/search-groupby-heavy-dist-1M-enwiki_abstract-hashes-countdistinct-k400.yml
@@ -1,0 +1,72 @@
+name: "search-groupby-heavy-dist-1M-enwiki_abstract-hashes-countdistinct-k400"
+description: "
+             - name: enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md),
+               English-language Wikipedia:Database page abstracts.
+             - total docs: 1 million
+             - fields per doc: 3 TEXT sortable fields
+             - Type (read/write/mixed): read
+             - Query type: FT.AGGREGATE high-cardinality GROUPBY with COUNT_DISTINCT
+
+             This case targets the coordinator, not the shards. A high-cardinality GROUPBY
+             cannot be reduced away on a shard: each shard ships one partial row per group it
+             saw and the coordinator merges them, so shard-to-coordinator reply volume and
+             per-row reply materialization at the coordinator dominate. Existing aggregate
+             benchmarks do not cover this regime - the SORTBY/LIMIT variants return few rows
+             per shard, and the groupby-collect family runs on 10K documents.
+
+             The term filter is deliberate and is what keeps this benchmark honest. Over the
+             whole keyspace this aggregation cannot finish inside the shipped search-timeout
+             of 500ms, and the default RETURN policy then answers with a partial reply
+             carrying the count and zero groups - the fan-in being measured never happens and
+             the run reports a meaningless number. The five-term union yields 32,308 groups,
+             which measured p50 266ms and p99 365ms on a 4-primary cluster: enough fan-in for
+             the coordinator to dominate, with headroom under the timeout so no reply is
+             silently truncated. That was verified by sampling the returned group count under
+             sustained load and confirming it stayed at 32,308.
+
+             This is the COUNT_DISTINCT sibling of the -collect- benchmark: same dataset,
+             filter and group count, a different reducer over the same shipped values.
+             COUNT_DISTINCT keeps a per-group membership set rather than a per-group list, so
+             it exercises the coordinator's per-group set-building instead of its list-building
+             while holding fan-in constant. Measured p50 208ms and p99 279ms, so it carries
+             more headroom under the timeout than the TOLIST variant.
+
+             Group count is a property of the fixed dataset rather than of a tuning knob, so
+             it does not drift if the benchmark is re-run. Cluster setups only, deliberately:
+             on a single shard the fan-in effect being measured does not exist.
+             oss-cluster-02-primaries is excluded on purpose - it requests 2 CPUs for 2 shards
+             plus the coordinator and I/O threads, so it saturates CPU before the coordinator
+             becomes the bottleneck.
+             "
+
+metadata:
+  component: "search"
+  query_type: "groupby-heavy-distributed-countdistinct"
+  backend: "hash"
+  window: "0-400"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+
+dbconfig:
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"CONFIG" "GET" "search-internal-row-block-format"'
+    - '"CONFIG" "GET" "search-timeout"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 1000000
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 1 -t 1 --hide-histogram --command 'FT.AGGREGATE enwiki_abstract @abstract:american|county|university|book|district LOAD 2 @title @url GROUPBY 1 @title REDUCE COUNT 0 AS n REDUCE COUNT_DISTINCT 1 @url AS d SORTBY 2 @d DESC LIMIT 0 400'"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: no macro benchmark covers heavy *distributed* aggregation. The existing `FT.AGGREGATE` configs either return few rows per shard (the `SORTBY`/`LIMIT` variants) or run on 10K documents (the `groupby-collect` family), so they exercise GROUPBY correctness rather than coordinator fan-in. Shard-to-coordinator reply volume and per-row reply materialization are therefore untracked, and that is where heavy `GROUPBY` queries spend their time.
2. Change: adds two cluster-only benchmark configs over the existing 1M-document enwiki dataset. Both produce the same 32,308 groups from the same filter and differ only in the reducer — `REDUCE TOLIST` and `REDUCE COUNT_DISTINCT` — so the coordinator's per-group list-building and set-building can be compared at constant fan-in.
3. Outcome: internal-only, no user-visible change. It gives RedisTimeSeries history and PR-comment comparison for the coordinator fan-in regime, so a regression there becomes visible instead of silent.

#### Which additional issues this PR fixes

1. N/A — related to MOD-17716 (coordinator row deserialization), which this measures but does not fix.

#### Main objects this PR modified

1. `tests/benchmarks/` — two new configs, `search-groupby-heavy-dist-*-collect-k400.yml` and `-countdistinct-k400.yml`.
2. No harness change: they reuse the existing `ftsb-1M-enwiki_abstract-hashes` S3 dataset and an inline `memtier_benchmark --command`, following the pattern already used by `search-asm-ftsb-1M-enwiki_abstract-hashes-*`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

### What a reviewer should look at first

**Why these are filtered rather than run over the whole keyspace — this is the part that makes them measure anything at all.** An unfiltered `GROUPBY @title` over 1M documents cannot finish inside the shipped `search-timeout` of 500ms. With the default `RETURN` policy the coordinator then answers with a partial reply carrying the count and **zero groups**, so the fan-in under test never happens and the run reports a number that moves with nothing.

That is not hypothetical: an earlier revision of this benchmark used the wildcard, and a paired comparison against a change that removes ~40% of coordinator CPU came back a **dead null** — 1.85 vs 1.83 ops/s ([baseline](https://github.com/RediSearch/RediSearch/actions/runs/34035116791), [treatment](https://github.com/RediSearch/RediSearch/actions/runs/34038114011)). The tell was in the logs the whole time: `KB/sec 1.10`, i.e. ~300 bytes per reply for a query that should return tens of KB.

The five-term union yields 32,308 groups with p50 266ms / p99 365ms locally, leaving headroom under the timeout. That headroom is **verified rather than assumed**: sampling the returned group count under sustained load confirmed it stayed at 32,308 rather than silently truncating. An intermediate 19-term variant measured p99 668ms and was rejected for exactly that reason — `memtier` reported `errs=0`, because a timeout-truncated reply is not an error.

**Each run now records what it measured.** The two `CONFIG GET` init_commands put the effective `search-timeout` and row-block setting into the run's own log. The null above was unexplainable for hours purely because nothing in the run attested to its own configuration.

**`oss-cluster-02-primaries` deliberately excluded.** It requests 2 CPUs for 2 shards plus coordinator and I/O threads, so it saturates CPU before the coordinator becomes the bottleneck. `oss-cluster-04-primaries` requests 24. Consequence: because the 04/08 jobs are gated on `inputs.extended` in `benchmark-runner.yml`, these configs run on the weekly extended matrix or a manual `workflow_dispatch`, not on a labeled PR.

### Evidence that they now discriminate

Paired `oss-cluster-04-primaries` runs, one client, no config override — baseline [34138577981](https://github.com/RediSearch/RediSearch/actions/runs/34138577981) against #11292 stacked on this branch [34138591561](https://github.com/RediSearch/RediSearch/actions/runs/34138591561):

| benchmark | baseline ops/s | with #11292 | Δ ops/s | baseline p50 | with #11292 | Δ p50 |
|---|---|---|---|---|---|---|
| `-collect-` (TOLIST) | 21.65 | 25.68 | **+18.6%** | 184.32 ms | 154.62 ms | **−16.1%** |
| `-countdistinct-` | 31.72 | 33.96 | **+7.1%** | 126.46 ms | 118.27 ms | **−6.5%** |

`KB/sec` is 1036–1446 in these runs against 1.10 in the broken revision, which is the clearest confirmation that rows are actually crossing the wire. p99 tops out at 264 ms, well clear of the 500 ms timeout.
