### PR TITLE
[8.6-rse] Fix Bullseye CI after end of LTS

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -103,6 +103,17 @@ jobs:
           # Platforms that don't support node20
           node20_unsupported_platforms = ['amazonlinux:2']
 
+          # Bullseye is EOL; pin metadata and packages together before live mirrors remove them.
+          # Only snapshot expiry checks are disabled; APT still verifies signatures.
+          bullseye_setup = (
+              "printf '%s\\n'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main'"
+              " 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main'"
+              " > /etc/apt/sources.list"
+              " && apt update && apt install -y git"
+          )
+
           # Platform configurations
           platform_configs = {
               "macos-15": {
@@ -232,12 +243,12 @@ jobs:
               "debian:bullseye": {
                   "x86_64": {
                       'container': 'gcc:11-bullseye',
-                      'setup_script': 'apt update && apt install -y git',
+                      'setup_script': bullseye_setup,
                       'name': 'Debian Bullseye x86_64'
                   },
                   "aarch64": {
                       'container': 'gcc:11-bullseye',
-                      'setup_script': 'apt update && apt install -y git',
+                      'setup_script': bullseye_setup,
                       'name': 'Debian Bullseye ARM64'
                   }
               },

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -3,6 +3,14 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
+# Cached images install dependencies before the workflow bootstrap can configure APT.
+# Keep these sources in sync with bullseye_setup in task-get-config.yml.
+$MODE tee /etc/apt/sources.list > /dev/null <<'EOF'
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main
+EOF
+
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
         rsync unzip curl libclang-dev gdb


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Bullseye CI fails after LTS ended because security metadata has expired and live-mirror packages are missing.
2. Change: Backport [#11337](https://github.com/RediSearch/RediSearch/pull/11337) to `8.6-rse`, pinning Bullseye repositories to the signed 2026-09-01 Debian snapshot.
3. Outcome: Internal-only: retain Bullseye CI and artifact builds after EOL.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. Platform configuration: preserve branch-specific settings and add the Bullseye snapshot bootstrap.
2. Bullseye dependency installer: configure the matching HTTPS snapshot repositories before APT runs.
3. APT verification: retain signature checks and disable only snapshot metadata expiry checks.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Original PR

https://github.com/RediSearch/RediSearch/pull/11337

Source squash commit: `b1b0934cdab8afd148472332925afcef5a56f6be`.

## Changes from original

Resolved the workflow insertion conflict while preserving the branch-specific Node.js, install-mode, and LTO configuration. Snapshot setup and the Bullseye installer match the original fix.

## Validation

Executed the generated workflow for all 29 platform/architecture configurations; only Bullseye bootstrap output changes. Shell syntax and snapshot-source consistency checks passed; the unchanged snapshot setup and installer were validated in the original PR.
