### PR TITLE
[MOD-17083] Add HIMPORT and hash template integration tests

### DIFF
--- a/tests/pytests/test_himport.py
+++ b/tests/pytests/test_himport.py
@@ -87,6 +87,30 @@ def test_himport_replacement(env):
 
 
 @skip(cluster=True, redis_less_than='8.10.0')
+def test_himport_replacement_clears_ttl(env):
+    """Replacing an expiring hash clears its key TTL and replaces its search postings."""
+    create_index(env)
+    with himport_connection(env) as conn:
+        conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
+        expiration = int(conn.time()[0]) + 86400
+        for encoding, extra in template_cases(env):
+            key = f'doc:{encoding}'
+            conn.execute_command('HSET', key, 'title', 'original', 'category', 'old', 'price', 1)
+            env.assertEqual(conn.execute_command('EXPIREAT', key, expiration), 1)
+            env.assertEqual(conn.execute_command('EXPIRETIME', key), expiration)
+            env.expect('FT.SEARCH', 'idx', '@title:original', 'NOCONTENT').equal([1, key])
+
+            env.assertEqual(conn.execute_command('HIMPORT', 'SET', key, 'fields',
+                                                'replacement', 'new', 2, extra), 'OK')
+            env.assertEqual(conn.execute_command('PTTL', key), -1)
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key, 'replacement', 'new', 2, extra)
+            for query in ['@title:original', '@category:{old}', '@price:[1 1]']:
+                env.expect('FT.SEARCH', 'idx', query, 'NOCONTENT').equal([0])
+            conn.execute_command('DEL', key)
+
+
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_hash_mutations(env):
     """Ordinary hash writes and deletions reindex template-backed documents."""
     create_index(env)

