### PR TITLE
[8.6] Fix Bullseye CI after end of LTS

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -83,6 +83,17 @@ jobs:
               'ec2_instance_type': ''
           }
 
+          # Bullseye is EOL; pin metadata and packages together before live mirrors remove them.
+          # Only snapshot expiry checks are disabled; APT still verifies signatures.
+          bullseye_setup = (
+              "printf '%s\\n'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main'"
+              " > /etc/apt/sources.list"
+              " && apt update && apt install -y git"
+          )
+
           # Platform configurations
           platform_configs = {
               "macos-15": {
@@ -210,12 +221,12 @@ jobs:
               "debian:bullseye": {
                   "x86_64": {
                       'container': 'gcc:11-bullseye',
-                      'setup_script': 'apt update && apt install -y git',
+                      'setup_script': bullseye_setup,
                       'name': 'Debian Bullseye x86_64'
                   },
                   "aarch64": {
                       'container': 'gcc:11-bullseye',
-                      'setup_script': 'apt update && apt install -y git',
+                      'setup_script': bullseye_setup,
                       'name': 'Debian Bullseye ARM64'
                   }
               },

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -3,6 +3,14 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
+# Cached images install dependencies before the workflow bootstrap can configure APT.
+# Keep these sources in sync with bullseye_setup in task-get-config.yml.
+$MODE tee /etc/apt/sources.list > /dev/null <<'EOF'
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main
+EOF
+
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
         rsync unzip curl libclang-dev gdb


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Bullseye CI fails before checkout because its security metadata expired after LTS ended; the live mirror also returns 404 for some build dependencies. See the [failed job](https://github.com/RediSearch/RediSearch/actions/runs/34190138162/job/101951573758).
2. Change: Pin Bullseye's base, updates, and security repositories to Debian's 2026-09-01 snapshot in both the workflow bootstrap and cached-container installer. Disable metadata-expiry checks only for these snapshot sources, retaining signature verification.
3. Outcome: Internal-only: retain Bullseye test and artifact coverage after EOL, including reusable cached images. Verified bootstrap and repeated dependency installation in disposable x86_64 Bullseye containers, plus the changed installer in a Docker build; signed ARM64 indexes and downloads of the affected packages also passed.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. Bullseye CI bootstrap: consistent frozen metadata and packages before checkout, on both architectures.
2. Cached-container dependency installer: configure the same snapshot sources before the first APT invocation, including repeated installation.
3. Backport scope: target `8.6`; also needed on `2.6`, `2.8`, `2.10`, `8.0`, `8.2`, `8.4`, and `8.6-rse`. Master, `8.8`, `8.8-rse`, and `8.10` no longer run Bullseye. The `2.6`, `2.8`, and `8.0` backports need adaptation to their older `task-get-linux-configurations.yml` bootstrap.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
