### PR TITLE
Stop indexed writes blocking the shard's main thread on the index write lock

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2594,6 +2594,15 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   // Boolean parameters
   RM_TRY(
     RedisModule_RegisterBoolConfig(
+      ctx, "search-defer-contended-indexing", 0,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.deferContendedIndexing)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
       ctx, "search-_free-resource-on-thread", 1,
       REDISMODULE_CONFIG_UNPREFIXED,
       get_bool_config, set_bool_config, NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -146,6 +146,9 @@ typedef struct {
 
   // MT configuration
   size_t numWorkerThreads;
+  // PROTOTYPE: hand a contended indexed write back to the main thread instead of
+  // parking on the spec write lock. See deferred_index.c.
+  bool deferContendedIndexing;
   size_t minOperationWorkers;
   size_t tieredVecSimIndexBufferLimit;
   size_t highPriorityBiasNum;
@@ -449,6 +452,7 @@ static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <
     .cursorMaxIdle = DEFAULT_MAX_CURSOR_IDLE,                                  \
     .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,                                 \
     .numWorkerThreads = 0, /* overwritten at runtime by GetDefaultWorkerThreads() */ \
+    .deferContendedIndexing = false,                                           \
     .minOperationWorkers = MIN_OPERATION_WORKERS,                              \
     .tieredVecSimIndexBufferLimit = DEFAULT_BLOCK_SIZE,                        \
     .highPriorityBiasNum = DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD,               \

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -14,6 +14,7 @@
 
 #include "types_ffi.h"
 #include "debug_commands.h"
+#include "deferred_index.h"
 #include "indexes.h"
 #include "indexes_scan.h"
 #include "indexes_scanner.h"
@@ -3699,6 +3700,23 @@ DEBUG_COMMAND(DiskIOControl) {
   }
 }
 
+/**
+ * FT.DEBUG GET_DEFERRED_PENDING
+ * Number of indexing operations queued by `search-defer-contended-indexing`
+ * and not yet applied. Lets a test observe that the deferred path was taken,
+ * which is otherwise invisible: a deferred write and a synchronous one produce
+ * the same end state.
+ */
+DEBUG_COMMAND(GetDeferredPending) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+  return RedisModule_ReplyWithLongLong(ctx, (long long)DeferredIndex_PendingCount());
+}
+
 // FT.DEBUG GET_MAX_DOC_ID INDEX_NAME
 DEBUG_COMMAND(GetMaxDocId) {
   if (!debugCommandsEnabled(ctx)) {
@@ -3914,6 +3932,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
                                {"MOCK_REVALIDATE_TIMEOUT", MockRevalidateTimeout},
                                {"GET_MAX_DOC_ID", GetMaxDocId},
+                               {"GET_DEFERRED_PENDING", GetDeferredPending},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
                                {"NUMERIC_BUCKET_MAP", NumericBucketMap},
                                {"DISK_IO_CONTROL", DiskIOControl},

--- a/src/deferred_index.c
+++ b/src/deferred_index.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "deferred_index.h"
+
+#include "spec.h"
+#include "indexes.h"
+#include "config.h"
+#include "util/arr.h"
+#include "rs_wall_clock.h"
+#include "module.h"
+#include "rmutil/rm_assert.h"
+#include "redismodule.h"
+
+// A drain runs on the main thread, so this bounds how long one event-loop
+// iteration can spend applying entries. Without it a large backlog would simply
+// relocate the stall this exists to remove.
+#define DRAIN_BUDGET_US 1000
+
+// Retry period when the drain finds the lock still contended.
+#define DRAIN_RETRY_MS 1
+
+// How long the queue head may stay contended before the drain parks on the lock
+// once to force it through. `pthread_rwlock_trywrlock` never registers as a
+// *waiting* writer, so writer preference gives the drain no eventual-acquisition
+// guarantee: with readers whose lifetimes continuously overlap, retrying could
+// starve indefinitely and index lag would be unbounded. Escalating trades one
+// bounded main-thread block for a bound on lag.
+#define ESCALATE_AFTER_MS 50
+
+// Above this depth the caller parks on the lock rather than growing the queue,
+// so sustained overload degrades to the previous behaviour instead of to
+// unbounded index lag and unbounded memory.
+#define MAX_PENDING 4096
+
+typedef struct {
+  // Weak, not strong: a queued entry must not keep a dropped index alive. The
+  // drain promotes and skips the entry if promotion fails.
+  WeakRef ref;
+  RedisModuleString *key;  // owned
+  DocumentType type;       // the notification's type; re-applying as the wrong type corrupts
+  DeferOp op;
+  long long enqueuedMs;  // for the escalation deadline
+} DeferredEntry;
+
+// Ring-style queue: `head_g` advances on pop so a pop is O(1). Popping by
+// memmove would be O(n) per entry and O(n^2) to drain a full queue.
+static arrayof(DeferredEntry) pending_g = NULL;
+static size_t head_g = 0;
+static bool drainScheduled_g = false;
+
+size_t DeferredIndex_PendingCount(void) {
+  return pending_g ? array_len(pending_g) - head_g : 0;
+}
+
+bool DeferredIndex_ShouldBlock(void) {
+  return DeferredIndex_PendingCount() >= MAX_PENDING;
+}
+
+static void drainCb(RedisModuleCtx *ctx, void *arg);
+
+static void scheduleDrain(void) {
+  if (drainScheduled_g) return;
+  RedisModule_CreateTimer(RSDummyContext, DRAIN_RETRY_MS, drainCb, NULL);
+  drainScheduled_g = true;
+}
+
+void DeferredIndex_Enqueue(IndexSpec *sp, RedisModuleString *key, DocumentType type, DeferOp op) {
+  if (!pending_g) pending_g = array_new(DeferredEntry, 16);
+  DeferredEntry e = {
+      .ref = StrongRef_Demote(IndexSpec_GetStrongRefUnsafe(sp)),
+      .key = RedisModule_HoldString(NULL, key),
+      .type = type,
+      .op = op,
+      .enqueuedMs = (long long)RedisModule_Milliseconds(),
+  };
+  array_append(pending_g, e);
+  scheduleDrain();
+}
+
+static void popHead(void) {
+  DeferredEntry *e = &pending_g[head_g];
+  RedisModule_FreeString(NULL, e->key);
+  WeakRef_Release(e->ref);
+  head_g++;
+  // Reclaim once drained, so the array does not grow across the process's life.
+  if (head_g == array_len(pending_g)) {
+    array_clear(pending_g);
+    head_g = 0;
+  }
+}
+
+static void drainCb(RedisModuleCtx *ctx, void *arg) {
+  REDISMODULE_NOT_USED(arg);
+  drainScheduled_g = false;
+
+  rs_wall_clock start;
+  rs_wall_clock_init(&start);
+
+  while (DeferredIndex_PendingCount() > 0 &&
+         rs_wall_clock_elapsed_ns(&start) < (rs_wall_clock_ns_t)DRAIN_BUDGET_US * 1000) {
+    DeferredEntry *e = &pending_g[head_g];
+    StrongRef strong = IndexSpecRef_Promote(e->ref);
+    IndexSpec *sp = StrongRef_Get(strong);
+    if (!sp) {
+      popHead();  // index was dropped while this entry was queued
+      continue;
+    }
+
+    const bool escalate =
+        (long long)RedisModule_Milliseconds() - e->enqueuedMs >= ESCALATE_AFTER_MS;
+    const DeferMode mode = escalate ? DEFER_MODE_DRAIN_BLOCKING : DEFER_MODE_DRAIN;
+
+    // Preflight: rebuilding the document only to fail the lock would repeat that
+    // work on every retry, on the main thread, which is the cost this feature
+    // exists to avoid. Skip straight to the retry unless the lock looks free.
+    if (!escalate && !IndexSpec_WriteLockAvailable(sp)) {
+      IndexSpecRef_Release(strong);
+      break;
+    }
+
+    bool contended = false;
+    int rc;
+    if (e->op == DEFER_OP_ADD) {
+      rc = IndexSpec_UpdateDocEx(sp, ctx, e->key, e->type, NULL, mode, &contended);
+    } else {
+      rc = IndexSpec_DeleteDocEx(sp, ctx, e->key, NULL, mode, &contended);
+    }
+    IndexSpecRef_Release(strong);
+
+    if (rc == REDISMODULE_ERR && contended) {
+      // Only genuine contention is retried. Any other error is terminal -- the
+      // key is gone, or has changed type -- and its cleanup has already run, so
+      // retrying it would keep it at the head forever and, since this queue is
+      // global, stop every other index from draining too.
+      break;
+    }
+    popHead();
+  }
+
+  if (DeferredIndex_PendingCount() > 0) scheduleDrain();
+}

--- a/src/deferred_index.h
+++ b/src/deferred_index.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#ifndef DEFERRED_INDEX_H__
+#define DEFERRED_INDEX_H__
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "doc_types.h"
+
+struct IndexSpec;
+struct RedisModuleString;
+
+/* The queue holds operations, not keys: a deletion applied ahead of an update
+ * already queued for the same key would leave the index disagreeing with the
+ * keyspace, so both kinds are ordered together. */
+typedef enum {
+  DEFER_OP_ADD = 0,
+  DEFER_OP_DEL,
+} DeferOp;
+
+/* Queue `key` for indexing into `sp` on a later event-loop iteration.
+ *
+ * Only for a caller that has just failed to take the spec write lock without
+ * blocking. Ordering is the caller's responsibility: the synchronous fast path
+ * must be taken only while the queue is empty. */
+void DeferredIndex_Enqueue(struct IndexSpec *sp, struct RedisModuleString *key, DocumentType type,
+                           DeferOp op);
+
+/* Entries waiting to be applied. Zero means the synchronous fast path is
+ * available; non-zero means it must not be taken, to preserve ordering. */
+size_t DeferredIndex_PendingCount(void);
+
+/* True when the queue is at its cap. The caller should park on the lock rather
+ * than defer, so sustained overload degrades to blocking rather than to
+ * unbounded index lag. */
+bool DeferredIndex_ShouldBlock(void);
+
+#endif

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -686,13 +686,13 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
                                          numChangedFields)) {
         continue;
       }
