### PR TITLE
[8.2] [MOD-6841] Report the missing QUERY keyword error in coordinator FT.PROFILE SEARCH

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1964,6 +1964,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   rs_wall_clock_init(&req->initClock);
 
   if (rscParseProfile(req, argv) != REDISMODULE_OK) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "The QUERY keyword is expected");
     searchRequestCtx_Free(req);
     return NULL;
   }

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -1,6 +1,15 @@
 from common import *
 
 @skip(cluster=False)
+def test_profile_missing_query_error_on_coordinator():
+    """MOD-6841: exercise the distributed parser, not the single-shard optimization."""
+    env = Env(shardsCount=3)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.PROFILE', 'idx', 'SEARCH', 'banana', 'banana').error().equal(
+        'The QUERY keyword is expected')
+
+
+@skip(cluster=False)
 def testInfo(env):
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: In a multi-shard cluster the coordinator parses `FT.SEARCH` / `FT.PROFILE <idx> SEARCH ...`
   in `rscParseRequest` (`src/module.c`). When `rscParseProfile` fails because the `QUERY` keyword is
   missing (e.g. `FT.PROFILE idx SEARCH banana banana`), `rscParseRequest` frees the request and
   returns `NULL` without ever filling the `QueryError *status` out-parameter. `createReq` then hands
   that untouched, `QUERY_OK` status to `bailOut`, so the client gets an empty error, which Redis
   renders as `Success (not an error)`.
2. **Change**: Set `QUERY_EPARSEARGS` with the message `The QUERY keyword is expected` before freeing
   the request, so the distributed parser reports the same error the standalone/single-shard path
   already reports.
3. **Outcome**: `FT.PROFILE <idx> SEARCH ...` without the `QUERY` keyword now returns
   `The QUERY keyword is expected` on a multi-shard cluster instead of `Success (not an error)`.

The regression test comes from the closed diagnostic PR #10685 (cherry-picked, authorship preserved).
It uses `Env(shardsCount=3)` so the command goes through the coordinator parser — the existing
assertion in `test_single_shard_optimization` runs with one shard and therefore never exercised this
path. It is marked `@skip(cluster=False)`: RLTest only honours `shardsCount` in cluster environments, so in standalone mode the test would merely repeat the existing single-shard assertion.

#### Which additional issues this PR fixes
1. MOD-6841

#### Main objects this PR modified
1. `rscParseRequest` in `src/module.c`
2. `tests/pytests/test_coordinator.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixed `FT.PROFILE <index> SEARCH ...` without the `QUERY` keyword replying `Success (not an error)`
on a multi-shard cluster; it now returns `The QUERY keyword is expected`, as it already did on a
single shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