--- a/tests/pytests/test_himport.py
+++ b/tests/pytests/test_himport.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+from contextlib import contextmanager
+
+from common import getConnectionByEnv, skip, to_dict, waitForIndex
+
+
+def require_himport(env):
+    # Unreleased Redis builds report 255.255.255 even before HIMPORT exists.
+    if not env.cmd('COMMAND LIST', 'FILTERBY', 'PATTERN', 'himport|set'):
+        env.skip()
+
+
+@contextmanager
+def himport_connection(env):
+    # Fieldsets belong to a physical connection, not a connection pool.
+    with getConnectionByEnv(env).client() as conn:
+        try:
+            yield conn
+        finally:
+            conn.execute_command('HIMPORT', 'DISCARDALL')
+
+
+def create_index(env, index='idx', prefix='doc:'):
+    env.expect('FT.CREATE', index, 'ON', 'HASH', 'PREFIX', 1, prefix,
+               'SCHEMA', 'title', 'TEXT', 'category', 'TAG',
+               'price', 'NUMERIC', 'SORTABLE').ok()
+
+
+def template_cases(env):
+    limit = int(env.cmd('CONFIG GET', 'hash-max-listpack-value')['hash-max-listpack-value'])
+    return [('template-listpack', 'short'), ('template-array', 'x' * (limit + 1))]
+
+
+def assert_document(env, index, key, title, category, price, extra):
+    query = f'@title:{title} @category:{{{category}}} @price:[{price} {price}]'
+    env.expect('FT.SEARCH', index, query, 'NOCONTENT').equal([1, key])
+    env.expect('FT.SEARCH', index, query, 'RETURN', 2, 'title', 'extra').equal(
+        [1, key, ['title', title, 'extra', extra]])
+    env.expect('FT.SEARCH', index, query, 'SORTBY', 'price', 'RETURN', 1, 'price').equal(
+        [1, key, ['price', str(price)]])
+    result = env.cmd('FT.SEARCH', index, query)
+    env.assertEqual(result[:2], [1, key], message=result)
+    env.assertEqual(to_dict(result[2]), {
+        'title': title, 'category': category, 'price': str(price), 'extra': extra})
+    env.expect('FT.AGGREGATE', index, query, 'LOAD', 2, '@title', '@extra').equal(
+        [1, ['title', title, 'extra', extra]])
+
+
+@skip(cluster=True)
+def test_himport_indexing_and_loading(env):
+    """HIMPORT notifications and module hash reads support both template encodings."""
+    require_himport(env)
+    create_index(env)
+    with himport_connection(env) as conn:
+        env.assertEqual(conn.execute_command('HIMPORT', 'PREPARE', 'fields',
+                                            'title', 'price', 'extra', 'category'), 'OK')
+        for encoding, extra in template_cases(env):
+            key = f'doc:{encoding}'
+            title = 'compact' if encoding == 'template-listpack' else 'expanded'
+            env.assertEqual(conn.execute_command('HIMPORT', 'SET', key, 'fields',
+                                                title, 12, extra, 'books'), 'OK')
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key, title, 'books', 12, extra)
+
+
+@skip(cluster=True)
+def test_himport_replacement(env):
+    """Replacing a hash removes old postings, including fields absent from the new fieldset."""
+    require_himport(env)
+    create_index(env)
+    with himport_connection(env) as conn:
+        conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
+        conn.execute_command('HIMPORT', 'PREPARE', 'unindexed', 'extra')
+        for encoding, extra in template_cases(env):
+            key = f'doc:{encoding}'
+            conn.execute_command('HSET', key, 'title', 'original', 'category', 'old', 'price', 1)
+            env.expect('FT.SEARCH', 'idx', '@title:original', 'NOCONTENT').equal([1, key])
+            env.assertEqual(conn.execute_command('HIMPORT', 'SET', key, 'fields',
+                                                'replacement', 'new', 2, extra), 'OK')
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key, 'replacement', 'new', 2, extra)
+            for query in ['@title:original', '@category:{old}', '@price:[1 1]']:
+                env.expect('FT.SEARCH', 'idx', query, 'NOCONTENT').equal([0])
+
+            env.assertEqual(conn.execute_command('HIMPORT', 'SET', key, 'unindexed', extra), 'OK')
+            for query in ['@title:replacement', '@category:{new}', '@price:[2 2]']:
+                env.expect('FT.SEARCH', 'idx', query, 'NOCONTENT').equal([0])
+            conn.execute_command('DEL', key)
+
+
+@skip(cluster=True)
+def test_himport_hash_mutations(env):
+    """Ordinary hash writes and deletions reindex template-backed documents."""
+    require_himport(env)
+    create_index(env)
+    with himport_connection(env) as conn:
+        conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'price', 'extra')
+        for encoding, extra in template_cases(env):
+            key = f'doc:{encoding}'
+            conn.execute_command('HIMPORT', 'SET', key, 'fields', 'original', 1, extra)
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key), encoding)
+            conn.execute_command('HSET', key, 'title', 'updated', 'category', 'added')
+            conn.execute_command('HINCRBY', key, 'price', 2)
+            assert_document(env, 'idx', key, 'updated', 'added', 3, extra)
+            env.expect('FT.SEARCH', 'idx', '@title:original | @price:[1 1]',
+                       'NOCONTENT').equal([0])
+            conn.execute_command('HDEL', key, 'category')
+            env.expect('FT.SEARCH', 'idx', '@category:{added}', 'NOCONTENT').equal([0])
+            env.expect('FT.SEARCH', 'idx', '@title:updated', 'NOCONTENT').equal([1, key])
+            conn.execute_command('DEL', key)
+            env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([0])
+
+
+@skip(cluster=True)
+def test_himport_backfill_and_reload(env):
+    """Background indexing and RDB loading can read persisted template hashes."""
+    require_himport(env)
+    cases = template_cases(env)
+    with himport_connection(env) as conn:
+        conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
+        for encoding, extra in cases:
+            conn.execute_command('HIMPORT', 'SET', f'doc:{encoding}', 'fields',
+                                 'compact' if encoding == 'template-listpack' else 'expanded',
+                                 'books', 12, extra)
+    create_index(env)
+    waitForIndex(env, 'idx')
+    for _ in env.reloadingIterator():
+        waitForIndex(env, 'idx')
+        for encoding, extra in cases:
+            key = f'doc:{encoding}'
+            env.assertEqual(env.cmd('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key,
+                            'compact' if encoding == 'template-listpack' else 'expanded',
+                            'books', 12, extra)
+
+
+@skip(cluster=True)
+def test_hash_auto_template_conversion(env):
+    """HSET's opt-in conversion preserves indexing and field loading without HIMPORT."""
+    require_himport(env)
+    create_index(env)
+    config = env.cmd('CONFIG GET', 'hash-min-template-entries', 'hash-max-template-entries')
+    conn = getConnectionByEnv(env)
+    try:
+        env.cmd('CONFIG SET', 'hash-min-template-entries', 0, 'hash-max-template-entries', 0)
+        cases = template_cases(env)
+        for encoding, extra in cases:
+            conn.execute_command('HSET', f'doc:{encoding}', 'title', 'original',
+                                 'category', 'books', 'price', 12, 'extra', extra)
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', f'doc:{encoding}'),
+                            'listpack' if encoding == 'template-listpack' else 'hashtable')
+        env.cmd('CONFIG SET', 'hash-min-template-entries', 4)
+        for encoding, extra in cases:
+            key = f'doc:{encoding}'
+            title = 'compact' if encoding == 'template-listpack' else 'expanded'
+            conn.execute_command('HSET', key, 'title', title)
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key, title, 'books', 12, extra)
+        env.expect('FT.SEARCH', 'idx', '@title:original', 'NOCONTENT').equal([0])
+    finally:
+        env.cmd('CONFIG SET', *[arg for item in config.items() for arg in item])
+
+
+@skip(cluster=True)
+def test_himport_restore(env):
+    """RESTORE, also used by HIMPORT replication, indexes template hashes and replacements."""
+    require_himport(env)
+    create_index(env)
+    with himport_connection(env) as conn:
+        conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
+        for encoding, extra in template_cases(env):
+            conn.execute_command('HIMPORT', 'SET', 'source', 'fields', 'restored', 'books', 12, extra)
+            payload = conn.dump('source')
+            conn.execute_command('HSET', 'doc:restored', 'title', 'original')
+            conn.execute_command('RESTORE', 'doc:restored', 0, payload, 'REPLACE')
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', 'doc:restored'), encoding)
+            assert_document(env, 'idx', 'doc:restored', 'restored', 'books', 12, extra)
+            env.expect('FT.SEARCH', 'idx', '@title:original', 'NOCONTENT').equal([0])
+            conn.execute_command('DEL', 'doc:restored')
+
+
+@skip(cluster=True)
+def test_hash_template_conversion_on_rdb_load(env):
+    """Converting plain hashes while loading an RDB preserves Search results."""
+    require_himport(env)
+    create_index(env)
+    config = env.cmd('CONFIG GET', 'hash-min-template-entries',
+                     'hash-rdb-load-min-template-entries', 'hash-rdb-load-max-template-entries',
+                     'hash-rdb-load-template-disassembly-threshold')
+    conn = getConnectionByEnv(env)
+    try:
+        env.cmd('CONFIG SET', 'hash-min-template-entries', 0,
+                'hash-rdb-load-min-template-entries', 4, 'hash-rdb-load-max-template-entries', 0,
+                'hash-rdb-load-template-disassembly-threshold', 0)
+        cases = template_cases(env)
+        for encoding, extra in cases:
+            key = f'doc:{encoding}'
+            title = 'compact' if encoding == 'template-listpack' else 'expanded'
+            conn.execute_command('HSET', key, 'title', title, 'category', 'books',
+                                 'price', 12, 'extra', extra)
+            env.assertEqual(conn.execute_command('OBJECT', 'ENCODING', key),
+                            'listpack' if encoding == 'template-listpack' else 'hashtable')
+            assert_document(env, 'idx', key, title, 'books', 12, extra)
+        env.dumpAndReload()
+        waitForIndex(env, 'idx')
+        for encoding, extra in cases:
+            key = f'doc:{encoding}'
+            env.assertEqual(env.cmd('OBJECT', 'ENCODING', key), encoding)
+            assert_document(env, 'idx', key,
+                            'compact' if encoding == 'template-listpack' else 'expanded',
+                            'books', 12, extra)
+    finally:
+        env.cmd('CONFIG SET', *[arg for item in config.items() for arg in item])

