### PR TITLE
[2.8] Fix Bullseye CI after end of LTS

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -136,17 +136,31 @@ jobs:
               'OS': 'mcr.microsoft.com/azurelinux/base/core:3.0',
               'pre-deps': "tdnf install -y --noplugins tar git ca-certificates"})
 
+          # Bullseye is EOL; pin metadata and packages together before live mirrors remove them.
+          # The minimal image has no CA certificates; bootstrap over HTTP with APT signatures.
+          # Only snapshot expiry checks are disabled; switch to HTTPS once certificates exist.
+          bullseye_setup = (
+              "printf '%s\\n'"
+              " 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main'"
+              " 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main'"
+              " 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main'"
+              " > /etc/apt/sources.list"
+              " && apt update && apt install -y git ca-certificates"
+              " && sed -i 's|http://snapshot.debian.org/|https://snapshot.debian.org/|g' /etc/apt/sources.list"
+          )
+
           # Ubuntu and Debian distributions need git pre-checkout dependencies
           debian_based_os = ['ubuntu:noble', 'ubuntu:jammy', 'ubuntu:focal', 'debian:bullseye', 'gcc:12-bookworm']
           for os_name in debian_based_os:
+            pre_deps = bullseye_setup if os_name == 'debian:bullseye' else "apt update && apt install -y git"
             if os_name in x86_platforms:
               x86_include.append({
                 'OS': os_name,
-                'pre-deps': "apt update && apt install -y git"})
+                'pre-deps': pre_deps})
             if os_name in arm_platforms:
               arm_include.append({
                 'OS': os_name,
-                'pre-deps': "apt update && apt install -y git"})
+                'pre-deps': pre_deps})
 
           # rockylinux needs git pre-checkout dependencies
           for rocky_version in ['rockylinux:8', 'rockylinux:9']:

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -3,6 +3,14 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
+# Cached images install dependencies before the workflow bootstrap can configure APT.
+# Keep these sources in sync with bullseye_setup in task-get-linux-configurations.yml.
+$MODE tee /etc/apt/sources.list > /dev/null <<'EOF'
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main
+EOF
+
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
         rsync unzip curl libclang-dev gdb

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -3,13 +3,17 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
-# Cached images install dependencies before the workflow bootstrap can configure APT.
+# The minimal image needs CA certificates before it can use HTTPS snapshots.
 # Keep these sources in sync with bullseye_setup in task-get-linux-configurations.yml.
 $MODE tee /etc/apt/sources.list > /dev/null <<'EOF'
-deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main
-deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main
-deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye-updates main
 EOF
+
+$MODE apt update -qq
+$MODE apt install -yqq ca-certificates
+$MODE sed -i 's|http://snapshot.debian.org/|https://snapshot.debian.org/|g' /etc/apt/sources.list
 
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Bullseye CI fails after LTS ended because security metadata has expired and live-mirror packages are missing.
2. Change: Backport [#11337](https://github.com/RediSearch/RediSearch/pull/11337) to `2.8`, pinning Bullseye repositories to the signed 2026-09-01 Debian snapshot.
3. Outcome: Internal-only: retain Bullseye CI and artifact builds after EOL.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. Legacy matrix generator: use the snapshot bootstrap only for Bullseye and retain existing platform coverage.
2. Bullseye dependency installer: bootstrap CA certificates from signed HTTP snapshots before switching to HTTPS, including when invoked directly on the minimal image.
3. APT verification: retain signature checks and disable only snapshot metadata expiry checks.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Original PR

https://github.com/RediSearch/RediSearch/pull/11337

Source squash commit: `b1b0934cdab8afd148472332925afcef5a56f6be`.

## Changes from original

Adapted the bootstrap to this branch’s existing `task-get-linux-configurations.yml` instead of adding the newer workflow. The minimal `debian:bullseye` image lacks CA certificates, so bootstrap uses signed HTTP snapshot repositories to install Git and certificates, then switches to HTTPS before dependency installation.

## Validation

Executed five matrix-generation cases and checked that other platform outputs remain unchanged. The shared legacy bootstrap and dependency installation passed in a disposable `debian:bullseye` container; shell syntax and bootstrap/installer source consistency checks also passed.


Direct installer validation also reproduced the missing-certificate failure before the fix. After the fix, dependency installation and a repeated run passed on a clean `debian:bullseye` image without running the workflow bootstrap first; final sources use HTTPS.
