### PR TITLE
[MOD-18356] Fix crash from FT.ALTER racing concurrent query execution under WORKERS

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1532,7 +1532,7 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Expected a " SPEC_VECTOR_STR " field", " `%s`", fieldName);
     return REDISMODULE_ERR;
   }
-  vq->field = vectorField;
+  VectorQuery_SetField(vq, vectorField);
 
   QueryNode *vecNode = NewQueryNode(QN_VECTOR);
   vecNode->vn.vq = vq;

--- a/src/query.c
+++ b/src/query.c
@@ -323,6 +323,9 @@ QueryNode *NewPhraseNode(int exact) {
 QueryNode *NewTagNode(const FieldSpec *field) {
   QueryNode *ret = NewQueryNode(QN_TAG);
   ret->tag.fs = field;
+  // The legacy (v1) grammar creates a placeholder node with `field == NULL` and
+  // fills in `tag.fs`/`tag.fieldIndex` once it resolves the field itself.
+  ret->tag.fieldIndex = field ? field->index : RS_INVALID_FIELD_INDEX;
   return ret;
 }
 
@@ -567,8 +570,11 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn,
     if (qn->vn.vq->scoreField) {
       // Since the KNN syntax allows specifying the distance field in two ways (...=>[KNN ... AS <dist_field>] and
       // ...=>[KNN ...]=>{$YIELD_DISTANCE_AS:<dist_field>), we validate that we got it only once.
+      // Re-derived via fieldIndex, not `vq->field` directly - see NewVectorIterator (MOD-18356).
+      RS_ASSERT(qn->vn.vq->fieldIndex < q->sctx->spec->numFields);
+      const FieldSpec *fieldSpec = q->sctx->spec->fields + qn->vn.vq->fieldIndex;
       size_t len;
-      const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, &len);
+      const char *fieldName = HiddenString_GetUnsafe(fieldSpec->fieldName, &len);
       char default_score_field[len + 9];  // buffer for __<field>_score
       sprintf(default_score_field, "__%s_score", fieldName);
       // If the saved score field is NOT the default one, we return an error, otherwise, just override it.
@@ -919,9 +925,16 @@ static QueryIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_ASSERT(qn->type == QN_TAG);
   QueryTagNode *node = &qn->tag;
 
+  // Re-derive the field from the spec's current array via the stable index captured at
+  // parse time, rather than dereferencing `node->fs` directly: under WORKERS>0, evaluation
+  // can run on a worker thread well after parsing, and a concurrent FT.ALTER may have since
+  // reallocated IndexSpec.fields, leaving `node->fs` a dangling pointer (MOD-18356).
+  RS_ASSERT(node->fieldIndex < q->sctx->spec->numFields);
+  const FieldSpec *fs = q->sctx->spec->fields + node->fieldIndex;
+
   // Open the TagIndex - in disk mode it contains sentinel values for tag enumeration
   // In memory mode it contains InvertedIndex pointers
-  TagIndex *idx = TagIndex_Open(node->fs);
+  TagIndex *idx = TagIndex_Open(fs);
   if (!idx) {
     // There are no documents to traverse.
     return NULL;
@@ -929,13 +942,13 @@ static QueryIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
 
   if (QueryNode_NumChildren(qn) == 1) {
     // a union stage with one child is the same as the child, so we just return it
-    return query_EvalSingleTagNode(q, idx, qn->children[0], qn->opts.weight, node->fs);
+    return query_EvalSingleTagNode(q, idx, qn->children[0], qn->opts.weight, fs);
   }
 
   // recursively eval the children
   QueryIterator **iters = rm_malloc(QueryNode_NumChildren(qn) * sizeof(QueryIterator *));
   for (size_t i = 0; i < QueryNode_NumChildren(qn); i++) {
-    iters[i] = query_EvalSingleTagNode(q, idx, qn->children[i], qn->opts.weight, node->fs);
+    iters[i] = query_EvalSingleTagNode(q, idx, qn->children[i], qn->opts.weight, fs);
   }
   // We want to get results with all the matching children (`quickExit == false`), unless:
   // 1. We are a `Not` sub-tree, so we only care about the set of IDs
@@ -1203,7 +1216,8 @@ static int QueryNode_CheckIsValid(QueryNode *n, IndexSpec *spec, RSSearchOptions
     case QN_TAG:
       {
         opts->flags |= QueryNode_IsTag;
-        const FieldSpec *fs = n->tag.fs;
+        // Re-derived via fieldIndex, not `tag.fs` directly - see Query_EvalTagNode (MOD-18356).
+        const FieldSpec *fs = spec ? spec->fields + n->tag.fieldIndex : n->tag.fs;
         if (fs && FieldSpec_IndexesEmpty(fs)) {
           opts->flags |= QueryNode_IndexesEmpty;
         }
@@ -1439,12 +1453,16 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       s = doPad(s, depth);
       s = sdscat(s, "}");
       break;
-    case QN_TAG:
-      s = sdscatprintf(s, "TAG:@%s {\n", HiddenString_GetUnsafe(qs->tag.fs->fieldName, NULL));
+    case QN_TAG: {
+      // Re-derived via fieldIndex when possible, not `tag.fs` directly - see
+      // Query_EvalTagNode (MOD-18356).
+      const FieldSpec *tagFs = spec ? spec->fields + qs->tag.fieldIndex : qs->tag.fs;
+      s = sdscatprintf(s, "TAG:@%s {\n", HiddenString_GetUnsafe(tagFs->fieldName, NULL));
       s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
       s = doPad(s, depth);
       s = sdscat(s, "}");
       break;
+    }
     case QN_GEO:
       s = sdscatprintf(s, "GEO %s:{%f,%f --> %f %s}", HiddenString_GetUnsafe(qs->gn.gf->fieldSpec->fieldName, NULL), qs->gn.gf->lon,
                        qs->gn.gf->lat, qs->gn.gf->radius,
@@ -1503,7 +1521,12 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
           break;
         }
       } // switch (qs->vn.vq->type). Next is a common part for both types.
-      s = sdscatprintf(s, "in vector index associated with field @%s", HiddenString_GetUnsafe(qs->vn.vq->field->fieldName, NULL));
+      {
+        // Re-derived via fieldIndex when possible, not `vq->field` directly - see
+        // NewVectorIterator (MOD-18356).
+        const FieldSpec *vecFs = spec ? spec->fields + qs->vn.vq->fieldIndex : qs->vn.vq->field;
+        s = sdscatprintf(s, "in vector index associated with field @%s", HiddenString_GetUnsafe(vecFs->fieldName, NULL));
+      }
       for (size_t i = 0; i < array_len(qs->vn.vq->params.params); i++) {
         s = sdscatprintf(s, ", %s = ", qs->vn.vq->params.params[i].name);
         s = sdscatlen(s, qs->vn.vq->params.params[i].value, qs->vn.vq->params.params[i].valLen);

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -42,7 +42,12 @@ typedef struct {
 } QueryNullNode;
 
 typedef struct {
-  const struct FieldSpec *fs;
+  const struct FieldSpec *fs;   // the tag field, as it existed when the query was parsed.
+                                 // Only safe to dereference at parse time - see fieldIndex.
+  t_fieldIndex fieldIndex;      // stable index of `fs` into IndexSpec.fields; use this for a
+                                 // fresh lookup at evaluation time instead of dereferencing `fs`
+                                 // directly (a concurrent FT.ALTER may have since reallocated the
+                                 // spec's field array under WORKERS>0 - see MOD-18356)
 } QueryTagNode;
 
 /* A token node is a terminal, single term/token node. An expansion of synonyms is represented by a

--- a/src/query_parser/v1/parser.c
+++ b/src/query_parser/v1/parser.c
@@ -1531,6 +1531,8 @@ static YYACTIONTYPE yy_reduce(
             if (!yylhsminor.yy75->tag.fs) {
                 QueryNode_Free(yylhsminor.yy75);
                 yylhsminor.yy75 = NULL;
+            } else {
+                yylhsminor.yy75->tag.fieldIndex = yylhsminor.yy75->tag.fs->index;
             }
         }
     }

--- a/src/query_parser/v1/parser.y
+++ b/src/query_parser/v1/parser.y
@@ -492,6 +492,8 @@ expr(A) ::= modifier(B) COLON tag_list(C) . {
             if (!A->tag.fs) {
                 QueryNode_Free(A);
                 A = NULL;
+            } else {
+                A->tag.fieldIndex = A->tag.fs->index;
             }
         }
     }

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -2436,7 +2436,7 @@ static YYACTIONTYPE yy_reduce(
   } else if (yymsp[-3].minor.yy0.len == strlen("KNN") && !strncasecmp("KNN", yymsp[-3].minor.yy0.s, yymsp[-3].minor.yy0.len)) {
     yymsp[0].minor.yy0.type = QT_PARAM_VEC;
     yylhsminor.yy3 = NewVectorNode_WithParams(ctx, VECSIM_QT_KNN, &yymsp[-2].minor.yy0, &yymsp[0].minor.yy0);
-    yylhsminor.yy3->vn.vq->field = yymsp[-1].minor.yy150.fs;
+    VectorQuery_SetField(yylhsminor.yy3->vn.vq, yymsp[-1].minor.yy150.fs);
     VectorQuery_SetDefaultScoreField(yylhsminor.yy3->vn.vq, yymsp[-1].minor.yy150.tok.s, yymsp[-1].minor.yy150.tok.len);
   } else {
     reportSyntaxError(ctx->status, &yymsp[-3].minor.yy0, "Syntax error: Expecting Vector Similarity command");
@@ -2484,7 +2484,7 @@ static YYACTIONTYPE yy_reduce(
     REPORT_WRONG_FIELD_TYPE(yymsp[-4].minor.yy150, SPEC_VECTOR_STR);
     QueryNode_Free(yymsp[-1].minor.yy3);
   } else if (yymsp[-1].minor.yy3) {
-    yymsp[-1].minor.yy3->vn.vq->field = yymsp[-4].minor.yy150.fs;
+    VectorQuery_SetField(yymsp[-1].minor.yy3->vn.vq, yymsp[-4].minor.yy150.fs);
     yylhsminor.yy3 = yymsp[-1].minor.yy3;
   }
 }

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -1090,7 +1090,7 @@ vector_command(A) ::= TERM(T) param_size(B) modifier(C) ATTRIBUTE(D). {
   } else if (T.len == strlen("KNN") && !strncasecmp("KNN", T.s, T.len)) {
     D.type = QT_PARAM_VEC;
     A = NewVectorNode_WithParams(ctx, VECSIM_QT_KNN, &B, &D);
-    A->vn.vq->field = C.fs;
+    VectorQuery_SetField(A->vn.vq, C.fs);
     VectorQuery_SetDefaultScoreField(A->vn.vq, C.tok.s, C.tok.len);
   } else {
     reportSyntaxError(ctx->status, &T, "Syntax error: Expecting Vector Similarity command");
@@ -1131,7 +1131,7 @@ expr(A) ::= modifier(B) COLON LSQB vector_range_command(C) RSQB. {
     REPORT_WRONG_FIELD_TYPE(B, SPEC_VECTOR_STR);
     QueryNode_Free(C);
   } else if (C) {
-    C->vn.vq->field = B.fs;
+    VectorQuery_SetField(C->vn.vq, B.fs);
     A = C;
   }
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -232,8 +232,13 @@ static int VectorQuery_ValidateDiskHybridPolicy(const QueryEvalCtx *q, const Vec
 
 QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator *child_it) {
   RedisSearchCtx *ctx = q->sctx;
-  // Cast is safe: openVectorIndex only mutates fieldSpec when create_if_missing is true.
-  VecSimIndex *vecsim = openVectorIndex(ctx->redisCtx, (FieldSpec *)vq->field, DONT_CREATE_INDEX);
+  // Re-derive the field from the spec's current array via the stable index captured at
+  // parse time, rather than dereferencing `vq->field` directly: under WORKERS>0, evaluation
+  // can run on a worker thread well after parsing, and a concurrent FT.ALTER may have since
+  // reallocated IndexSpec.fields, leaving `vq->field` a dangling pointer (MOD-18356).
+  RS_ASSERT(vq->fieldIndex < ctx->spec->numFields);
+  FieldSpec *fieldSpec = ctx->spec->fields + vq->fieldIndex;
+  VecSimIndex *vecsim = openVectorIndex(ctx->redisCtx, fieldSpec, DONT_CREATE_INDEX);
   if (!vecsim) {
     return NULL;
   }
@@ -244,7 +249,7 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
   VecSimMetric metric = info.metric;
 
   VecSimQueryParams qParams = {0};
-  FieldFilterContext filterCtx = {.field = {.index_tag = FieldMaskOrIndex_Index, .index = vq->field->index}, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
+  FieldFilterContext filterCtx = {.field = {.index_tag = FieldMaskOrIndex_Index, .index = fieldSpec->index}, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
   switch (vq->type) {
     case VECSIM_QT_KNN: {
       if ((dim * VecSimType_sizeof(type)) != vq->knn.vecLen) {
@@ -264,10 +269,10 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
       }
       // On disk (Flex) HNSW, query-time RERANK is an override only. When the query omits
       // it, fall back to the index's create-time RERANK default
-      if (vq->field->vectorOpts.diskCtx.indexName != NULL &&
+      if (fieldSpec->vectorOpts.diskCtx.indexName != NULL &&
           qParams.hnswDiskRuntimeParams.shouldRerank == VecSimBool_UNSET) {
         qParams.hnswDiskRuntimeParams.shouldRerank =
-            vq->field->vectorOpts.diskCtx.rerank ? VecSimBool_TRUE : VecSimBool_FALSE;
+            fieldSpec->vectorOpts.diskCtx.rerank ? VecSimBool_TRUE : VecSimBool_FALSE;
       }
       if (vq->knn.k > MAX_KNN_K) {
         QueryError_SetWithoutUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
@@ -349,6 +354,11 @@ int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *param
   params.params[index].value = rm_strndup(val, val_len);
   params.params[index].valLen = val_len;
   return 1;
+}
+
+void VectorQuery_SetField(VectorQuery *vq, const FieldSpec *field) {
+  vq->field = field;
+  vq->fieldIndex = field->index;
 }
 
 char *VectorQuery_GetDefaultScoreFieldName(const char *fieldName, size_t fieldNameLen) {

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -113,7 +113,14 @@ typedef struct {
 } RangeVectorQuery;
 
 typedef struct VectorQuery {
-  const FieldSpec *field;             // the vector field
+  const FieldSpec *field;             // the vector field, as it existed when the query was parsed.
+                                       // Only safe to dereference at parse time: under `WORKERS>0`,
+                                       // evaluation can run on a worker thread well after parsing,
+                                       // and a concurrent `FT.ALTER` may have since reallocated the
+                                       // spec's field array, leaving this pointer dangling. At
+                                       // evaluation time, re-derive the field via `fieldIndex` instead.
+  t_fieldIndex fieldIndex;            // stable index of `field` into IndexSpec.fields, safe to use
+                                       // for a fresh lookup after re-acquiring the spec lock
   char *scoreField;                   // name of score field
   union {
     KNNVectorQuery knn;
@@ -157,6 +164,8 @@ int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *param
 void VectorQuery_Free(VectorQuery *vq);
 char *VectorQuery_GetDefaultScoreFieldName(const char *fieldName, size_t fieldNameLen);
 void VectorQuery_SetDefaultScoreField(VectorQuery *vq, const char *fieldName, size_t fieldNameLen);
+// Sets both `field` and `fieldIndex`; keeps them from drifting out of sync.
+void VectorQuery_SetField(VectorQuery *vq, const FieldSpec *field);
 
 VecSimResolveCode VecSim_ResolveQueryParams(VecSimIndex *index, VecSimRawParam *params, size_t params_len,
                                             VecSimQueryParams *qParams, VecsimQueryType queryType, QueryError *status);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Under `WORKERS>0`, evaluating a `VECTOR` or `TAG` query clause can run on a worker thread well after the query was parsed on the main thread. Both node types dereference a `FieldSpec*` that was captured once at parse time.
2. Change: A concurrent `FT.ALTER ... SCHEMA ADD` reallocates the index's field table (a flat array grown via `rm_realloc`), which can move it and leave that cached pointer dangling. `VECTOR`/`TAG` nodes now also capture the field's stable index at parse time and re-derive the current `FieldSpec*` from the index spec at every evaluation-time use, instead of trusting the pointer captured before parsing.
3. Outcome: `FT.SEARCH` / `FT.AGGREGATE` / `FT.HYBRID` queries against `VECTOR` or `TAG` fields no longer crash the shard when they race a concurrent `FT.ALTER SCHEMA ADD` under `search-workers>0`.

#### Which additional issues this PR fixes

1. MOD-18356
2. MOD-17374 (customer crash this was found while triaging)

#### Main objects this PR modified

1. `VectorQuery` (`vector_index.h`) — added `fieldIndex`; new `VectorQuery_SetField` helper keeps `field`/`fieldIndex` from drifting out of sync
2. `QueryTagNode` (`query_node.h`) — added `fieldIndex` alongside `fs`
3. `NewVectorIterator` (`vector_index.c`) — re-derives the field via `fieldIndex` instead of the parse-time pointer before calling `openVectorIndex`
4. `Query_EvalVectorNode`, `Query_EvalTagNode`, `QueryNode_CheckIsValid`, `QueryNode_DumpSds` (`query.c`) — same re-derivation at each remaining evaluation/validation/explain site
5. `applyVectorQuery` (`aggregate_request.c`) — `FT.HYBRID`'s own vector-field resolution now goes through `VectorQuery_SetField` too
6. Lemon grammars (`query_parser/v1`, `v2`) — `parser.y` edited, `parser.c` regenerated to match

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
