### PR TITLE
RED-214512 Modify workflows to use GHCR mirror

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       packages: write # required for GHCR push
     outputs:
-      image: ${{ steps.meta.outputs.image }}
+      image: ${{ steps.select-pull-image.outputs.image }}
       succeeded: ${{ steps.mark-status.outputs.succeeded }}
     steps:
       - name: Checkout
@@ -62,12 +62,15 @@ jobs:
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')
-          IMAGE_TAG="${IMAGE_NAME}:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-${RUN_ID}"
+          IMAGE_PATH="${OWNER_LC}/redisearch-ci:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-${RUN_ID}"
+          GHCR_IMAGE_TAG="ghcr.io/${IMAGE_PATH}"
           CACHE_REF="${IMAGE_NAME}:${CONTAINER_SAFE}-${SAN_SAFE}-${RUNNER_ENV_SAFE}-cache"
 
-          echo "image=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image-path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
+          echo "ghcr-image=$GHCR_IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "cache=$CACHE_REF" >> "$GITHUB_OUTPUT"
-          echo "Using image tag: $IMAGE_TAG"
+          echo "Using image path: $IMAGE_PATH"
+          echo "Using GHCR image tag: $GHCR_IMAGE_TAG"
           echo "Using cache ref: $CACHE_REF"
           if [[ "$IS_FORK_PR" == "true" ]]; then
             echo "can_push=false" >> "$GITHUB_OUTPUT"
@@ -101,9 +104,40 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ github.token }}
           file: Dockerfile
-          tags: ${{ steps.meta.outputs.image }}
+          tags: ${{ steps.meta.outputs.ghcr-image }}
           cache-to: ${{ steps.meta.outputs.can_push == 'true' && format('type=registry,ref={0},mode=max,compression=zstd', steps.meta.outputs.cache) || '' }}
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache }}
+
+      - name: Select pull image
+        if: always()
+        id: select-pull-image
+        env:
+          GHCR_IMAGE: ${{ steps.meta.outputs.ghcr-image }}
+          IMAGE_PATH: ${{ steps.meta.outputs.image-path }}
+          BUILD_OUTCOME: ${{ steps.build-and-push.outcome }}
+          GHCR_MIRROR_HOST: ${{ vars.GHCR_MIRROR_HOST }}
+          # The mirror is only reachable from self-hosted runners; skip the
+          # check on GitHub-hosted runners rather than pay for a connection
+          # that can't succeed.
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        run: |
+          image="$GHCR_IMAGE"
+
+          if [[ "$BUILD_OUTCOME" == "success" && "$RUNNER_ENVIRONMENT" == "self-hosted" && -n "${GHCR_MIRROR_HOST:-}" ]]; then
+            mirror_image="${GHCR_MIRROR_HOST%/}/${IMAGE_PATH}"
+            echo "Checking mirror manifest: $mirror_image"
+            if docker manifest inspect "$mirror_image" >/dev/null 2>&1; then
+              image="$mirror_image"
+              echo "Mirror image is available."
+            else
+              echo "Mirror image is not available; using GHCR image."
+            fi
+          else
+            echo "Mirror host is unreachable (not a self-hosted runner), unconfigured, or image build did not succeed; using GHCR image."
+          fi
+
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "Using pull image tag: $image"
 
       - name: Mark build status
         if: always()


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Pulling job container images from the internal GHCR mirror required client credentials (`vars.GHCR_MIRROR_USERNAME`/`secrets.GHCR_MIRROR_PASSWORD`). Because GitHub Actions' `container:` key can't switch between a plain image string and a credentialed struct within one job, every container-based workflow had to be split into 4 near-duplicate jobs (`*-ghcr`/`*-mirror`/`*-raw`/`*-host`) glued together with YAML anchors, which also made the Actions job list noisy (ugly names on the skipped variants).
2. Change: Removes the client → mirror credential requirement. The mirror is reachable without auth, so every split job collapses back into the single job each workflow had before the mirror was introduced. Only `task-build-cached-container.yml` changes functionally: it still resolves GHCR vs. mirror once per build (via `docker manifest inspect`), but no longer logs in to do it, and a bug is fixed where `GHCR_MIRROR_HOST` was referenced in the mirror-selection step but never wired into that step's `env:` — so the mirror branch never actually fired before.
3. Outcome: CI job lists are back to their normal single-job-per-platform shape. Self-hosted runners pull the cached CI image from the internal mirror when available, transparently falling back to GHCR (and then to the raw base image) otherwise — with no mirror credentials needed anywhere.

#### Which additional issues this PR fixes

1. RED-214512

#### Main objects this PR modified

1. `task-build-cached-container.yml` — mirror image selection in the `build-image` job; drops the `docker login` to the mirror and the `GHCR_MIRROR_PASSWORD` secret.
2. `task-build.yml`, `task-build-artifacts.yml`, `task-build-redis.yml`, `task-build-rejson.yml`, `task-lint.yml`, `task-miri.yml`, `task-test.yml`, `task-test-unit.yml`, `task-test-flow.yml` — collapsed the 4-way job split back to the single job each had before the mirror feature, using the original `container: ${{ ... fromJSON(...) || null }}` ternary.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