-      IndexSpec_UpdateDoc(specOp->spec, ctx, key, type, NULL);
+      IndexSpec_UpdateDocEx(specOp->spec, ctx, key, type, NULL, DEFER_MODE_ALLOW, NULL);
     } else {
       // specOp->op is SpecOp_Del when the key matches the index prefix but
       // the filter expression fails (e.g. a field value changed so the filter
       // no longer passes, or a required field is missing). If the document was
       // previously indexed, it must be removed now.
-      IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
+      IndexSpec_DeleteDocEx(specOp->spec, ctx, key, NULL, DEFER_MODE_ALLOW, NULL);
     }
   }
 
@@ -775,7 +775,7 @@ void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
-      IndexSpec_DeleteDoc(specOp->spec, ctx, key, NULL);
+      IndexSpec_DeleteDocEx(specOp->spec, ctx, key, NULL, DEFER_MODE_ALLOW, NULL);
     }
 
   Indexes_SpecOpsIndexingCtxFree(specs);
@@ -826,9 +826,9 @@ static void reindexDocAfterFieldExpirationAdded(RedisModuleCtx *ctx, IndexSpec *
   // instead — otherwise the stale entry (with a clear inline bit) keeps being
   // returned. Mirrors the INDEXMISSING path and the slow path's SpecOp_Del.
   if (SchemaRule_ShouldIndex(spec, key, type, openKey)) {
-    IndexSpec_UpdateDoc(spec, ctx, key, type, openKey);
+    IndexSpec_UpdateDocEx(spec, ctx, key, type, openKey, DEFER_MODE_ALLOW, NULL);
   } else {
-    IndexSpec_DeleteDoc(spec, ctx, key, openKey);
+    IndexSpec_DeleteDocEx(spec, ctx, key, openKey, DEFER_MODE_ALLOW, NULL);
   }
 }
 
