### PR TITLE
[MOD-17341] GC_FORCEINVOKE reports failure, not DONE, when memory pressure skips the fork

### DIFF
--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -160,6 +160,9 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
 
     if (isOutOfMemory(ctx)) {
       RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
+      if (forced) {
+        forced->outcome = GC_FORCED_RUN_NO_FORK;
+      }
       return -1;
     }
 

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -587,7 +587,9 @@ def test_gc_oom(env:Env):
     for i in range(num_docs):
         env.expect('DEL', f'doc{i}').equal(1)
 
-    forceInvokeGC(env)
+    # A forced cycle that skips its fork for memory pressure reports failure, not DONE.
+    waitForRdbSaveToFinish(env)
+    env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx').error().contains('GC DID NOT RUN')
 
     # Verify no bytes collected by GC
     info = index_info(env)
@@ -1132,3 +1134,21 @@ def testForcedGCReportsWhenItCannotFork():
 
     env.assertContains('GC DID NOT RUN', forced.get('error', ''),
                        message=f'expected an error, got {forced}')
+
+
+@skip(cluster=True)
+def testForcedGCReportsWhenOutOfMemory():
+    """A forced GC that skips its fork because of memory pressure has to say so, not reply
+    DONE for a cycle that collected nothing -- the counterpart to
+    testForcedGCReportsWhenItCannotFork's EEXIST branch, for forkGCChild's isOutOfMemory
+    branch. Unlike that test, no sync points are needed: the memory check is synchronous, so
+    a tight maxmemory is already in place before GC_FORCEINVOKE is sent."""
+    env = Env()
+    skipIfNoEnableAssert(env)
+    indexWithCollectableDocs(env)
+    set_tight_maxmemory_for_oom(env)
+    try:
+        env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 2000).error() \
+            .contains('GC DID NOT RUN')
+    finally:
+        set_unlimited_maxmemory_for_oom(env)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `forkGCChild()`'s out-of-memory branch returns `-1` without recording an outcome on `forced`, unlike every other failure path in the function. `FT.DEBUG GC_FORCEINVOKE` relies on that outcome to reply with an error instead of `DONE` for a cycle that never forked.
2. Change: set `forced->outcome = GC_FORCED_RUN_NO_FORK` on this path too, matching the existing EEXIST and budget-exhausted branches.
3. Outcome: a forced GC that is skipped for memory pressure now replies with an error (`"GC DID NOT RUN..."`) instead of `DONE`, so callers can no longer observe a "successful" GC cycle that collected nothing.

#### Which additional issues this PR fixes

1. MOD-17341
2. N/A

#### Main objects this PR modified

1. `src/fork_gc/fork_gc.c` — `forkGCChild()`: record `GC_FORCED_RUN_NO_FORK` on the `isOutOfMemory()` skip path.
2. `tests/pytests/test_gc.py` — new `testForcedGCReportsWhenOutOfMemory` (mirrors the existing EEXIST coverage in `testForcedGCReportsWhenItCannotFork`); `test_gc_oom` updated to expect the corrected error reply instead of silent success.

#### Mark if applicable

`FT.DEBUG GC_FORCEINVOKE`'s reply changes from `DONE` to an error string for the OOM-skip
case only; every other outcome keeps its existing reply.

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
