### PR TITLE
[MOD-18346] Align EC2 runner ownership tags

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -18,7 +18,6 @@ env:
       {"Key": "Environment",  "Value": "CI"},
       {"Key": "Run ID",       "Value": "${{ github.run_id }}"},
       {"Key": "PR",           "Value": "${{ github.event.number }}"},
-      {"Key": "Owner",        "Value": "${{ github.actor }}"},
       {"Key": "Project",      "Value": "${{ github.repository }}"},
       {"Key": "Context",      "Value": "micro-benchmarks"}
     ]
@@ -46,6 +45,30 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
+      - name: Prepare EC2 ownership tags
+        id: ec2-tags
+        # Keep the original workflow actor as owner, including on reruns.
+        env:
+          OWNER_HANDLE: ${{ github.actor }}
+        shell: python
+        run: |
+          import json
+          import os
+          import re
+
+          owner = os.environ["OWNER_HANDLE"].lower()
+          owner = re.sub(r"[^a-z0-9_]", "_", owner)
+          owner = re.sub(r"_+", "_", owner)[:63].strip("_")
+          if not owner:
+              raise SystemExit("Cannot derive an EC2 owner tag from github.actor")
+
+          tags = json.loads(os.environ["TAGS"])
+          tags.extend([
+              {"Key": "owner", "Value": owner},
+              {"Key": "team", "Value": "rqe"},
+          ])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"tags={json.dumps(tags)}\n")
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
@@ -56,7 +79,7 @@ jobs:
           ec2-instance-type: ${{ inputs.instance-type }}
           subnet-id: ${{ secrets.AWS_EC2_SUBNET_ID_BENCHMARK }}
           security-group-id: ${{ secrets.AWS_EC2_SG_ID_BENCHMARK }}
-          aws-resource-tags: ${{ env.TAGS }}
+          aws-resource-tags: ${{ steps.ec2-tags.outputs.tags }}
 
   micro-benchmark:
     name: Run micro-benchmarks on runner

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -24,7 +24,6 @@ env:
       {"Key": "Run ID",       "Value": "${{ github.run_id }}"},
       {"Key": "PR",           "Value": "${{ github.event.number }}"},
       {"Key": "Container",    "Value": "${{ inputs.container }}"},
-      {"Key": "Owner",        "Value": "${{ github.actor }}"},
       {"Key": "Project",      "Value": "${{ github.repository }}"}
     ]
 
@@ -51,6 +50,30 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
+      - name: Prepare EC2 ownership tags
+        id: ec2-tags
+        # Keep the original workflow actor as owner, including on reruns.
+        env:
+          OWNER_HANDLE: ${{ github.actor }}
+        shell: python
+        run: |
+          import json
+          import os
+          import re
+
+          owner = os.environ["OWNER_HANDLE"].lower()
+          owner = re.sub(r"[^a-z0-9_]", "_", owner)
+          owner = re.sub(r"_+", "_", owner)[:63].strip("_")
+          if not owner:
+              raise SystemExit("Cannot derive an EC2 owner tag from github.actor")
+
+          tags = json.loads(os.environ["TAGS"])
+          tags.extend([
+              {"Key": "owner", "Value": owner},
+              {"Key": "team", "Value": "rqe"},
+          ])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"tags={json.dumps(tags)}\n")
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2
@@ -61,7 +84,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           subnet-id: ${{ secrets.CI_CTO_AWS_EC2_SUBNET_ID }}
           security-group-id: ${{ secrets.CI_CTO_AWS_EC2_SG_ID }}
-          aws-resource-tags: ${{ env.TAGS }}
+          aws-resource-tags: ${{ steps.ec2-tags.outputs.tags }}
 
   run:
     needs: start-runner # required to start the main job when the runner is ready

--- a/.github/workflows/task-start-ec2-runner.yml
+++ b/.github/workflows/task-start-ec2-runner.yml
@@ -43,7 +43,6 @@ jobs:
           {"Key": "Environment",  "Value": "CI"},
           {"Key": "Run ID",       "Value": "${{ github.run_id }}"},
           {"Key": "PR",           "Value": "${{ github.event.number }}"},
-          {"Key": "Owner",        "Value": "${{ github.actor }}"},
           {"Key": "Project",      "Value": "${{ github.repository }}"}
         ]
     outputs:
@@ -67,6 +66,30 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
 
+      - name: Prepare EC2 ownership tags
+        id: ec2-tags
+        # Keep the original workflow actor as owner, including on reruns.
+        env:
+          OWNER_HANDLE: ${{ github.actor }}
+        shell: python
+        run: |
+          import json
+          import os
+          import re
+
+          owner = os.environ["OWNER_HANDLE"].lower()
+          owner = re.sub(r"[^a-z0-9_]", "_", owner)
+          owner = re.sub(r"_+", "_", owner)[:63].strip("_")
+          if not owner:
+              raise SystemExit("Cannot derive an EC2 owner tag from github.actor")
+
+          tags = json.loads(os.environ["TAGS"])
+          tags.extend([
+              {"Key": "owner", "Value": owner},
+              {"Key": "team", "Value": "rqe"},
+          ])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"tags={json.dumps(tags)}\n")
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
@@ -77,4 +100,4 @@ jobs:
           ec2-instance-type: ${{ inputs.ec2-instance-type }}
           subnet-id: ${{ secrets.AWS_EC2_SUBNET_ID_BENCHMARK }}
           security-group-id: ${{ secrets.AWS_EC2_SG_ID_BENCHMARK }}
-          aws-resource-tags: ${{ env.TAGS }}
+          aws-resource-tags: ${{ steps.ec2-tags.outputs.tags }}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: EC2 CI runners use an unnormalized `Owner` tag and lack a `team` tag, diverging from the ownership format adopted in [VectorSimilarity#1032](https://github.com/RedisAI/VectorSimilarity/pull/1032).
2. Change: Use lowercase `owner` and `team=rqe` across runner workflows and the template. Normalize the original workflow actor to lowercase ASCII letters, digits, and collapsed underscores, with a 63-character limit; reject an empty result before launching EC2.
3. Outcome: Internal-only: newly launched runners carry consistent ownership metadata for infrastructure policies. Existing non-ownership tags are preserved.

#### Which additional issues this PR fixes

[MOD-18346](https://redislabs.atlassian.net/browse/MOD-18346)

#### Main objects this PR modified

1. Reusable EC2 runner provisioning — normalized ownership tags at launch.
2. Micro-benchmark runner provisioning — the same ownership format.
3. Self-hosted workflow template — consistent tags for future workflows.

Manual validation executed all three embedded Python steps against eight handle cases each, checking tag JSON, normalization boundaries, and empty-owner rejection. Live EC2 validation remains for CI.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


[MOD-18346]: https://redislabs.atlassian.net/browse/MOD-18346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