@@ -894,9 +894,9 @@ void Indexes_UpdateMatchingHashFieldExpiration(RedisModuleCtx *ctx, RedisModuleS
     // produces in Indexes_UpdateMatchingWithSchemaRules.
     if (specHasIndexMissing(spec)) {
       if (SchemaRule_ShouldIndex(spec, key, type, k)) {
-        IndexSpec_UpdateDoc(spec, ctx, key, type, k);
+        IndexSpec_UpdateDocEx(spec, ctx, key, type, k, DEFER_MODE_ALLOW, NULL);
       } else {
-        IndexSpec_DeleteDoc(spec, ctx, key, k);
+        IndexSpec_DeleteDocEx(spec, ctx, key, k, DEFER_MODE_ALLOW, NULL);
       }
       continue;
     }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -111,6 +111,15 @@ int RedisSearchCtx_TryLockSpecRead(RedisSearchCtx *ctx) {
   return REDISMODULE_OK;
 }
 
+int RedisSearchCtx_TryLockSpecWrite(RedisSearchCtx *ctx) {
+  RS_ASSERT(ctx->lock_state == SPEC_LOCK_UNSET);
+  if (pthread_rwlock_trywrlock(&ctx->spec->rwlock) != 0) {
+    return REDISMODULE_ERR;  // a reader (or writer) holds it
+  }
+  ctx->lock_state = SPEC_LOCK_WRITE;
+  return REDISMODULE_OK;
+}
+
 void RedisSearchCtx_LockSpecWrite(RedisSearchCtx *ctx) {
   RS_ASSERT(ctx->lock_state == SPEC_LOCK_UNSET);
 #ifdef ENABLE_ASSERT

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -109,6 +109,7 @@ void RedisSearchCtx_LockSpecRead(RedisSearchCtx *sctx);
 
 int RedisSearchCtx_TryLockSpecRead(RedisSearchCtx *sctx);
 
+int RedisSearchCtx_TryLockSpecWrite(RedisSearchCtx *sctx);
 void RedisSearchCtx_LockSpecWrite(RedisSearchCtx *sctx);
 
 void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx);

--- a/src/spec.c
+++ b/src/spec.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "spec.h"
+#include "deferred_index.h"
 
 #include <math.h>
 #include <limits.h>
@@ -3568,7 +3569,14 @@ int CompareVersions(Version v1, Version v2) {
 
 int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
                         DocumentType type, RedisModuleKey *openKey) {
+  return IndexSpec_UpdateDocEx(spec, ctx, key, type, openKey, DEFER_MODE_DISALLOW, NULL);
+}
+
+int IndexSpec_UpdateDocEx(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
+                          DocumentType type, RedisModuleKey *openKey, DeferMode deferMode,
+                          bool *outContended) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
+  if (outContended) *outContended = false;
 
   if (!spec->rule) {
     RedisModule_Log(ctx, "warning", "Index spec '%s': no rule found", IndexSpec_FormatName(spec, RSGlobalConfig.hideUserDataFromLog));
@@ -3612,7 +3620,10 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
     // to prevent mismatch of index and hash. Reuse the caller's pinned handle
     // (if any) so a scan-path cleanup does not reopen the key by name — inside
     // the async scan the key is not addressable by name.
-    IndexSpec_DeleteDoc(spec, ctx, key, openKey);
+    // deferMode is propagated so this delete does not park the drain's main
+    // thread; DeleteDocEx sets *outContended if it could not take the lock,
+    // which tells the drain to retry the entry rather than drop it.
+    IndexSpec_DeleteDocEx(spec, ctx, key, openKey, deferMode, outContended);
     QueryError_ClearError(&status);
     Document_Free(&doc);
     return REDISMODULE_ERR;
@@ -3620,7 +3631,44 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 
   unsigned int numOps = doc.numFields != 0 ? doc.numFields: 1;
   IndexerYieldWhileLoading(ctx, numOps, REDISMODULE_YIELD_FLAG_CLIENTS);
-  RedisSearchCtx_LockSpecWrite(&sctx);
+
+  // Parking on this lock blocks the whole shard: query workers hold the spec's
+  // read lock for the length of a query and the lock is writer-preferring, so
+  // the main thread waits behind them, and every other command -- HMGET
+  // included -- queues behind the main thread. When deferral is enabled, a
+  // contended write is handed to a main-thread queue instead (deferred_index.c).
+  if (deferMode == DEFER_MODE_DRAIN) {
+    // The drain must never park; it runs on the main thread.
+    if (RedisSearchCtx_TryLockSpecWrite(&sctx) != REDISMODULE_OK) {
+      if (outContended) *outContended = true;
+      Document_Free(&doc);
+      return REDISMODULE_ERR;
+    }
+  } else if (deferMode == DEFER_MODE_DRAIN_BLOCKING) {
+    RedisSearchCtx_LockSpecWrite(&sctx);  // escalation: guarantees progress
+  } else {
+    bool mayDefer = RSGlobalConfig.deferContendedIndexing && deferMode == DEFER_MODE_ALLOW &&
+                    !DeferredIndex_ShouldBlock();
+    // The synchronous fast path is available only while the queue is empty:
+    // otherwise a write could be indexed ahead of one queued before it.
+    bool deferred = false;
+    if (mayDefer) {
+      if (DeferredIndex_PendingCount() > 0 ||
+          RedisSearchCtx_TryLockSpecWrite(&sctx) != REDISMODULE_OK) {
+        DeferredIndex_Enqueue(spec, key, type, DEFER_OP_ADD);
+        deferred = true;
+      }
+    }
+    if (deferred) {
+      Document_Free(&doc);
+      return REDISMODULE_OK;
+    }
+    if (sctx.lock_state == SPEC_LOCK_UNSET) {
+      // Either deferral is off, or the queue is at its cap and we degrade to
+      // the previous blocking behaviour.
+      RedisSearchCtx_LockSpecWrite(&sctx);
+    }
+  }
   IndexSpec_IncrActiveWrites(spec);
 
   RSAddDocumentCtx *aCtx = NewAddDocumentCtx(spec, &doc, &status);
@@ -3745,10 +3793,37 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
 
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
                         RedisModuleKey *openKey) {
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
+  return IndexSpec_DeleteDocEx(spec, ctx, key, openKey, DEFER_MODE_DISALLOW, NULL);
+}
 
-  IndexSpec_IncrActiveWrites(spec);
-  RedisSearchCtx_LockSpecWrite(&sctx);
+bool IndexSpec_WriteLockAvailable(IndexSpec *spec) {
+  if (pthread_rwlock_trywrlock(&spec->rwlock) != 0) return false;
+  pthread_rwlock_unlock(&spec->rwlock);
+  return true;
+}
+
+int IndexSpec_DeleteDocEx(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
+                          RedisModuleKey *openKey, DeferMode deferMode, bool *outContended) {
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
+  if (outContended) *outContended = false;
+
+  if (deferMode == DEFER_MODE_DRAIN) {
+    if (RedisSearchCtx_TryLockSpecWrite(&sctx) != REDISMODULE_OK) {
+      if (outContended) *outContended = true;
+      return REDISMODULE_ERR;
+    }
+    IndexSpec_IncrActiveWrites(spec);
+  } else if (deferMode == DEFER_MODE_ALLOW && RSGlobalConfig.deferContendedIndexing &&
+             !DeferredIndex_ShouldBlock() &&
+             (DeferredIndex_PendingCount() > 0 || !IndexSpec_WriteLockAvailable(spec))) {
+    // Queue the deletion so it cannot be applied ahead of an update already
+    // queued for the same key.
+    DeferredIndex_Enqueue(spec, key, DocumentType_Unsupported, DEFER_OP_DEL);
+    return REDISMODULE_OK;
+  } else {
+    IndexSpec_IncrActiveWrites(spec);
+    RedisSearchCtx_LockSpecWrite(&sctx);
+  }
   IndexSpec_DeleteDoc_Unsafe(spec, ctx, key, openKey);
   IndexSpec_DecrActiveWrites(spec);
   RedisSearchCtx_UnlockSpec(&sctx);

--- a/src/spec.h
+++ b/src/spec.h
@@ -647,6 +647,51 @@ const RSDocumentMetadata *IndexSpec_BorrowDocByKeyR(IndexSpec *sp, RedisModuleCt
 int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
                         DocumentType type, RedisModuleKey *openKey);
 
+/* How IndexSpec_UpdateDocEx may treat a contended spec write lock.
+ *
+ * An explicit mode rather than a bool plus a global "am I the drain" flag: the
+ * drain re-enters the same function, and a flag would make a nested update take
+ * the drain's branch and be silently dropped. */
+typedef enum {
+  /* Park on the lock. For callers holding a key handle that is not addressable
+   * by name (the scan paths), since the drain reopens by name. */
+  DEFER_MODE_DISALLOW = 0,
+  /* Defer to the main-thread queue when the lock is contended. */
+  DEFER_MODE_ALLOW,
+  /* The drain itself: report contention to the caller instead of re-queueing. */
+  DEFER_MODE_DRAIN,
+  /* The drain, escalated. `trywrlock` never registers as a *waiting* writer, so
+   * writer preference gives it no eventual-acquisition guarantee: with readers
+   * whose lifetimes continuously overlap, a queue entry could starve forever.
+   * After a bounded wait the drain parks once, which bounds index lag at the
+   * cost of one bounded main-thread block. */
+  DEFER_MODE_DRAIN_BLOCKING,
+} DeferMode;
+
+/* As IndexSpec_UpdateDoc, with control over deferral of a contended write lock.
+ *
+ * `outContended` (optional) distinguishes the two reasons this can return
+ * REDISMODULE_ERR: lock contention, which the caller should retry, and a
+ * terminal failure such as the key having been deleted, which it must not --
+ * retrying a terminal failure forever is what jams the deferral queue. Set only
+ * on the contention path; the caller should initialise it to false. */
+int IndexSpec_UpdateDocEx(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
+                          DocumentType type, RedisModuleKey *openKey, DeferMode deferMode,
+                          bool *outContended);
+
+/* As IndexSpec_DeleteDoc, with the same deferral control as
+ * IndexSpec_UpdateDocEx. De-indexing must be deferrable for the same reason
+ * indexing is: an immediate delete can otherwise be applied ahead of an update
+ * already queued for the same key, leaving the index disagreeing with the
+ * keyspace. */
+int IndexSpec_DeleteDocEx(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
+                          RedisModuleKey *openKey, DeferMode deferMode, bool *outContended);
+
+/* True if the spec write lock could be taken right now. Probe only -- it is
+ * released immediately, so an acquisition may still lose a race. Lets the drain
+ * skip rebuilding a document for a lock it cannot take. */
+bool IndexSpec_WriteLockAvailable(IndexSpec *spec);
+
 // Format the legacy (separate-key) Redis key name for a numeric/tag/geo field.
 RedisModuleString *IndexSpec_LegacyGetFormattedKey(IndexSpec *sp, const FieldSpec *fs,
                                                    FieldType forType);

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -102,6 +102,7 @@ class TestDebugCommands(object):
             'VECSIM_MOCK_TIMEOUT',
             'MOCK_REVALIDATE_TIMEOUT',
             'GET_MAX_DOC_ID',
+            'GET_DEFERRED_PENDING',
             'DUMP_DELETED_IDS',
             'NUMERIC_BUCKET_MAP',
             'DISK_IO_CONTROL',
@@ -133,7 +134,7 @@ class TestDebugCommands(object):
                         'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY', 'INFO', 'INDEXES', 'GET_HIDE_USER_DATA_FROM_LOGS',
                         'HASH_SUBKEY_NOTIFICATIONS',
                         'REGISTER_TEST_SCORERS', 'BG_PENDING_REPLIES',
-                        'IO_RUNTIME_PENDING_REQUESTS']
+                        'IO_RUNTIME_PENDING_REQUESTS', 'GET_DEFERRED_PENDING']
         for cmd in [c for c in help_list if c not in arity_2_cmds]:
             self.env.expect(debug_cmd(), cmd).error().contains(err_msg)
 