--- a/tests/pytests/test_himport.py
+++ b/tests/pytests/test_himport.py
@@ -7,19 +7,13 @@
 
 from contextlib import contextmanager
 
-from common import getConnectionByEnv, skip, to_dict, waitForIndex
-
-
-def require_himport(env):
-    # Unreleased Redis builds report 255.255.255 even before HIMPORT exists.
-    if not env.cmd('COMMAND LIST', 'FILTERBY', 'PATTERN', 'himport|set'):
-        env.skip()
+from common import skip, to_dict, waitForIndex
 
 
 @contextmanager
 def himport_connection(env):
     # Fieldsets belong to a physical connection, not a connection pool.
-    with getConnectionByEnv(env).client() as conn:
+    with env.getClusterConnectionIfNeeded().client() as conn:
         try:
             yield conn
         finally:
@@ -52,10 +46,9 @@ def assert_document(env, index, key, title, category, price, extra):
         [1, ['title', title, 'extra', extra]])
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_indexing_and_loading(env):
     """HIMPORT notifications and module hash reads support both template encodings."""
-    require_himport(env)
     create_index(env)
     with himport_connection(env) as conn:
         env.assertEqual(conn.execute_command('HIMPORT', 'PREPARE', 'fields',
@@ -69,10 +62,9 @@ def test_himport_indexing_and_loading(env):
             assert_document(env, 'idx', key, title, 'books', 12, extra)
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_replacement(env):
     """Replacing a hash removes old postings, including fields absent from the new fieldset."""
-    require_himport(env)
     create_index(env)
     with himport_connection(env) as conn:
         conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
@@ -94,10 +86,9 @@ def test_himport_replacement(env):
             conn.execute_command('DEL', key)
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_hash_mutations(env):
     """Ordinary hash writes and deletions reindex template-backed documents."""
-    require_himport(env)
     create_index(env)
     with himport_connection(env) as conn:
         conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'price', 'extra')
@@ -117,10 +108,9 @@ def test_himport_hash_mutations(env):
             env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([0])
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_backfill_and_reload(env):
     """Background indexing and RDB loading can read persisted template hashes."""
-    require_himport(env)
     cases = template_cases(env)
     with himport_connection(env) as conn:
         conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
@@ -140,13 +130,12 @@ def test_himport_backfill_and_reload(env):
                             'books', 12, extra)
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_hash_auto_template_conversion(env):
     """HSET's opt-in conversion preserves indexing and field loading without HIMPORT."""
