### PR TITLE
[2.10] [MOD-6841] Report the missing QUERY keyword error in coordinator FT.PROFILE SEARCH

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -485,6 +485,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   rs_wall_clock_init(&req->initClock);
 
   if (rscParseProfile(req, argv) != REDISMODULE_OK) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "The QUERY keyword is expected");
     searchRequestCtx_Free(req);
     return NULL;
   }

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -3,6 +3,15 @@ from redis import ResponseError
 from time import sleep
 
 @skip(cluster=False)
+def test_profile_missing_query_error_on_coordinator():
+    """MOD-6841: exercise the distributed parser, not the single-shard optimization."""
+    env = Env(shardsCount=3)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.PROFILE', 'idx', 'SEARCH', 'banana', 'banana').error().equal(
+        'The QUERY keyword is expected')
+
+
+@skip(cluster=False)
 def testInfo(env):
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()


### PR DESCRIPTION
**Describe the changes in the pull request**

1. **Current state.** In a multi-shard cluster, `FT.SEARCH` and `FT.PROFILE <idx> SEARCH ...`
   are parsed by the coordinator in `rscParseRequest` (`coord/src/module.c`). When
   `rscParseProfile` rejects the arguments because the `QUERY` keyword is missing — for
   example `FT.PROFILE idx SEARCH banana banana` — `rscParseRequest` frees the request and
   returns `NULL`, but never fills its `QueryError *status` out-parameter. The caller
   (`createReq` -> `bailOut`) then replies with that still-empty `QueryError`, which Redis
   renders as `Success (not an error)`. The user sees a success-looking reply for a
   command that was in fact rejected, and gets no hint about what was wrong.

2. **What is the change.** Set the error before freeing the request, using the same code
   and the same message the non-distributed path already uses:

   ```c
   QueryError_SetError(status, QUERY_EPARSEARGS, "The QUERY keyword is expected");
   ```

3. **Changed state.** A multi-shard cluster now replies
   `The QUERY keyword is expected`, identical to standalone and to the single-shard
   shortcut. The error is also now counted correctly, because `bailOut` feeds
   `QueryError_GetCode(status)` into `QueryErrorsGlobalStats_UpdateError` — previously it
   recorded `QUERY_OK`.

**Which issues this PR fixes**
1. MOD-6841

**Main objects this PR modified**
1. `rscParseRequest` in `coord/src/module.c`
2. `tests/pytests/test_coordinator.py`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Release note: Fixed `FT.PROFILE <index> SEARCH` without the `QUERY` keyword replying
`Success (not an error)` on a multi-shard cluster; it now returns
`The QUERY keyword is expected`, matching standalone.

**Testing**

The regression test `test_profile_missing_query_error_on_coordinator` is taken from the
closed diagnostic PR #10687 (authored by @lerman25) and cherry-picked as its own commit so
authorship is preserved. It uses `Env(shardsCount=3)` so the command goes through the
coordinator's distributed parser rather than the single-shard shortcut — a one-shard
environment never exercised the bug. It is marked `@skip(cluster=False)`: RLTest only honours `shardsCount` in cluster environments, so in standalone mode the test would merely repeat the existing single-shard assertion.

Verified on this branch:

| Run | Mode | Result |
| --- | --- | --- |
| `test_coordinator.py:test_profile_missing_query_error_on_coordinator`, **before** the fix | `COORD=oss`, 3-shard oss-cluster | FAIL — `'Success (not an error)' == 'The QUERY keyword is expected'` |
| `test_coordinator.py` | `COORD=oss`, 3-shard oss-cluster | 12/12 pass |
| `test_coordinator.py` | standalone | 11 pass, new test skipped |
| `test_profile.py` | standalone | 31/31 pass |
| `RUN_UNIT_TESTS ENABLE_ASSERT=1` | standalone | 14/14 C, 223/223 C++ pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