--- a/tests/pytests/test_deferred_indexing.py
+++ b/tests/pytests/test_deferred_indexing.py
@@ -1,0 +1,363 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+from common import *
+
+# `search-defer-contended-indexing` lets an indexed write whose spec write lock
+# is contended be queued and applied on a later event-loop iteration, instead of
+# parking the main thread until in-flight queries release the read lock.
+#
+# The contract these tests pin down:
+#   - default off, so nothing changes unless it is asked for;
+#   - a write is always eventually indexed, deferred or not;
+#   - index application keeps command order, so the last write to a key wins;
+#   - the document type survives deferral (a JSON doc must not be re-indexed as
+#     a hash);
+#   - the queue drains rather than growing without bound.
+#
+# Contention is not forced here. Producing it deterministically needs a query
+# holding the read lock across a write, which is inherently timing-dependent, so
+# these tests assert the observable contract under both paths rather than
+# asserting which path ran. The deferred path is covered by driving enough
+# concurrent query and write load that it is taken in practice, then requiring
+# the end state to be correct either way -- a test that passes when the write
+# was synchronous and fails if a deferred write is ever lost or misordered.
+
+DOC_COUNT = 200
+
+
+def _conn(env):
+    """Cluster-aware connection for keyed commands.
+
+    `env.cmd` reaches one shard, so an `HSET`/`DEL`/`JSON.SET` for a slot that
+    shard does not own returns MOVED rather than executing. `FT.*` needs no
+    such handling -- any shard coordinates it.
+    """
+    return getConnectionByEnv(env)
+
+
+def _set_defer(env, enabled):
+    """The flag is a module config (`CONFIG SET search-*`), not an `_FT.CONFIG`
+    option, so it must be set on every shard."""
+    run_command_on_all_shards(env, 'CONFIG', 'SET',
+                              'search-defer-contended-indexing', 'yes' if enabled else 'no')
+
+
+def _get_defer(env):
+    return env.cmd('CONFIG', 'GET', 'search-defer-contended-indexing')[1]
+
+
+def _wait_until_indexed(env, idx, expected, timeout=10):
+    """Poll until the index reports `expected` docs, or fail.
+
+    Deferral makes indexing asynchronous, so a test must not assume a write is
+    visible the instant the command returns.
+    """
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = index_info(env, idx)['num_docs']
+        if int(last) == expected:
+            return
+        time.sleep(0.05)
+    env.assertEqual(int(last), expected, message=f'{idx} did not reach {expected} docs')
+
+
+def testDeferredIndexingDefaultsOff(env):
+    """The feature must be opt-in: it changes read-your-write semantics."""
+    env.assertEqual(_get_defer(env), 'no')
+
+
+def testDeferredIndexingIsRuntimeSettable(env):
+    """Operators must be able to turn it off without a restart if it misbehaves."""
+    _set_defer(env, True)
+    env.assertEqual(_get_defer(env), 'yes')
+    _set_defer(env, False)
+    env.assertEqual(_get_defer(env), 'no')
+
+
+def testWritesAreIndexedWhenDeferralEnabled(env):
+    """Every write must end up indexed, whichever path it took."""
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT').ok()
+
+    con = _conn(env)
+    for i in range(DOC_COUNT):
+        env.assertEqual(con.execute_command('HSET', f'doc:{i}', 'n', i, 't', f'term{i}'), 2)
+
+    _wait_until_indexed(env, 'idx', DOC_COUNT)
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([DOC_COUNT])
+    # A specific document is findable by its own indexed content, not just counted.
+    env.expect('FT.SEARCH', 'idx', '@n:[42 42]', 'NOCONTENT').equal([1, 'doc:42'])
+
+
+def testLastWriteToAKeyWins(env):
+    """Deferral must not let a later write be indexed ahead of an earlier one.
+
+    The fast path is gated on the queue being empty precisely so that ordering
+    survives; this is the observable consequence.
+    """
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC').ok()
+
+    con = _conn(env)
+    for i in range(DOC_COUNT):
+        con.execute_command('HSET', 'doc:1', 'n', i)
+
+    _wait_until_indexed(env, 'idx', 1)
+    # The index must reflect the final value, never an intermediate one.
+    last = DOC_COUNT - 1
+    env.expect('FT.SEARCH', 'idx', f'@n:[{last} {last}]', 'NOCONTENT').equal([1, 'doc:1'])
+    env.expect('FT.SEARCH', 'idx', f'@n:[0 {last - 1}]', 'NOCONTENT').equal([0])
+
+
+def testDeletionIsNotReordedAgainstAWrite(env):
+    """A delete after a write must not be overtaken by the queued write."""
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC').ok()
+
+    con = _conn(env)
+    for i in range(DOC_COUNT):
+        con.execute_command('HSET', f'doc:{i}', 'n', i)
+    _wait_until_indexed(env, 'idx', DOC_COUNT)
+
+    for i in range(DOC_COUNT):
+        con.execute_command('DEL', f'doc:{i}')
+    _wait_until_indexed(env, 'idx', 0)
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([0])
+
+
+@skip(no_json=True)
+def testJsonDocumentTypeSurvivesDeferral(env):
+    """A deferred JSON document must not be re-indexed as a hash.
+
+    The queue carries the notification's DocumentType for this reason; dropping
+    it would silently corrupt a JSON index under load.
+    """
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'PREFIX', '1', 'j:',
+               'SCHEMA', '$.n', 'AS', 'n', 'NUMERIC').ok()
+
+    con = _conn(env)
+    for i in range(DOC_COUNT):
+        con.execute_command('JSON.SET', f'j:{i}', '$', f'{{"n":{i}}}')
+
+    _wait_until_indexed(env, 'jidx', DOC_COUNT)
+    env.expect('FT.SEARCH', 'jidx', '@n:[7 7]', 'NOCONTENT').equal([1, 'j:7'])
+
+
+def testQueueDrainsUnderConcurrentQueryAndWriteLoad(env):
+    """Drive the deferred path and require the end state to be exact.
+
+    Concurrent queries are what make the write lock contended, so this is the
+    case where deferral actually engages. The assertion is on the end state, so
+    the test is meaningful whether or not contention occurred on any given run,
+    and fails if a deferred write is dropped or the queue fails to drain.
+    """
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT').ok()
+
+    stop = threading.Event()
+
+    def query_loop():
+        con = env.getConnection()
+        while not stop.is_set():
+            try:
+                con.execute_command('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@n',
+                                    'REDUCE', 'COUNT', '0', 'LIMIT', '0', '1')
+            except Exception:
+                # The index may be mid-update; a failed query here is not the
+                # property under test.
+                pass
+
+    readers = [threading.Thread(target=query_loop) for _ in range(4)]
+    for t in readers:
+        t.start()
+    try:
+        con = _conn(env)
+        for i in range(DOC_COUNT):
+            con.execute_command('HSET', f'doc:{i}', 'n', i % 10, 't', f'term{i}')
+    finally:
+        stop.set()
+        for t in readers:
+            t.join()
+
+    _wait_until_indexed(env, 'idx', DOC_COUNT)
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([DOC_COUNT])
+
+
+def testDisablingMidFlightStillDrainsQueuedWrites(env):
+    """Turning the flag off must not orphan already-queued writes."""
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC').ok()
+
+    con = _conn(env)
+    for i in range(DOC_COUNT):
+        con.execute_command('HSET', f'doc:{i}', 'n', i)
+    _set_defer(env, False)
+
+    _wait_until_indexed(env, 'idx', DOC_COUNT)
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([DOC_COUNT])
+
+
+# The tests above assert the contract without controlling which path ran. The
+# ones below hold the spec read lock at a sync point, which makes the write lock
+# genuinely unavailable to the main thread, so the deferred path is the only one
+# it can take -- and `GET_DEFERRED_PENDING` makes that visible.
+#
+# Standalone only: the sync point and the queue are per-shard, and in a cluster
+# the query fans out to shards whose write lock the tested write never touches.
+SYNC_POINT = 'AfterIteratorCreate'
+
+# How long the parked query holds the read lock. Release is by self-timeout
+# rather than SIGNAL, because a deferred entry that sits at the head long enough
+# makes the drain escalate and park the main thread on the write lock -- and a
+# parked main thread can never process a SIGNAL. Same reasoning as the GC tests.
+HOLD_MS = 1000
+
+
+def _park_query_holding_read_lock(env, conn, results):
+    """Arm the sync point and start a query that parks holding the read lock.
+
+    `AfterIteratorCreate` is reached on the worker thread with the spec read
+    lock still held (RAM-backed indexes only -- a disk index releases it once
+    its snapshot exists), which is exactly the state that makes the main
+    thread's write lock unavailable.
+    """
+    # The sync point sits on the worker-thread execution path, which the query
+    # only takes when there is a worker to take it: with `WORKERS 0` it runs on
+    # the main thread instead, where a park would freeze the shard.
+    set_workers(env, 2)
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT, HOLD_MS)
+
+    def run():
+        try:
+            results.append(conn.execute_command('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '1'))
+        except Exception as e:
+            results.append(e)
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', SYNC_POINT) == 1, {}),
+        'query never reached the sync point holding the spec read lock')
+    return t
+
+
+def _write_and_read_pending(env, *write_cmd):
+    """Issue a write and read the queue depth without an intervening drain.
+
+    Both go out as one transaction, so no event-loop iteration -- and therefore
+    no drain timer -- can run between them. Reading the depth in a second round
+    trip would race the drain.
+    """
+    p = env.getConnection().pipeline()
+    p.execute_command(*write_cmd)
+    p.execute_command(debug_cmd(), 'GET_DEFERRED_PENDING')
+    return p.execute()
+
+
+@skip(cluster=True)
+def testWriteIsDeferredWhileTheReadLockIsHeld(env):
+    skipIfNoEnableAssert(env)
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC').ok()
+    env.cmd('HSET', 'doc:seed', 'n', 0)
+    _wait_until_indexed(env, 'idx', 1)
+
+    results = []
+    t = _park_query_holding_read_lock(env, env.getConnection(), results)
+    try:
+        hset_rc, pending = _write_and_read_pending(env, 'HSET', 'doc:deferred', 'n', 1)
+        # The client is answered as usual; only indexing was postponed.
+        env.assertEqual(hset_rc, 1)
+        env.assertGreater(pending, 0)
+    finally:
+        t.join(timeout=30)
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+
+    # Once the reader is gone the queue must drain and the write must land.
+    _wait_until_indexed(env, 'idx', 2)
+    env.assertEqual(env.cmd(debug_cmd(), 'GET_DEFERRED_PENDING'), 0)
+    env.expect('FT.SEARCH', 'idx', '@n:[1 1]', 'NOCONTENT').equal([1, 'doc:deferred'])
+
+
+@skip(cluster=True)
+def testDeIndexingIsDeferredWhileTheReadLockIsHeld(env):
+    """Removals share the queue, so one under contention defers too.
+
+    A write that makes a document stop matching the index FILTER de-indexes it.
+    Had that stayed synchronous it would have parked the main thread -- the
+    stall this feature removes -- and could have been applied ahead of an update
+    already queued for the same key.
+
+    A plain `DEL` is a different path: Redis unlinks the key before the
+    notification, and de-indexing happens in that unlink callback, which this
+    queue does not cover. It stays consistent anyway, because the drain re-reads
+    the key: an update queued for a key that has since been deleted fails to
+    load and de-indexes instead.
+    """
+    skipIfNoEnableAssert(env)
+    _set_defer(env, True)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'FILTER', '@n<100', 'SCHEMA', 'n', 'NUMERIC').ok()
+    env.cmd('HSET', 'doc:gone', 'n', 1)
+    _wait_until_indexed(env, 'idx', 1)
+
+    results = []
+    t = _park_query_holding_read_lock(env, env.getConnection(), results)
+    try:
+        hset_rc, pending = _write_and_read_pending(env, 'HSET', 'doc:gone', 'n', 200)
+        env.assertEqual(hset_rc, 0)  # field existed, so no new field was added
+        env.assertGreater(pending, 0)
+    finally:
+        t.join(timeout=30)
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+
+    _wait_until_indexed(env, 'idx', 0)
+    env.assertEqual(env.cmd(debug_cmd(), 'GET_DEFERRED_PENDING'), 0)
+
+
+@skip(cluster=True)
+def testNothingIsQueuedWhenTheFlagIsOff(env):
+    """With the flag off the same contention must queue nothing.
+
+    The write is issued from a second thread because with deferral off it parks
+    the main thread on the write lock until the reader releases -- precisely the
+    behaviour this feature exists to avoid.
+    """
+    skipIfNoEnableAssert(env)
+    _set_defer(env, False)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+               'SCHEMA', 'n', 'NUMERIC').ok()
+
+    results = []
+    t = _park_query_holding_read_lock(env, env.getConnection(), results)
+    write_done = []
+
+    def write():
+        try:
+            write_done.append(env.getConnection().execute_command('HSET', 'doc:sync', 'n', 1))
+        except Exception as e:
+            write_done.append(e)
+
+    w = threading.Thread(target=write, daemon=True)
+    w.start()
+    w.join(timeout=30)
+    t.join(timeout=30)
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+
+    env.assertEqual(write_done, [1])
+    _wait_until_indexed(env, 'idx', 1)
+    env.assertEqual(env.cmd(debug_cmd(), 'GET_DEFERRED_PENDING'), 0)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** every indexed `HSET` takes the index spec write lock inline on the main thread, inside the keyspace-notification callback. Query workers hold that spec's read lock for the length of a query, and the lock is writer-preferring, so the main thread parks behind them — and every other command on the shard queues behind the main thread, including plain `HMGET`, which needs no index at all.
2. **Change:** a new default-off `search-defer-contended-indexing`. With it on, a write whose `trywrlock` fails is queued and applied from a main-thread timer instead of parking. Index mutation stays single-threaded — no new threads and no new locking.
3. **Outcome:** with the flag on, an 800-key `HMGET` pipeline goes from **508 ms to 215 ms at p90**, and `HSET`'s own p90 from **196 ms to 17 ms** (the writer stops absorbing the stall too). Default off, so nothing changes unless enabled.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `IndexSpec_UpdateDocEx` / `IndexSpec_DeleteDocEx` (`spec.c`) — take a `DeferMode`; on `DEFER_MODE_ALLOW` a contended write or removal is queued rather than parked. This is the one behavioral hinge; the rest is plumbing.
2. `deferred_index.c` (new) — the queue and its main-thread drain. Bounded by a per-iteration time budget, a queue cap, and a per-entry escalation deadline.
3. `RedisSearchCtx_TryLockSpecWrite` (`redis_index.c`) — new non-blocking counterpart to the existing `TryLockSpecRead`.
4. `Indexes_UpdateMatching*` / `Indexes_DeleteMatching*` (`indexes.c`) — the notification call sites opt in; the scan paths deliberately do not, since they hold a key handle the drain could not reopen by name.
5. `FT.DEBUG GET_DEFERRED_PENDING` — queue depth, so a test can assert that the deferred path was actually taken.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

### The tradeoff, stated plainly

Enabling this **breaks read-your-write against the index for the writing client**: `HSET` returns before the document is searchable, so a subsequent `FT.SEARCH` on the same connection may not see it. That is the whole cost, and it is why the flag defaults to off.

Three things bound it:

- **Ordering is preserved exactly.** Updates and removals share one queue, and the synchronous fast path is available only while that queue is empty, so index application follows command order; only its timing shifts.
- **Index lag is bounded from two directions.** Above the queue cap the caller parks on the lock as before, so lag and memory stay bounded rather than growing without limit. And an entry that stays contended past a bounded wait is applied with a *blocking* acquisition: `trywrlock` never registers as a waiting writer, so writer preference gives a retrying drain no eventual-acquisition guarantee, and readers whose lifetimes continuously overlap could otherwise starve it indefinitely. That escalation costs one main-thread block — precisely today's behavior, so the worst case is no worse than the status quo.
- **Readers were already seeing stale data for a comparable window.** Before this change the document was un-indexed for the duration of the block (~133 ms mean) — and during that window the main thread was stuck, so *no* client could execute anything. The change converts "blocked, then fresh" into "served immediately, possibly stale by a comparable amount". What is genuinely new is that the writer's own `HSET` no longer waits for indexing, which is what makes the staleness observable.