-    require_himport(env)
     create_index(env)
     config = env.cmd('CONFIG GET', 'hash-min-template-entries', 'hash-max-template-entries')
-    conn = getConnectionByEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
     try:
         env.cmd('CONFIG SET', 'hash-min-template-entries', 0, 'hash-max-template-entries', 0)
         cases = template_cases(env)
@@ -167,10 +156,9 @@ def test_hash_auto_template_conversion(env):
         env.cmd('CONFIG SET', *[arg for item in config.items() for arg in item])
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_himport_restore(env):
     """RESTORE, also used by HIMPORT replication, indexes template hashes and replacements."""
-    require_himport(env)
     create_index(env)
     with himport_connection(env) as conn:
         conn.execute_command('HIMPORT', 'PREPARE', 'fields', 'title', 'category', 'price', 'extra')
@@ -185,15 +173,14 @@ def test_himport_restore(env):
             conn.execute_command('DEL', 'doc:restored')
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='8.10.0')
 def test_hash_template_conversion_on_rdb_load(env):
     """Converting plain hashes while loading an RDB preserves Search results."""
-    require_himport(env)
     create_index(env)
     config = env.cmd('CONFIG GET', 'hash-min-template-entries',
                      'hash-rdb-load-min-template-entries', 'hash-rdb-load-max-template-entries',
                      'hash-rdb-load-template-disassembly-threshold')
-    conn = getConnectionByEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
     try:
         env.cmd('CONFIG SET', 'hash-min-template-entries', 0,
                 'hash-rdb-load-min-template-entries', 4, 'hash-rdb-load-max-template-entries', 0,


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Search lacks dedicated coverage for Redis HIMPORT and template-encoded hashes.
2. Change: Add eight integration tests covering ingestion, replacement (including clearing a key TTL), mutation, field loading, background indexing, RESTORE, and RDB conversion/reload with both template encodings. Tests target Redis 8.10 and later, using the standard version gate and environment connection helper.
3. Outcome: Internal-only regression coverage; no production-code changes are needed. All eight tests passed against Redis's HIMPORT merge commit `ba99faa23064`, including the TTL replacement scenario; both the CI pin `d3abc02fed66` and Redis 8.10.0 include HIMPORT. Local verification used checked-in Rust headers and direct RLTest execution because of header-cache and launcher environment issues.

#### Which additional issues this PR fixes

1. [MOD-17083](https://redislabs.atlassian.net/browse/MOD-17083)

#### Main objects this PR modified

1. Hash indexing tests — ingestion, replacement, and ordinary mutations.
2. Search and aggregate loading tests — template-listpack and template-array reads.
3. Persistence tests — backfill, RESTORE, RDB reload, and automatic template conversion.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.


[MOD-17083]: https://redislabs.atlassian.net/browse/MOD-17083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