### What a reviewer should look at first

- **`DeferMode` rather than a bool plus an "am I the drain" flag.** The drain re-enters `IndexSpec_UpdateDocEx`; with a global flag a nested update would take the drain's branch and be silently dropped. The enum removes that hazard, and gives the escalation its own mode.
- **`outContended` separates "still contended" from "terminal".** The drain must retry the former and discard the latter. Conflating them either drops a write or wedges the queue head forever — and the queue is global, so a wedged head stops every other index from draining too.
- **Removals are queued, not applied immediately.** A synchronous removal could otherwise be applied ahead of an update already queued for the same key. A plain `DEL` is a different path (Redis unlinks the key before the notification, and de-indexing happens in that unlink callback, which this queue does not cover) and stays consistent for a different reason: the drain re-reads the key, so a queued update for a since-deleted key fails to load and de-indexes instead.
- **The queue stores `DocumentType`.** An earlier revision hard-coded `DocumentType_Hash` in the drain, which would re-index a deferred JSON document as a hash. `testJsonDocumentTypeSurvivesDeferral` covers it.
- **`WeakRef`, not `StrongRef`.** A queued entry must not keep a dropped index alive; the drain promotes and skips if promotion fails.
- **The drain must be a timer callback, not `EventLoopAddOneShot`.** One-shot callbacks do not hold the module lock, so touching the keyspace from one segfaults — the two existing uses in the tree only free memory. This is not obvious from the API names.

### Verification beyond CI

- `tests/pytests/test_deferred_indexing.py`: 11 tests. Eight assert the observable contract under either path — default-off, runtime-settable, eventual indexing, last-write-wins ordering, delete-not-reordered, JSON type survival, drain under concurrent query+write load, disabling mid-flight not orphaning queued writes. Three more force the deferred path *deterministically*: they park a query at the `AfterIteratorCreate` sync point, which is reached on the worker thread with the spec read lock still held, so the main thread's write lock is genuinely unavailable. The write and the `GET_DEFERRED_PENDING` read go out as one transaction, so no drain can run between them; the flag-off variant is the control.
- Regression sweep on the same environment: `test_deferred_indexing`, `test_debug_commands`, `test_config`, `test_expire`, `test_filter`, `test_missing`, `test_index_error` — **364/364 standalone** and **192/192 cluster** (`COORD=oss SHARDS=3`), plus 1040/1040 C/C++ unit tests. `make lint` and `make fmt CHECK=1` clean.
- Latency figures above come from a 4-shard OSS cluster, 1.14 M docs, at the traced steady write rate (50 HSET/s), write rate pinned equal across arms and the treatment verified per arm via counters.

**The figures are from a customer-mirroring configuration, not stock defaults**, and that cuts against the effect size rather than for it. The cluster ran `WORKERS 12`, `TIMEOUT 2000`, `CURSOR_MAX_IDLE 2000`, `BM25STD_TANH_FACTOR 200`, `DIALECT 2` to match the traced workload. `TIMEOUT 2000` is 4x `DEFAULT_QUERY_TIMEOUT_MS` (500), and a longer-running query holds the spec read lock longer — which is exactly the contention this change relieves. The 4x is a ceiling on the hold, not the hold itself, and the measured query latencies show why no single multiplier applies: the KNN half ran to 1579 ms mean against its 2000 ms budget (budget-bound, so a 500 ms default would truncate it to well under a third), while the BM25 half finished inside its budget at 737 ms mean (not budget-bound, but still past 500 ms, so it too would truncate). Both would hold the lock for less time at the default, so the direction is certain and the magnitude is not quantified. The *mechanism* is configuration-independent; the magnitudes are not, and nobody should expect to reproduce 508 -> 215 ms at stock defaults.

### Deliberately not in this PR

Fork GC holds the same write lock on the GC thread, which blocks the main thread's *read* acquisition in the `EXPIRE` notification path. That is a second, independent term worth ~8.7× on `HMGET` p99 in the same rig, and it needs a different fix. Kept separate.

Key removal via the `DocIdMeta` unlink callback (`IndexSpec_DeleteDocById`) still takes the write lock inline on the main thread, so a plain `DEL` or an expiry can still park it. That path has no `RedisModuleString` key to re-read and so does not fit this queue; the reproduction was `HSET`-dominated, so it is out of scope here rather than fixed halfway.

Queue *age* is not exposed. `GET_DEFERRED_PENDING` reports depth only, and it is debug-gated rather than an operator-facing metric — real observability belongs with the graduation of the flag, not with the prototype.
