### PR TITLE
Negotiate row-block reply capability per shard during rolling upgrades

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -402,9 +402,13 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     }
   } else if (AC_AdvanceIfMatch(ac, "_NUM_SSTRING")) {
     REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_TYPED);
-  } else if (AC_AdvanceIfMatch(ac, "_ROW_BLOCK")) {
+  } else if (!RSGlobalConfig.simulateLegacyShard && AC_AdvanceIfMatch(ac, "_ROW_BLOCK")) {
     // Recorded on the request rather than as a QEFlag: that bitfield is a full u32
     // (QEFlag_Debug holds 0x80000000), so a new flag would mean widening it everywhere.
+    // Guarded on search-_simulate-legacy-shard (RSConfig.simulateLegacyShard) so tests can
+    // make this shard reject the token exactly as a pre-row-block build would: short-circuit
+    // leaves the argument unconsumed, so it falls through to the terminal `else` below like
+    // any other argument an old shard has never heard of.
     papCtx->reqConfig->internalRowBlock = true;
   } else if (AC_AdvanceIfMatch(ac, "WITHRAWIDS")) {
     REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_SENDRAWIDS);

--- a/src/config.c
+++ b/src/config.c
@@ -1528,6 +1528,21 @@ static int get_on_oom(const char *name, void *privdata){
   REDISMODULE_NOT_USED(name);
   return *((RSOomPolicy *)privdata);
 }
+
+// search-_force-shard-caps: see RSConfig.forceShardCapsOverride and
+// MRConnManager_NodeSupports for what this actually forces.
+static int set_force_shard_caps(const char *name, int val, void *privdata,
+                                 RedisModuleString **err) {
+  REDISMODULE_NOT_USED(name);
+  REDISMODULE_NOT_USED(err);
+  *((RSForceShardCaps *)privdata) = (RSForceShardCaps)val;
+  return REDISMODULE_OK;
+}
+
+static int get_force_shard_caps(const char *name, void *privdata) {
+  REDISMODULE_NOT_USED(name);
+  return *((RSForceShardCaps *)privdata);
+}
 // Legacy module-ARGS setter for search-disk-drop-read-cache.
 // Handles yes/no/true/false (case-insensitive).
 // TODO: remove once RLTest can emit `--<config-name> <value>` directly (see RLTest
@@ -2588,6 +2603,20 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       on_oom_vals, on_oom_enums, 3,
       get_on_oom, set_on_oom, NULL,
       (void*)&RSGlobalConfig.requestConfigParams.oomPolicy
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterEnumConfig(
+      // Hidden test/ops-only, coordinator-side: "no" forces
+      // MRConnManager_NodeSupports to treat every shard as supporting no
+      // RSCapability, without a HELLO round trip - see RSConfig.forceShardCapsOverride.
+      // "auto" (the default) is a no-op in production.
+      ctx, "search-_force-shard-caps", RSForceShardCaps_Auto,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      force_shard_caps_vals, force_shard_caps_enums, 2,
+      get_force_shard_caps, set_force_shard_caps, NULL,
+      (void*)&RSGlobalConfig.forceShardCapsOverride
     )
   )
 

--- a/src/config.c
+++ b/src/config.c
@@ -2691,6 +2691,17 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
 
   RM_TRY(
     RedisModule_RegisterBoolConfig(
+      // Test-only: simulates an old shard that rejects `_ROW_BLOCK`, for exercising
+      // rolling-upgrade capability negotiation. See RSConfig.simulateLegacyShard.
+      ctx, "search-_simulate-legacy-shard", 0,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.simulateLegacyShard)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
       ctx, "search-_simulate-in-flex", 0,
       REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,
       get_bool_config, set_bool_config, NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -219,6 +219,14 @@ typedef struct {
   // a shard only emits blocks when asked, and only a coordinator of the same version knows
   // to decode them, so this must not be enabled mid-upgrade.
   bool internalRowBlockFormat;
+  // Test-only knob: make this shard reject the internal `_ROW_BLOCK` argument
+  // exactly as a pre-row-block build would (see aggregate_request.c's parseAggPlan),
+  // regardless of what this shard's own build actually supports. RLTest starts every
+  // shard in a cluster from the same modulePath, so a genuinely mixed-build fleet
+  // cannot be started by the harness; this is the only way to exercise the
+  // coordinator's per-shard capability negotiation (see RediSearchCaps_HasRowBlock)
+  // against a shard that truly rejects the token.
+  bool simulateLegacyShard;
   // Control user data obfuscation in logs
   bool hideUserDataFromLog;
   // Set how much time after OOM is detected we should wait to enable the resource manager to

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,25 @@ static const char *on_oom_vals[3] = {
 };
 
 
+// Hidden coordinator-only test/ops override for MRConnManager_NodeSupports (see
+// RSConfig.forceShardCapsOverride and search-_force-shard-caps in config.c).
+// `Auto` is the real, HELLO/demotion-derived decision; `No` forces every shard
+// to read as supporting no capability, without consulting per-node state.
+typedef enum {
+  RSForceShardCaps_Auto,
+  RSForceShardCaps_No,
+  RSForceShardCaps_Invalid  // Not a real value
+} RSForceShardCaps;
+
+static const int force_shard_caps_enums[2] = {
+  RSForceShardCaps_Auto,
+  RSForceShardCaps_No
+};
+static const char *force_shard_caps_vals[2] = {
+  "auto",
+  "no"
+};
+
 typedef enum { GCPolicy_Fork = 0, GCPolicy_Disk = 1 } GCPolicy;
 
 const char *TimeoutPolicy_ToString(RSTimeoutPolicy);
@@ -224,9 +243,18 @@ typedef struct {
   // regardless of what this shard's own build actually supports. RLTest starts every
   // shard in a cluster from the same modulePath, so a genuinely mixed-build fleet
   // cannot be started by the harness; this is the only way to exercise the
-  // coordinator's per-shard capability negotiation (see RediSearchCaps_HasRowBlock)
+  // coordinator's per-shard capability negotiation (see RediSearchCaps_Supports)
   // against a shard that truly rejects the token.
   bool simulateLegacyShard;
+  // Test/ops-only, coordinator-side: force MRConnManager_NodeSupports to treat
+  // every shard as supporting no RSCapability, regardless of what HELLO or
+  // demotion say (RSForceShardCaps_No). `auto` (the default, RSForceShardCaps_Auto)
+  // is a no-op - production always takes this branch. Unlike simulateLegacyShard,
+  // which fakes one shard's own argument parser, this fakes the coordinator's
+  // belief about every shard directly, without a HELLO round trip - the knob a
+  // test reaches for when it needs "the coordinator never asked" rather than
+  // "asked and was refused" (see MRConnManager_DemoteCapability for that path).
+  RSForceShardCaps forceShardCapsOverride;
   // Control user data obfuscation in logs
   bool hideUserDataFromLog;
   // Set how much time after OOM is detected we should wait to enable the resource manager to
@@ -510,6 +538,7 @@ static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <
     .trimmingStateCheckDelayMS = DEFAULT_TRIMMING_STATE_CHECK_DELAY,           \
     .infoEmitOnZeroIndexes = false,                                            \
     .simulateInFlex = false,                                                   \
+    .forceShardCapsOverride = RSForceShardCaps_Auto,                           \
     .monitorExpiration = true,                                                 \
     .diskBufferPercentage = DEFAULT_DISK_BUFFER_PERCENTAGE,                    \
     .diskDropReadCache = false,                                                \

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -539,12 +539,9 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
   APPEND_LITERAL("WITHCURSOR");
   // Numeric responses are encoded as simple strings.
   APPEND_LITERAL("_NUM_SSTRING");
-  // Ask for the compact row-block encoding only when this coordinator can decode it.
-  // Older shards reject the unknown argument, so the config must stay off until the whole
-  // fleet is upgraded; see RSGlobalConfig.internalRowBlockFormat.
-  if (RSGlobalConfig.internalRowBlockFormat) {
-    APPEND_LITERAL("_ROW_BLOCK");
-  }
+  // The `_ROW_BLOCK` token, when asked for, is filled in per shard at fan-out time
+  // (see iterStartCb in rmr.c) rather than here: whether to ask depends on each
+  // shard's rolling-upgrade capability, which this build step cannot know yet.
 
   int argOffset = 0;
   // Preserve WITHCOUNT flag from the original command

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -540,8 +540,12 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
   // Numeric responses are encoded as simple strings.
   APPEND_LITERAL("_NUM_SSTRING");
   // The `_ROW_BLOCK` token, when asked for, is filled in per shard at fan-out time
-  // (see iterStartCb in rmr.c) rather than here: whether to ask depends on each
-  // shard's rolling-upgrade capability, which this build step cannot know yet.
+  // (see maybeAskRowBlock in rmr.c) rather than here: whether to ask depends on each
+  // shard's rolling-upgrade capability, which this build step cannot know yet. Remember
+  // *where* to insert it, though: an insertion here must not land after anything appended
+  // post-build (notably FT.DEBUG's DEBUG_PARAMS_COUNT block in dist_aggregate.c's debug
+  // wrapper, which the shard parses from the end of the command).
+  uint32_t rowBlockPos = array_len(tmparr);
 
   int argOffset = 0;
   // Preserve WITHCOUNT flag from the original command
@@ -604,6 +608,7 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
 #undef APPEND_ARG
 
   *xcmd = MR_NewCommandArgvLen(array_len(tmparr), tmparr, tmplens);
+  xcmd->rowBlockArgIndex = rowBlockPos;
 
   // Prepare command for slot info (Cluster mode)
   MRCommand_PrepareForSlotInfo(xcmd, slotsInfoPos);

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -80,18 +80,18 @@ void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     const char* error = MRReply_String(rep, NULL);
     RedisModule_Log(RSDummyContext, "notice", "Coordinator got an error '%.*s' from a shard", GetRedisErrorCodeLength(error), error);
     RedisModule_Log(RSDummyContext, "verbose", "Shard error: %s", error);
-    // Defence in depth: this shard was believed capable (RediSearchCaps_HasRowBlock
-    // said yes for its advertised version), so we asked it for the row-block format
-    // on its first command (cmd->rootCommand == C_AGG - a cursor READ/DEL never
-    // carries the token, see getCursorCommand below), and it rejected the token
-    // anyway. That is a hole in the version-to-capability mapping, not a transient
-    // error. Demote it so later queries stop repeating the mistake against this
-    // node; this cannot rescue the query that discovered the problem, which still
-    // fails here as it does today for any unrecognized argument.
+    // Defence in depth: this shard was believed to support RS_CAP_ROW_BLOCK
+    // (RediSearchCaps_Supports said yes for its advertised version), so we asked
+    // it for the row-block format on its first command (cmd->rootCommand == C_AGG
+    // - a cursor READ/DEL never carries the token, see getCursorCommand below),
+    // and it rejected the token anyway. That is a hole in the version-to-capability
+    // mapping, not a transient error. Demote it so later queries stop repeating the
+    // mistake against this node; this cannot rescue the query that discovered the
+    // problem, which still fails here as it does today for any unrecognized argument.
     if (cmd->rootCommand == C_AGG && cmd->targetShard && strstr(error, "_ROW_BLOCK")) {
       MRIterator *it = MRIteratorCallback_GetIterator(ctx);
       IORuntimeCtx *ioRuntime = MRIterator_GetIORuntime(it);
-      MRConnManager_DemoteRowBlockCap(&ioRuntime->conn_mgr, cmd->targetShard);
+      MRConnManager_DemoteCapability(&ioRuntime->conn_mgr, cmd->targetShard, RS_CAP_ROW_BLOCK);
     }
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
     MRIteratorCallback_Done(ctx, 1);

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -19,6 +19,7 @@
 #include "query_error.h"
 #include "query_error_ffi.h"
 #include "redismodule.h"
+#include "rmr/io_runtime_ctx.h"
 #include "rmr/rmr.h"
 #include "rmutil/rm_assert.h"
 
@@ -79,6 +80,19 @@ void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     const char* error = MRReply_String(rep, NULL);
     RedisModule_Log(RSDummyContext, "notice", "Coordinator got an error '%.*s' from a shard", GetRedisErrorCodeLength(error), error);
     RedisModule_Log(RSDummyContext, "verbose", "Shard error: %s", error);
+    // Defence in depth: this shard was believed capable (RediSearchCaps_HasRowBlock
+    // said yes for its advertised version), so we asked it for the row-block format
+    // on its first command (cmd->rootCommand == C_AGG - a cursor READ/DEL never
+    // carries the token, see getCursorCommand below), and it rejected the token
+    // anyway. That is a hole in the version-to-capability mapping, not a transient
+    // error. Demote it so later queries stop repeating the mistake against this
+    // node; this cannot rescue the query that discovered the problem, which still
+    // fails here as it does today for any unrecognized argument.
+    if (cmd->rootCommand == C_AGG && cmd->targetShard && strstr(error, "_ROW_BLOCK")) {
+      MRIterator *it = MRIteratorCallback_GetIterator(ctx);
+      IORuntimeCtx *ioRuntime = MRIterator_GetIORuntime(it);
+      MRConnManager_DemoteRowBlockCap(&ioRuntime->conn_mgr, cmd->targetShard);
+    }
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
     MRIteratorCallback_Done(ctx, 1);
     return;

--- a/src/coord/rmr/command.c
+++ b/src/coord/rmr/command.c
@@ -69,6 +69,7 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->lens = rm_malloc(sizeof(*cmd->lens) * len);
   cmd->slotsInfoArgIndex = 0;
   cmd->dispatchTimeArgIndex = 0;
+  cmd->rowBlockArgIndex = 0;
   cmd->targetShard = NULL;
   cmd->cmd = NULL;
   cmd->protocol = 0;
@@ -94,6 +95,7 @@ MRCommand MRCommand_Copy(const MRCommand *cmd) {
   MRCommand_Init(&ret, cmd->num);
   ret.slotsInfoArgIndex = cmd->slotsInfoArgIndex;
   ret.dispatchTimeArgIndex = cmd->dispatchTimeArgIndex;
+  ret.rowBlockArgIndex = cmd->rowBlockArgIndex;
   ret.targetShard = cmd->targetShard ? rm_strdup(cmd->targetShard) : NULL;
   ret.protocol = cmd->protocol;
   ret.forCursor = cmd->forCursor;
@@ -131,6 +133,13 @@ static void MRCommand_updateArgIndices(MRCommand *cmd, int pos, int toAdd) {
 
   if (cmd->dispatchTimeArgIndex && pos < cmd->dispatchTimeArgIndex) {
     cmd->dispatchTimeArgIndex += toAdd;
+  }
+
+  // rowBlockArgIndex has no reserved placeholder to protect (see command.h), so unlike
+  // the two indices above it may equal `pos` here - that is exactly the row-block
+  // insertion itself (see maybeAskRowBlock in rmr.c), not a corruption.
+  if (cmd->rowBlockArgIndex && pos < cmd->rowBlockArgIndex) {
+    cmd->rowBlockArgIndex += toAdd;
   }
 }
 

--- a/src/coord/rmr/command.h
+++ b/src/coord/rmr/command.h
@@ -40,6 +40,19 @@ typedef struct {
   /* Dispatch time arg offset - 0 if not set */
   uint32_t dispatchTimeArgIndex;
 
+  /* Position at which to insert the internal `_ROW_BLOCK` token, if a per-shard fill
+   * point (see rmr.c's maybeAskRowBlock) decides to ask this shard for the row-block
+   * reply format - 0 if not set (first argument is always the command, so 0 never a
+   * real position). Unlike slotsInfoArgIndex/dispatchTimeArgIndex, no space is
+   * reserved here: the token is optional per shard, so filling it (or not) is a plain
+   * MRCommand_Insert at this position rather than replacing a placeholder. Set once
+   * when the command is built (buildMRCommand in dist_aggregate.c) and, like the other
+   * two index fields, kept in sync by MRCommand_Insert/MRCommand_Copy so that anything
+   * inserted or appended afterward - notably FT.DEBUG's DEBUG_PARAMS_COUNT block,
+   * which the shard parses by reading fixed positions from the *end* of the command -
+   * is never displaced by a later row-block insertion. */
+  uint32_t rowBlockArgIndex;
+
   /* if not NULL, this value indicate to which shard the command should be sent.*/
   char *targetShard;
 

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -255,6 +255,15 @@ void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict) {
       array_append(stateList, rm_strdup(stateStr));
     }
 
+    // One row-block capability line per pool (not per connection - see
+    // MRNodeCapState in conn.h for why this is tracked per node).
+    char *capStr;
+    MRNodeCapState cap = pool->rowBlockDemoted ? MRNodeCap_No : pool->rowBlockCap;
+    rm_asprintf(&capStr, "RowBlockCapability=%s(demoted=%s,version=%d)",
+               MRNodeCapState_Str(cap), pool->rowBlockDemoted ? "true" : "false",
+               pool->rowBlockCapVersion);
+    array_append(stateList, capStr);
+
     dictSetVal(stateDict, target_entry, stateList); // Update the value in case it was reallocated
     rm_free(key);
   }

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -297,7 +297,8 @@ const char *MRConnManager_GetNodeState(MRConnManager *mgr, const char *id) {
   return NULL;
 }
 
-MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id, int *outVersion) {
+MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id,
+                                                    int *outVersion) {
   dictEntry *ptr = dictFind(mgr->map, id);
   if (!ptr) {
     if (outVersion) *outVersion = -1;
@@ -419,7 +420,8 @@ int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *pri
     // after this dispatch's own command (see MRConn_HelloCallback's doc comment
     // and RediSearchCaps_HasRowBlock's callers), so up to one command per
     // connection runs without knowing the shard's capability yet.
-    if (redisAsyncCommand(c->conn, MRConn_HelloCallback, NULL, "HELLO %d", requiredProtocol) == REDIS_ERR) {
+    if (redisAsyncCommand(c->conn, MRConn_HelloCallback, NULL, "HELLO %d", requiredProtocol) ==
+        REDIS_ERR) {
       return REDIS_ERR;
     }
     c->protocol = requiredProtocol;

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -22,16 +22,20 @@
 #include "hiredis/hiredis_ssl.h"
 #include "hiredis/read.h"
 #include "hiredis/sds.h"
+#include "redisearch_caps.h"
 #include "rmalloc.h"
 #include "rmr/command.h"
 #include "rmr/endpoint.h"
 #include "rmutil/rm_assert.h"
 #include "util/arr/arr.h"
+#include "version.h"
 
 // Hot path first: callbacks read conn+state+protocol on every entry, so
 // they share the head of the first cache line. ep/loop are warm (init and
 // connect paths). The libuv timer is last because it is large and only
 // touched while in Reconnecting / ReAuth.
+typedef struct MRConnPool MRConnPool;
+
 struct MRConn {
   redisAsyncContext *conn;
   MRConnState state;
@@ -39,6 +43,7 @@ struct MRConn {
   MREndpoint ep;
   uv_loop_t *loop;
   uv_timer_t timer;         // back-off timer for Reconnecting / ReAuth
+  MRConnPool *pool;         // owning pool; used to invalidate/update its capability belief
 };
 
 static void MRConn_ConnectCallback(const redisAsyncContext *c, int status);
@@ -46,8 +51,9 @@ static void MRConn_DisconnectCallback(const redisAsyncContext *, int);
 static int MRConn_Connect(MRConn *conn);
 static void MRConn_SwitchState(MRConn *conn, MRConnState nextState);
 static void MRConn_Disconnect(MRConn *conn);
-static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop);
+static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop, MRConnPool *pool);
 static int MRConn_SendAuth(MRConn *conn);
+static void MRConn_HelloCallback(redisAsyncContext *c, void *r, void *privdata);
 
 #define RECONNECT_MS_DELAY 250
 #define REAUTH_MS_DELAY 1000
@@ -78,11 +84,31 @@ static void detachRedisAsyncContext(MRConn *conn) {
   redisAsyncDisconnect(ac);
 }
 
-typedef struct {
+struct MRConnPool {
   uint32_t num;
   uint32_t rr;  // round robin counter
   MRConn **conns;
-} MRConnPool;
+  // Row-block capability belief for this node (see MRNodeCapState in conn.h),
+  // learned from HELLO and reset to Unknown whenever any connection in `conns`
+  // leaves MRConn_Connected (MRConn_SwitchState). `rowBlockCapVersion` is the last
+  // `search` module version parsed from a HELLO reply, kept for diagnostics even
+  // when the capability is No; -1 means no version was ever parsed.
+  MRNodeCapState rowBlockCap;
+  int rowBlockCapVersion;
+  // Sticky defence-in-depth demotion (MRConnManager_DemoteRowBlockCap): once set,
+  // rowBlockCap reads as No regardless of any past or future HELLO reply, until
+  // this pool struct itself is replaced by a new one (endpoint change).
+  bool rowBlockDemoted;
+};
+
+/* Reset the tri-state row-block belief to Unknown. Does not touch rowBlockDemoted:
+ * a sticky demotion must survive the same invalidation trigger that resets the
+ * ordinary belief, since it is evidence about a hole in the version mapping, not
+ * about the connection's current liveness. */
+static void MRConnPool_ResetRowBlockCap(MRConnPool *pool) {
+  pool->rowBlockCap = MRNodeCap_Unknown;
+  pool->rowBlockCapVersion = -1;
+}
 
 static MRConnPool *_MR_NewConnPool(MREndpoint *ep, uint32_t num, uv_loop_t *loop) {
   MRConnPool *pool = rm_malloc(sizeof(*pool));
@@ -90,11 +116,14 @@ static MRConnPool *_MR_NewConnPool(MREndpoint *ep, uint32_t num, uv_loop_t *loop
       .num = num,
       .rr = 0,
       .conns = rm_malloc(num * sizeof(MRConn *)),
+      .rowBlockCap = MRNodeCap_Unknown,
+      .rowBlockCapVersion = -1,
+      .rowBlockDemoted = false,
   };
 
   /* Create the connection */
   for (uint32_t i = 0; i < num; i++) {
-    pool->conns[i] = MR_NewConn(ep, loop);
+    pool->conns[i] = MR_NewConn(ep, loop, pool);
   }
   return pool;
 }
@@ -259,6 +288,105 @@ const char *MRConnManager_GetNodeState(MRConnManager *mgr, const char *id) {
   return NULL;
 }
 
+MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id, int *outVersion) {
+  dictEntry *ptr = dictFind(mgr->map, id);
+  if (!ptr) {
+    if (outVersion) *outVersion = -1;
+    return MRNodeCap_Unknown;
+  }
+  MRConnPool *pool = dictGetVal(ptr);
+  if (outVersion) *outVersion = pool->rowBlockCapVersion;
+  return pool->rowBlockDemoted ? MRNodeCap_No : pool->rowBlockCap;
+}
+
+void MRConnManager_DemoteRowBlockCap(MRConnManager *mgr, const char *id) {
+  dictEntry *ptr = dictFind(mgr->map, id);
+  if (!ptr) return;
+  MRConnPool *pool = dictGetVal(ptr);
+  if (pool->rowBlockDemoted) return;  // already demoted; don't re-log every query
+  pool->rowBlockDemoted = true;
+  pool->rowBlockCap = MRNodeCap_No;
+  RedisModule_Log(RSDummyContext, "notice",
+                  "Shard %s rejected the internal row-block format after being believed "
+                  "capable of it; falling back to RESP for it until its connection pool "
+                  "is rebuilt", id);
+}
+
+/* Apply a parsed HELLO capability result to the connection's pool, logging the
+ * Unknown -> Yes/No transition once (not per query, since most reconnects resolve
+ * it identically to before). Skipped once the pool is sticky-demoted
+ * (MRConnManager_DemoteRowBlockCap) so a benign HELLO reply cannot undo evidence
+ * from an actual rejection. */
+static void MRConnPool_SetRowBlockCap(MRConn *conn, bool capable, int version) {
+  MRConnPool *pool = conn->pool;
+  if (pool->rowBlockDemoted) return;
+  if (pool->rowBlockCap == MRNodeCap_Unknown) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "Shard %s:%d row-block capability resolved to %s (module version %d)",
+                    conn->ep.host, conn->ep.port, capable ? "supported" : "unsupported", version);
+  }
+  pool->rowBlockCap = capable ? MRNodeCap_Yes : MRNodeCap_No;
+  pool->rowBlockCapVersion = version;
+}
+
+/* Find the `search` module entry in a HELLO reply's `modules` list and return its
+ * advertised version, or -1 if there is no such entry (module missing, no `modules`
+ * field, or a malformed/non-integer `ver`). Handles both RESP2 (the reply and each
+ * module entry arrive as flat arrays) and RESP3 (both arrive as real maps) shapes,
+ * per the reply type already carried on each MRReply - see MRReply_ArrayToMap. */
+static int helloReply_GetSearchModuleVersion(MRReply *hello) {
+  if (MRReply_Type(hello) != MR_REPLY_ARRAY && MRReply_Type(hello) != MR_REPLY_MAP) return -1;
+  if (MRReply_Type(hello) == MR_REPLY_ARRAY) MRReply_ArrayToMap(hello);
+
+  MRReply *modules = MRReply_MapElement(hello, "modules");
+  if (!modules || MRReply_Type(modules) != MR_REPLY_ARRAY) return -1;
+
+  for (size_t i = 0; i < MRReply_Length(modules); i++) {
+    MRReply *entry = MRReply_ArrayElement(modules, i);
+    if (!entry) continue;
+    if (MRReply_Type(entry) == MR_REPLY_ARRAY) MRReply_ArrayToMap(entry);
+    if (MRReply_Type(entry) != MR_REPLY_MAP) continue;
+
+    MRReply *name = MRReply_MapElement(entry, "name");
+    if (!name || MRReply_Type(name) != MR_REPLY_STRING ||
+        !MRReply_StringEquals(name, REDISEARCH_MODULE_NAME, false)) {
+      continue;
+    }
+    MRReply *ver = MRReply_MapElement(entry, "ver");
+    if (!ver || MRReply_Type(ver) != MR_REPLY_INTEGER) return -1;
+    return (int)MRReply_Integer(ver);
+  }
+  return -1;
+}
+
+/* HELLO reply callback: parses the shard's per-module capability advertisement
+ * (piggybacked on the RESP protocol handshake every connection already performs,
+ * see MRConn_SendCommand) and updates the owning pool's row-block belief.
+ *
+ * Any content-level failure - no `modules` field, no `search` entry, a
+ * non-integer `ver`, or an error reply - resolves capability to No via
+ * RediSearchCaps_HasRowBlock(-1), per that predicate's fail-closed contract; it
+ * is not surfaced as a connection error, since a HELLO reply's only other job
+ * (protocol negotiation) already happened synchronously in MRConn_SendCommand.
+ *
+ * A NULL reply or a hiredis-level error on the async context means the
+ * connection is tearing down; the disconnect path (MRConn_SwitchState leaving
+ * Connected) already resets the pool to Unknown, so there is nothing to update
+ * here. */
+static void MRConn_HelloCallback(redisAsyncContext *c, void *r, void *privdata) {
+  UNUSED(privdata);
+  MRConn *conn = c->data;
+  MRReply *rep = r;
+
+  if (conn && rep && !c->err) {
+    int version = helloReply_GetSearchModuleVersion(rep);
+    MRConnPool_SetRowBlockCap(conn, RediSearchCaps_HasRowBlock(version), version);
+  }
+
+  // We run with `REDIS_OPT_NOAUTOFREEREPLIES` so we need to free the reply ourselves.
+  MRReply_Free(rep);
+}
+
 /* Send a command to the connection */
 int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *privdata) {
 
@@ -277,7 +405,12 @@ int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *pri
   MRConnProtocol requiredProtocol = (MRConnProtocol)cmd->protocol;
   if (requiredProtocol != MRConn_Protocol_Undetermined && c->protocol != requiredProtocol) {
     RS_ASSERT(requiredProtocol == MRConn_Protocol_RESP2 || requiredProtocol == MRConn_Protocol_RESP3);
-    if (redisAsyncCommand(c->conn, NULL, NULL, "HELLO %d", requiredProtocol) == REDIS_ERR) {
+    // Piggyback capability discovery on the protocol handshake every connection
+    // already performs: no extra command, no extra round trip. The reply lands
+    // after this dispatch's own command (see MRConn_HelloCallback's doc comment
+    // and RediSearchCaps_HasRowBlock's callers), so up to one command per
+    // connection runs without knowing the shard's capability yet.
+    if (redisAsyncCommand(c->conn, MRConn_HelloCallback, NULL, "HELLO %d", requiredProtocol) == REDIS_ERR) {
       return REDIS_ERR;
     }
     c->protocol = requiredProtocol;
@@ -356,7 +489,7 @@ void MRConnManager_Expand(MRConnManager *m, uint32_t num, uv_loop_t *loop) {
     // There should always be at least one connection in the pool
     MREndpoint *ep = &pool->conns[0]->ep;
     for (uint32_t i = pool->num; i < num; i++) {
-      pool->conns[i] = MR_NewConn(ep, loop);
+      pool->conns[i] = MR_NewConn(ep, loop, pool);
     }
     pool->num = num;
   }
@@ -409,7 +542,15 @@ static void MRConn_SwitchState(MRConn *conn, MRConnState nextState) {
   // We reach any other state linearly from the previous one, so no timer should be active on the transition.
   RS_ASSERT(!uv_is_active((uv_handle_t *)&conn->timer) || nextState == MRConn_Reconnecting || nextState == MRConn_Freeing);
 
+  // Any connection leaving Connected invalidates the whole pool's row-block belief,
+  // not just this connection's: capability is tracked per node (see MRNodeCapState),
+  // and a stale Yes cannot be trusted once any one of the node's connections has
+  // dropped, since the process behind it may have been replaced by an older build.
+  bool wasConnected = conn->state == MRConn_Connected;
   conn->state = nextState;
+  if (wasConnected && nextState != MRConn_Connected) {
+    MRConnPool_ResetRowBlockCap(conn->pool);
+  }
   switch (nextState) {
 
     case MRConn_Reconnecting:
@@ -700,13 +841,14 @@ static void MRConn_DisconnectCallback(const redisAsyncContext *c, int status) {
  * connection attempt via SwitchState(Connecting), which dispatches the async
  * connect and falls back to Reconnecting on synchronous failure. The initial
  * Reconnecting value is just a placeholder overwritten by SwitchState. */
-static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop) {
+static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop, MRConnPool *pool) {
   MRConn *conn = rm_new(MRConn);
   *conn = (MRConn){
     .state = MRConn_Connecting,
     .conn = NULL,
     .protocol = MRConn_Protocol_Undetermined,
     .loop = loop,
+    .pool = pool,
   };
   uv_timer_init(loop, &conn->timer);
   conn->timer.data = conn;

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -88,26 +88,26 @@ struct MRConnPool {
   uint32_t num;
   uint32_t rr;  // round robin counter
   MRConn **conns;
-  // Row-block capability belief for this node (see MRNodeCapState in conn.h),
-  // learned from HELLO and reset to Unknown whenever any connection in `conns`
-  // leaves MRConn_Connected (MRConn_SwitchState). `rowBlockCapVersion` is the last
-  // `search` module version parsed from a HELLO reply, kept for diagnostics even
-  // when the capability is No; -1 means no version was ever parsed.
-  MRNodeCapState rowBlockCap;
-  int rowBlockCapVersion;
-  // Sticky defence-in-depth demotion (MRConnManager_DemoteRowBlockCap): once set,
-  // rowBlockCap reads as No regardless of any past or future HELLO reply, until
-  // this pool struct itself is replaced by a new one (endpoint change).
-  bool rowBlockDemoted;
+  // The `search` module version this node advertised in its last parsed HELLO
+  // reply, or -1 if none has been parsed yet (see conn.h's doc comment on why
+  // this single field, not a per-capability tri-state, is the source of truth).
+  // Reset to -1 whenever any connection in `conns` leaves MRConn_Connected
+  // (MRConn_SwitchState).
+  int moduleVersion;
+  // Sticky defence-in-depth demotion (MRConnManager_DemoteCapability): bit
+  // `1u << cap` set means `cap` reads as unsupported for this node regardless of
+  // any past or future HELLO reply, until this pool struct itself is replaced by
+  // a new one (endpoint change). Per capability, unlike moduleVersion, because a
+  // shard rejecting one capability's token is not evidence about another.
+  uint32_t demoted;
 };
 
-/* Reset the tri-state row-block belief to Unknown. Does not touch rowBlockDemoted:
- * a sticky demotion must survive the same invalidation trigger that resets the
- * ordinary belief, since it is evidence about a hole in the version mapping, not
+/* Reset the module version to "unknown" (-1). Does not touch `demoted`: a sticky
+ * demotion must survive the same invalidation trigger that resets the version,
+ * since it is evidence about a hole in the version-to-capability mapping, not
  * about the connection's current liveness. */
-static void MRConnPool_ResetRowBlockCap(MRConnPool *pool) {
-  pool->rowBlockCap = MRNodeCap_Unknown;
-  pool->rowBlockCapVersion = -1;
+static void MRConnPool_ResetModuleVersion(MRConnPool *pool) {
+  pool->moduleVersion = -1;
 }
 
 static MRConnPool *_MR_NewConnPool(MREndpoint *ep, uint32_t num, uv_loop_t *loop) {
@@ -116,9 +116,8 @@ static MRConnPool *_MR_NewConnPool(MREndpoint *ep, uint32_t num, uv_loop_t *loop
       .num = num,
       .rr = 0,
       .conns = rm_malloc(num * sizeof(MRConn *)),
-      .rowBlockCap = MRNodeCap_Unknown,
-      .rowBlockCapVersion = -1,
-      .rowBlockDemoted = false,
+      .moduleVersion = -1,
+      .demoted = 0,
   };
 
   /* Create the connection */
@@ -255,13 +254,22 @@ void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict) {
       array_append(stateList, rm_strdup(stateStr));
     }
 
-    // One row-block capability line per pool (not per connection - see
-    // MRNodeCapState in conn.h for why this is tracked per node).
+    // One capabilities line per pool (not per connection - see conn.h's doc
+    // comment on MRConnPool for why capability state is tracked per node).
+    // Prints the version once, then live/demoted for every registered
+    // RSCapability, so adding a capability needs no change to this format.
+    const char *nodeId = dictGetKey(entry);
     char *capStr;
-    MRNodeCapState cap = pool->rowBlockDemoted ? MRNodeCap_No : pool->rowBlockCap;
-    rm_asprintf(&capStr, "RowBlockCapability=%s(demoted=%s,version=%d)",
-               MRNodeCapState_Str(cap), pool->rowBlockDemoted ? "true" : "false",
-               pool->rowBlockCapVersion);
+    rm_asprintf(&capStr, "Capabilities(version=%d)", pool->moduleVersion);
+    for (int cap = 0; cap < RS_CAP__COUNT; cap++) {
+      bool demoted = (pool->demoted & (1u << cap)) != 0;
+      bool live = MRConnManager_NodeSupports(mgr, nodeId, (RSCapability)cap);
+      char *next;
+      rm_asprintf(&next, "%s;%s=%s(demoted=%s)", capStr, RSCapability_Name((RSCapability)cap),
+                 live ? "Yes" : "No", demoted ? "true" : "false");
+      rm_free(capStr);
+      capStr = next;
+    }
     array_append(stateList, capStr);
 
     dictSetVal(stateDict, target_entry, stateList); // Update the value in case it was reallocated
@@ -297,46 +305,46 @@ const char *MRConnManager_GetNodeState(MRConnManager *mgr, const char *id) {
   return NULL;
 }
 
-MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id,
-                                                    int *outVersion) {
+bool MRConnManager_NodeSupports(MRConnManager *mgr, const char *id, RSCapability cap) {
+  // Forced-off test/ops override wins outright: see RSForceShardCaps in config.h.
+  // It has no per-node state to consult, so it is checked before even looking `id`
+  // up - a global "treat every shard as incapable" cannot be expressed any other
+  // way and must not depend on whether `id` happens to be in the pool.
+  if (RSGlobalConfig.forceShardCapsOverride == RSForceShardCaps_No) return false;
   dictEntry *ptr = dictFind(mgr->map, id);
-  if (!ptr) {
-    if (outVersion) *outVersion = -1;
-    return MRNodeCap_Unknown;
-  }
+  if (!ptr) return false;
   MRConnPool *pool = dictGetVal(ptr);
-  if (outVersion) *outVersion = pool->rowBlockCapVersion;
-  return pool->rowBlockDemoted ? MRNodeCap_No : pool->rowBlockCap;
+  if (pool->moduleVersion < 0) return false;
+  if (pool->demoted & (1u << cap)) return false;
+  return RediSearchCaps_Supports(cap, pool->moduleVersion);
 }
 
-void MRConnManager_DemoteRowBlockCap(MRConnManager *mgr, const char *id) {
+void MRConnManager_DemoteCapability(MRConnManager *mgr, const char *id, RSCapability cap) {
   dictEntry *ptr = dictFind(mgr->map, id);
   if (!ptr) return;
   MRConnPool *pool = dictGetVal(ptr);
-  if (pool->rowBlockDemoted) return;  // already demoted; don't re-log every query
-  pool->rowBlockDemoted = true;
-  pool->rowBlockCap = MRNodeCap_No;
+  uint32_t bit = 1u << cap;
+  if (pool->demoted & bit) return;  // already demoted; don't re-log every query
+  pool->demoted |= bit;
   RedisModule_Log(RSDummyContext, "notice",
-                  "Shard %s rejected the internal row-block format after being believed "
-                  "capable of it; falling back to RESP for it until its connection pool "
-                  "is rebuilt", id);
+                  "Shard %s rejected the internal %s format after being believed capable of "
+                  "it; falling back until its connection pool is rebuilt", id,
+                  RSCapability_Name(cap));
 }
 
-/* Apply a parsed HELLO capability result to the connection's pool, logging the
- * Unknown -> Yes/No transition once (not per query, since most reconnects resolve
- * it identically to before). Skipped once the pool is sticky-demoted
- * (MRConnManager_DemoteRowBlockCap) so a benign HELLO reply cannot undo evidence
- * from an actual rejection. */
-static void MRConnPool_SetRowBlockCap(MRConn *conn, bool capable, int version) {
+/* Apply a parsed HELLO module version to the connection's pool, logging the
+ * unknown -> known transition once (not per query, since most reconnects resolve
+ * it identically to before). Does not touch `demoted`: a HELLO reply is not
+ * evidence about any specific capability the way a wire rejection is (see
+ * MRConnManager_DemoteCapability), so it must not be able to undo one. */
+static void MRConnPool_SetModuleVersion(MRConn *conn, int version) {
   MRConnPool *pool = conn->pool;
-  if (pool->rowBlockDemoted) return;
-  if (pool->rowBlockCap == MRNodeCap_Unknown) {
+  if (pool->moduleVersion < 0 && version >= 0) {
     RedisModule_Log(RSDummyContext, "notice",
-                    "Shard %s:%d row-block capability resolved to %s (module version %d)",
-                    conn->ep.host, conn->ep.port, capable ? "supported" : "unsupported", version);
+                    "Shard %s:%d module version resolved to %d", conn->ep.host, conn->ep.port,
+                    version);
   }
-  pool->rowBlockCap = capable ? MRNodeCap_Yes : MRNodeCap_No;
-  pool->rowBlockCapVersion = version;
+  pool->moduleVersion = version;
 }
 
 /* Find the `search` module entry in a HELLO reply's `modules` list and return its
@@ -369,20 +377,21 @@ static int helloReply_GetSearchModuleVersion(MRReply *hello) {
   return -1;
 }
 
-/* HELLO reply callback: parses the shard's per-module capability advertisement
+/* HELLO reply callback: parses the shard's per-module version advertisement
  * (piggybacked on the RESP protocol handshake every connection already performs,
- * see MRConn_SendCommand) and updates the owning pool's row-block belief.
+ * see MRConn_SendCommand) and updates the owning pool's module version - the
+ * single source of truth every RSCapability is decided from (RediSearchCaps_Supports).
  *
  * Any content-level failure - no `modules` field, no `search` entry, a
- * non-integer `ver`, or an error reply - resolves capability to No via
- * RediSearchCaps_HasRowBlock(-1), per that predicate's fail-closed contract; it
- * is not surfaced as a connection error, since a HELLO reply's only other job
- * (protocol negotiation) already happened synchronously in MRConn_SendCommand.
+ * non-integer `ver`, or an error reply - resolves to -1 (unknown), which every
+ * capability's fail-closed contract already treats as unsupported; it is not
+ * surfaced as a connection error, since a HELLO reply's only other job (protocol
+ * negotiation) already happened synchronously in MRConn_SendCommand.
  *
  * A NULL reply or a hiredis-level error on the async context means the
  * connection is tearing down; the disconnect path (MRConn_SwitchState leaving
- * Connected) already resets the pool to Unknown, so there is nothing to update
- * here. */
+ * Connected) already resets the pool's version to unknown, so there is nothing
+ * to update here. */
 static void MRConn_HelloCallback(redisAsyncContext *c, void *r, void *privdata) {
   UNUSED(privdata);
   MRConn *conn = c->data;
@@ -390,7 +399,7 @@ static void MRConn_HelloCallback(redisAsyncContext *c, void *r, void *privdata) 
 
   if (conn && rep && !c->err) {
     int version = helloReply_GetSearchModuleVersion(rep);
-    MRConnPool_SetRowBlockCap(conn, RediSearchCaps_HasRowBlock(version), version);
+    MRConnPool_SetModuleVersion(conn, version);
   }
 
   // We run with `REDIS_OPT_NOAUTOFREEREPLIES` so we need to free the reply ourselves.
@@ -418,8 +427,8 @@ int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *pri
     // Piggyback capability discovery on the protocol handshake every connection
     // already performs: no extra command, no extra round trip. The reply lands
     // after this dispatch's own command (see MRConn_HelloCallback's doc comment
-    // and RediSearchCaps_HasRowBlock's callers), so up to one command per
-    // connection runs without knowing the shard's capability yet.
+    // and MRConnManager_NodeSupports's callers), so up to one command per
+    // connection runs without knowing the shard's capabilities yet.
     if (redisAsyncCommand(c->conn, MRConn_HelloCallback, NULL, "HELLO %d", requiredProtocol) ==
         REDIS_ERR) {
       return REDIS_ERR;
@@ -553,14 +562,15 @@ static void MRConn_SwitchState(MRConn *conn, MRConnState nextState) {
   // We reach any other state linearly from the previous one, so no timer should be active on the transition.
   RS_ASSERT(!uv_is_active((uv_handle_t *)&conn->timer) || nextState == MRConn_Reconnecting || nextState == MRConn_Freeing);
 
-  // Any connection leaving Connected invalidates the whole pool's row-block belief,
-  // not just this connection's: capability is tracked per node (see MRNodeCapState),
-  // and a stale Yes cannot be trusted once any one of the node's connections has
-  // dropped, since the process behind it may have been replaced by an older build.
+  // Any connection leaving Connected invalidates the whole pool's module version,
+  // not just this connection's: capability is tracked per node (see conn.h's doc
+  // comment on MRConnPool), and a stale known version cannot be trusted once any
+  // one of the node's connections has dropped, since the process behind it may
+  // have been replaced by an older build.
   bool wasConnected = conn->state == MRConn_Connected;
   conn->state = nextState;
   if (wasConnected && nextState != MRConn_Connected) {
-    MRConnPool_ResetRowBlockCap(conn->pool);
+    MRConnPool_ResetModuleVersion(conn->pool);
   }
   switch (nextState) {
 

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -102,6 +102,19 @@ typedef enum {
   MRNodeCap_Yes,
 } MRNodeCapState;
 
+static inline const char *MRNodeCapState_Str(MRNodeCapState state) {
+  switch (state) {
+    case MRNodeCap_Unknown:
+      return "Unknown";
+    case MRNodeCap_No:
+      return "No";
+    case MRNodeCap_Yes:
+      return "Yes";
+    default:
+      return "<UNKNOWN CAPABILITY STATE>";
+  }
+}
+
 /* Get the row-block capability belief for the node's pool, and (for diagnostics
  * only) the last `search` module version parsed from its HELLO reply in
  * *outVersion, or -1 if none was ever parsed. outVersion may be NULL.
@@ -130,9 +143,14 @@ void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx);
 
 /*
  * Fill the state dictionary with the connection pool state.
- * The dictionary is a map of host:port strings to an array of connection states.
- * The array contains the state of each connection in the pool. The stateDict may be empty
- * or already contain information from other ConnManager
+ * The dictionary is a map of host:port strings to an array of strings: the state of
+ * each connection in the pool (see MRConnState_Str), followed by one row-block
+ * capability line for the pool as a whole (see MRNodeCapState_Str and
+ * MRConnManager_GetRowBlockCapability) - capability is tracked per node/pool, not
+ * per connection, so it appears once per pool rather than once per connection.
+ * The stateDict may be empty or already contain information from other ConnManagers
+ * (one per IO thread; a node's entries from different IO threads can disagree
+ * while a rolling capability belief is still converging).
 */
 void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict);
 

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -121,7 +121,8 @@ static inline const char *MRNodeCapState_Str(MRNodeCapState state) {
  * Returns MRNodeCap_Unknown (with *outVersion == -1) if `id` is not in the pool.
  * Must be called from the uv event loop thread that owns `mgr`, as mgr->map is
  * not thread-safe. */
-MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id, int *outVersion);
+MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id,
+                                                    int *outVersion);
 
 /* Defence in depth, on top of (not instead of) RediSearchCaps_HasRowBlock: force a
  * node's row-block capability to No, sticky until its connection pool is rebuilt

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -81,6 +81,45 @@ typedef struct {
   int nodeConns;
 } MRConnManager;
 
+/*
+ * A node's belief about whether its shard supports a given rolling-upgrade-gated
+ * capability (currently just the row-block reply format; see
+ * RediSearchCaps_HasRowBlock), learned from the `search` module version advertised
+ * in the connection's HELLO reply. Tracked per node/pool rather than per connection
+ * because the decision point (building a per-shard command at fan-out time) knows
+ * only the target node id, not which of its pool's connections will end up carrying
+ * the command - see MRConnPool_GetConn's round-robin selection.
+ *
+ * Fresh connection => Unknown. Resolved by the first parsed HELLO reply => No or
+ * Yes. Reset to Unknown whenever any connection in the pool leaves MRConn_Connected:
+ * a process cannot be replaced (rollback, restore, failover onto an older build)
+ * without dropping its connections first, so a stale Yes cannot survive one.
+ * Nothing here is persisted or survives a restart on either side.
+ */
+typedef enum {
+  MRNodeCap_Unknown,
+  MRNodeCap_No,
+  MRNodeCap_Yes,
+} MRNodeCapState;
+
+/* Get the row-block capability belief for the node's pool, and (for diagnostics
+ * only) the last `search` module version parsed from its HELLO reply in
+ * *outVersion, or -1 if none was ever parsed. outVersion may be NULL.
+ * Returns MRNodeCap_Unknown (with *outVersion == -1) if `id` is not in the pool.
+ * Must be called from the uv event loop thread that owns `mgr`, as mgr->map is
+ * not thread-safe. */
+MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id, int *outVersion);
+
+/* Defence in depth, on top of (not instead of) RediSearchCaps_HasRowBlock: force a
+ * node's row-block capability to No, sticky until its connection pool is rebuilt
+ * (i.e. its endpoint changes, see MRConnManager_Add), regardless of what any past
+ * or future HELLO reply says. Call this when a shard believed capable rejects
+ * `_ROW_BLOCK` with an unknown-argument error - evidence stronger than a version
+ * string, covering any hole in the version-to-capability mapping.
+ * No-op if `id` is not in the pool. Idempotent. Must be called from the uv event
+ * loop thread that owns `mgr`. */
+void MRConnManager_DemoteRowBlockCap(MRConnManager *mgr, const char *id);
+
 void MRConnManager_Init(MRConnManager *mgr, int nodeConns);
 
 /*

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -18,6 +18,7 @@ extern "C" {
 #include "hiredis/async.h"
 #include "endpoint.h"
 #include "command.h"
+#include "redisearch_caps.h"
 #include "util/dict.h"
 #include <uv.h>
 
@@ -82,57 +83,54 @@ typedef struct {
 } MRConnManager;
 
 /*
- * A node's belief about whether its shard supports a given rolling-upgrade-gated
- * capability (currently just the row-block reply format; see
- * RediSearchCaps_HasRowBlock), learned from the `search` module version advertised
- * in the connection's HELLO reply. Tracked per node/pool rather than per connection
- * because the decision point (building a per-shard command at fan-out time) knows
- * only the target node id, not which of its pool's connections will end up carrying
- * the command - see MRConnPool_GetConn's round-robin selection.
+ * A node's capabilities are pure functions of one piece of state: the `search`
+ * module version it advertised in its connection's HELLO reply (see
+ * RediSearchCaps_Supports), plus a per-capability sticky demotion bit. Tracked
+ * per node/pool rather than per connection because the decision point (building
+ * a per-shard command at fan-out time) knows only the target node id, not which
+ * of its pool's connections will end up carrying the command - see
+ * MRConnPool_GetConn's round-robin selection.
  *
- * Fresh connection => Unknown. Resolved by the first parsed HELLO reply => No or
- * Yes. Reset to Unknown whenever any connection in the pool leaves MRConn_Connected:
- * a process cannot be replaced (rollback, restore, failover onto an older build)
- * without dropping its connections first, so a stale Yes cannot survive one.
- * Nothing here is persisted or survives a restart on either side.
+ * "Unknown" is `moduleVersion < 0`, not a per-capability tri-state: one source of
+ * truth, so two capabilities can never disagree about whether the node has been
+ * re-probed. Fresh connection => -1. Resolved by the first parsed HELLO reply =>
+ * the parsed version (>= 0). Reset to -1 whenever any connection in the pool
+ * leaves MRConn_Connected: a process cannot be replaced (rollback, restore,
+ * failover onto an older build) without dropping its connections first, so a
+ * stale version cannot survive one. Nothing here is persisted or survives a
+ * restart on either side.
+ *
+ * `demoted`, unlike the version, stays per capability (a bitmask of
+ * `1u << RSCapability`): a shard rejecting one capability's token says nothing
+ * about another capability, so demotion cannot be folded into the single version
+ * the way "supported" can. See MRConnManager_NodeSupports for how the two combine
+ * and MRConnManager_DemoteCapability for how a bit gets set.
  */
-typedef enum {
-  MRNodeCap_Unknown,
-  MRNodeCap_No,
-  MRNodeCap_Yes,
-} MRNodeCapState;
 
-static inline const char *MRNodeCapState_Str(MRNodeCapState state) {
-  switch (state) {
-    case MRNodeCap_Unknown:
-      return "Unknown";
-    case MRNodeCap_No:
-      return "No";
-    case MRNodeCap_Yes:
-      return "Yes";
-    default:
-      return "<UNKNOWN CAPABILITY STATE>";
-  }
-}
-
-/* Get the row-block capability belief for the node's pool, and (for diagnostics
- * only) the last `search` module version parsed from its HELLO reply in
- * *outVersion, or -1 if none was ever parsed. outVersion may be NULL.
- * Returns MRNodeCap_Unknown (with *outVersion == -1) if `id` is not in the pool.
+/* Returns whether node `id` currently supports `cap`, applying (in order):
+ * 1. The `search-_force-shard-caps` config forcing every shard incapable
+ *    (RSForceShardCaps_No in config.h) - a test/ops override, evaluated first so
+ *    it can force every other rule's outcome to false without touching state.
+ * 2. `id` not in the pool, or its module version unknown (moduleVersion < 0) -
+ *    false, same as "no HELLO reply parsed yet".
+ * 3. `cap` sticky-demoted for this node (MRConnManager_DemoteCapability) - false,
+ *    regardless of what the version predicate would say.
+ * 4. Otherwise, RediSearchCaps_Supports(cap, moduleVersion).
  * Must be called from the uv event loop thread that owns `mgr`, as mgr->map is
  * not thread-safe. */
-MRNodeCapState MRConnManager_GetRowBlockCapability(MRConnManager *mgr, const char *id,
-                                                    int *outVersion);
+bool MRConnManager_NodeSupports(MRConnManager *mgr, const char *id, RSCapability cap);
 
-/* Defence in depth, on top of (not instead of) RediSearchCaps_HasRowBlock: force a
- * node's row-block capability to No, sticky until its connection pool is rebuilt
- * (i.e. its endpoint changes, see MRConnManager_Add), regardless of what any past
- * or future HELLO reply says. Call this when a shard believed capable rejects
- * `_ROW_BLOCK` with an unknown-argument error - evidence stronger than a version
- * string, covering any hole in the version-to-capability mapping.
+/* Defence in depth, on top of (not instead of) RediSearchCaps_Supports: force
+ * node `id`'s belief for `cap` to unsupported, sticky until its connection pool
+ * is rebuilt (i.e. its endpoint changes, see MRConnManager_Add), regardless of
+ * what any past or future HELLO reply says. Call this when a shard believed
+ * capable of `cap` rejects its wire token with an unknown-argument error -
+ * evidence stronger than a version string, covering any hole in the
+ * version-to-capability mapping. Demoting one capability leaves every other
+ * capability's belief for the same node untouched.
  * No-op if `id` is not in the pool. Idempotent. Must be called from the uv event
  * loop thread that owns `mgr`. */
-void MRConnManager_DemoteRowBlockCap(MRConnManager *mgr, const char *id);
+void MRConnManager_DemoteCapability(MRConnManager *mgr, const char *id, RSCapability cap);
 
 void MRConnManager_Init(MRConnManager *mgr, int nodeConns);
 
@@ -145,10 +143,11 @@ void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx);
 /*
  * Fill the state dictionary with the connection pool state.
  * The dictionary is a map of host:port strings to an array of strings: the state of
- * each connection in the pool (see MRConnState_Str), followed by one row-block
- * capability line for the pool as a whole (see MRNodeCapState_Str and
- * MRConnManager_GetRowBlockCapability) - capability is tracked per node/pool, not
- * per connection, so it appears once per pool rather than once per connection.
+ * each connection in the pool (see MRConnState_Str), followed by one capabilities
+ * line for the pool as a whole (module version plus, for every RSCapability, live
+ * vs. demoted - see MRConnManager_NodeSupports) - capability state is tracked per
+ * node/pool, not per connection, so it appears once per pool rather than once per
+ * connection.
  * The stateDict may be empty or already contain information from other ConnManagers
  * (one per IO thread; a node's entries from different IO threads can disagree
  * while a rolling capability belief is still converging).

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -762,6 +762,23 @@ bool MRIterator_AllShardsConnected(const MRIterator *it) {
   return true;
 }
 
+// Ask a single shard for the compact row-block encoding (src/aggregate/row_block.h),
+// once `cmd` already has its final `targetShard` set. Per-shard, not per-request:
+// asking a shard we don't yet know is capable of decoding the token (or which is
+// known incapable, or sticky-demoted after previously rejecting it - see
+// MRConnManager_DemoteRowBlockCap) would hard-fail that shard's whole query
+// (parseAggPlan's terminal `else` on an unrecognized argument), so an incapable or
+// Unknown shard gets no token at all, not a placeholder: even an empty argument
+// would be just as unrecognized as `_ROW_BLOCK` itself to an older build.
+static inline void maybeAskRowBlock(IORuntimeCtx *io_runtime_ctx, MRCommand *cmd) {
+  if (!RSGlobalConfig.internalRowBlockFormat) return;
+  MRNodeCapState cap =
+      MRConnManager_GetRowBlockCapability(&io_runtime_ctx->conn_mgr, cmd->targetShard, NULL);
+  if (cap == MRNodeCap_Yes) {
+    MRCommand_AppendLiteral(cmd, "_ROW_BLOCK");
+  }
+}
+
 // This function already runs in one of the IO threads. We need to make sure that the adequate RuntimeCtx is used. This info can be found in the MRIterator ctx
 void iterStartCb(void *p) {
   MRIterator *it = (MRIterator *)p;
@@ -795,24 +812,13 @@ void iterStartCb(void *p) {
     it->ctx.commandModifier(cmd, numShards, MRIterator_GetPrivateData(it));
   }
 
-  // Ask for the compact row-block encoding (src/aggregate/row_block.h) only when this
-  // coordinator wants it. Filled here, at fan-out time, rather than where the rest of the
-  // command is built (dist_aggregate.c's buildMRCommand): every shard's copy is made from
-  // `cmd` below, so appending it once here reaches every shard identically. A later commit
-  // makes this a per-shard decision driven by each shard's rolling-upgrade capability; until
-  // then this is a pure relocation of the existing config-gated behavior, appended after
-  // every other argument (including ones inserted at fixed offsets, like SLOTS and
-  // _COORD_DISPATCH_TIME) to prove a bare flag token parses correctly from any position.
-  if (RSGlobalConfig.internalRowBlockFormat) {
-    MRCommand_AppendLiteral(cmd, "_ROW_BLOCK");
-  }
-
   for (size_t targetShardIdx = 1; targetShardIdx < numShards; targetShardIdx++) {
     it->cbxs[targetShardIdx].it = it;
     it->cbxs[targetShardIdx].cmd = MRCommand_Copy(cmd);
     // Set each command to target a different shard
     it->cbxs[targetShardIdx].cmd.targetShard = rm_strdup(shards[targetShardIdx].node.id);
     MRCommand_SetSlotInfo(&it->cbxs[targetShardIdx].cmd, shards[targetShardIdx].slotRanges);
+    maybeAskRowBlock(io_runtime_ctx, &it->cbxs[targetShardIdx].cmd);
 
     it->cbxs[targetShardIdx].privateData = MRIterator_GetPrivateData(it);
   }
@@ -820,6 +826,7 @@ void iterStartCb(void *p) {
   // Set the first command to target the first shard (while not having copied it)
   cmd->targetShard = rm_strdup(shards[0].node.id);
   MRCommand_SetSlotInfo(cmd, shards[0].slotRanges);
+  maybeAskRowBlock(io_runtime_ctx, cmd);
 
   // Send commands to all shards
   for (size_t i = 0; i < numShards; i++) {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -770,12 +770,20 @@ bool MRIterator_AllShardsConnected(const MRIterator *it) {
 // (parseAggPlan's terminal `else` on an unrecognized argument), so an incapable or
 // Unknown shard gets no token at all, not a placeholder: even an empty argument
 // would be just as unrecognized as `_ROW_BLOCK` itself to an older build.
+//
+// Inserts at cmd->rowBlockArgIndex rather than appending at the current tail:
+// commands built via the FT.DEBUG wrapper (dist_aggregate.c) have their
+// DEBUG_PARAMS_COUNT block appended *after* this command was built but *before*
+// fan-out, and the shard parses that block by position from the end of the
+// command, so a tail append here would silently displace it. A command that never
+// reserved a position (rowBlockArgIndex == 0) - not built via buildMRCommand, e.g.
+// a hybrid or cursor-read command - is simply never asked.
 static inline void maybeAskRowBlock(IORuntimeCtx *io_runtime_ctx, MRCommand *cmd) {
-  if (!RSGlobalConfig.internalRowBlockFormat) return;
+  if (!RSGlobalConfig.internalRowBlockFormat || !cmd->rowBlockArgIndex) return;
   MRNodeCapState cap =
       MRConnManager_GetRowBlockCapability(&io_runtime_ctx->conn_mgr, cmd->targetShard, NULL);
   if (cap == MRNodeCap_Yes) {
-    MRCommand_AppendLiteral(cmd, "_ROW_BLOCK");
+    MRCommand_Insert(cmd, cmd->rowBlockArgIndex, "_ROW_BLOCK", sizeof("_ROW_BLOCK") - 1);
   }
 }
 

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -795,6 +795,18 @@ void iterStartCb(void *p) {
     it->ctx.commandModifier(cmd, numShards, MRIterator_GetPrivateData(it));
   }
 
+  // Ask for the compact row-block encoding (src/aggregate/row_block.h) only when this
+  // coordinator wants it. Filled here, at fan-out time, rather than where the rest of the
+  // command is built (dist_aggregate.c's buildMRCommand): every shard's copy is made from
+  // `cmd` below, so appending it once here reaches every shard identically. A later commit
+  // makes this a per-shard decision driven by each shard's rolling-upgrade capability; until
+  // then this is a pure relocation of the existing config-gated behavior, appended after
+  // every other argument (including ones inserted at fixed offsets, like SLOTS and
+  // _COORD_DISPATCH_TIME) to prove a bare flag token parses correctly from any position.
+  if (RSGlobalConfig.internalRowBlockFormat) {
+    MRCommand_AppendLiteral(cmd, "_ROW_BLOCK");
+  }
+
   for (size_t targetShardIdx = 1; targetShardIdx < numShards; targetShardIdx++) {
     it->cbxs[targetShardIdx].it = it;
     it->cbxs[targetShardIdx].cmd = MRCommand_Copy(cmd);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -764,12 +764,12 @@ bool MRIterator_AllShardsConnected(const MRIterator *it) {
 
 // Ask a single shard for the compact row-block encoding (src/aggregate/row_block.h),
 // once `cmd` already has its final `targetShard` set. Per-shard, not per-request:
-// asking a shard we don't yet know is capable of decoding the token (or which is
-// known incapable, or sticky-demoted after previously rejecting it - see
-// MRConnManager_DemoteRowBlockCap) would hard-fail that shard's whole query
-// (parseAggPlan's terminal `else` on an unrecognized argument), so an incapable or
-// Unknown shard gets no token at all, not a placeholder: even an empty argument
-// would be just as unrecognized as `_ROW_BLOCK` itself to an older build.
+// asking a shard we don't yet know supports RS_CAP_ROW_BLOCK (or which is known
+// unsupporting, or sticky-demoted after previously rejecting it - see
+// MRConnManager_DemoteCapability) would hard-fail that shard's whole query
+// (parseAggPlan's terminal `else` on an unrecognized argument), so an unsupporting
+// or not-yet-known shard gets no token at all, not a placeholder: even an empty
+// argument would be just as unrecognized as `_ROW_BLOCK` itself to an older build.
 //
 // Inserts at cmd->rowBlockArgIndex rather than appending at the current tail:
 // commands built via the FT.DEBUG wrapper (dist_aggregate.c) have their
@@ -780,9 +780,7 @@ bool MRIterator_AllShardsConnected(const MRIterator *it) {
 // a hybrid or cursor-read command - is simply never asked.
 static inline void maybeAskRowBlock(IORuntimeCtx *io_runtime_ctx, MRCommand *cmd) {
   if (!RSGlobalConfig.internalRowBlockFormat || !cmd->rowBlockArgIndex) return;
-  MRNodeCapState cap =
-      MRConnManager_GetRowBlockCapability(&io_runtime_ctx->conn_mgr, cmd->targetShard, NULL);
-  if (cap == MRNodeCap_Yes) {
+  if (MRConnManager_NodeSupports(&io_runtime_ctx->conn_mgr, cmd->targetShard, RS_CAP_ROW_BLOCK)) {
     MRCommand_Insert(cmd, cmd->rowBlockArgIndex, "_ROW_BLOCK", sizeof("_ROW_BLOCK") - 1);
   }
 }

--- a/src/redisearch_caps.c
+++ b/src/redisearch_caps.c
@@ -26,6 +26,14 @@ typedef struct {
 #define MINOR_LINE_MIN(major, minor) ((major) * 10000 + (minor) * 100)
 #define MINOR_LINE_MAX(major, minor) (MINOR_LINE_MIN((major), (minor)) + 99)
 
+// A predicate's version ranges stay per-feature (not folded into one generic
+// `>=` threshold): a later backport lands in one release line and not another,
+// and expressing that as a single threshold would either wrongly exclude the
+// backport or wrongly widen every version above the threshold. Each predicate
+// below is independently unit-testable (tests/ctests/test_redisearch_caps.c)
+// with no cluster involved.
+typedef bool (*RSCapabilityPredicate)(int moduleVersion);
+
 // Minor lines known to decode the row-block reply format (src/aggregate/row_block.h).
 //
 // The format has not shipped in a numbered release yet, so the only version known
@@ -41,12 +49,7 @@ static const CapVersionRange kRowBlockCapableRanges[] = {
     {REDISEARCH_MODULE_VERSION, REDISEARCH_MODULE_VERSION},
 };
 
-bool RediSearchCaps_HasRowBlock(int moduleVersion) {
-  // Fail closed on zero (never parsed / explicitly absent) and any negative
-  // sentinel a caller might use for "unknown".
-  if (moduleVersion <= 0) {
-    return false;
-  }
+static bool rowBlockPredicate(int moduleVersion) {
   for (size_t i = 0; i < sizeof(kRowBlockCapableRanges) / sizeof(kRowBlockCapableRanges[0]); i++) {
     if (moduleVersion >= kRowBlockCapableRanges[i].minInclusive &&
         moduleVersion <= kRowBlockCapableRanges[i].maxInclusive) {
@@ -54,4 +57,36 @@ bool RediSearchCaps_HasRowBlock(int moduleVersion) {
     }
   }
   return false;
+}
+
+// Designated-initializer table indexed by RSCapability, so a capability added to
+// the enum without a matching entry here is a zero-initialized (NULL) slot rather
+// than a silently misaligned one - RediSearchCaps_Supports treats a NULL slot as
+// "fail closed", not a crash.
+static const RSCapabilityPredicate kPredicates[RS_CAP__COUNT] = {
+    [RS_CAP_ROW_BLOCK] = rowBlockPredicate,
+};
+
+static const char *kCapabilityNames[RS_CAP__COUNT] = {
+    [RS_CAP_ROW_BLOCK] = "ROW_BLOCK",
+};
+
+const char *RSCapability_Name(RSCapability cap) {
+  if (cap < 0 || cap >= RS_CAP__COUNT || !kCapabilityNames[cap]) {
+    return "<UNKNOWN CAPABILITY>";
+  }
+  return kCapabilityNames[cap];
+}
+
+bool RediSearchCaps_Supports(RSCapability cap, int moduleVersion) {
+  // Fail closed on zero (never parsed / explicitly absent) and any negative
+  // sentinel a caller might use for "unknown" - shared by every capability so
+  // each predicate only has to express its own version ranges.
+  if (moduleVersion <= 0) {
+    return false;
+  }
+  if (cap < 0 || cap >= RS_CAP__COUNT || !kPredicates[cap]) {
+    return false;
+  }
+  return kPredicates[cap](moduleVersion);
 }

--- a/src/redisearch_caps.c
+++ b/src/redisearch_caps.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "redisearch_caps.h"
+
+#include <stddef.h>
+
+#include "version.h"
+
+// An inclusive [min, max] span of `REDISEARCH_MODULE_VERSION`-encoded versions that
+// share one minor release line, e.g. every 8.11.x patch.
+typedef struct {
+  int minInclusive;
+  int maxInclusive;
+} CapVersionRange;
+
+// Encode a `major.minor` line's version floor/ceiling using the same
+// major*10000 + minor*100 + patch scheme as REDISEARCH_MODULE_VERSION, spanning
+// every patch (0-99) of that line.
+#define MINOR_LINE_MIN(major, minor) ((major) * 10000 + (minor) * 100)
+#define MINOR_LINE_MAX(major, minor) (MINOR_LINE_MIN((major), (minor)) + 99)
+
+// Minor lines known to decode the row-block reply format (src/aggregate/row_block.h).
+//
+// The format has not shipped in a numbered release yet, so the only version known
+// to be capable today is the development sentinel every master build reports
+// (REDISEARCH_VERSION_{MAJOR,MINOR,PATCH} == 99.99.99, see version.h). When a
+// release first ships the format, add its minor line here, e.g.
+// `{MINOR_LINE_MIN(8, 11), MINOR_LINE_MAX(8, 11)}`. If the format is later
+// backported to an older line, add a second entry for that line rather than
+// widening this one's bounds — a single threshold could not express that without
+// wrongly including every unpatched version of the older line's earlier point
+// releases.
+static const CapVersionRange kRowBlockCapableRanges[] = {
+    {REDISEARCH_MODULE_VERSION, REDISEARCH_MODULE_VERSION},
+};
+
+bool RediSearchCaps_HasRowBlock(int moduleVersion) {
+  // Fail closed on zero (never parsed / explicitly absent) and any negative
+  // sentinel a caller might use for "unknown".
+  if (moduleVersion <= 0) {
+    return false;
+  }
+  for (size_t i = 0; i < sizeof(kRowBlockCapableRanges) / sizeof(kRowBlockCapableRanges[0]); i++) {
+    if (moduleVersion >= kRowBlockCapableRanges[i].minInclusive &&
+        moduleVersion <= kRowBlockCapableRanges[i].maxInclusive) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/redisearch_caps.h
+++ b/src/redisearch_caps.h
@@ -20,22 +20,37 @@ extern "C" {
 // whether to ask a shard for a feature) and, potentially, a shard-side consumer,
 // so the version-to-capability mapping cannot drift between the two sides.
 //
-// Every predicate here must fail closed: an unrecognized, unparseable, or absent
-// version resolves to `false`. Treating an incapable shard as capable is the only
-// failure mode that breaks a query outright (the shard hard-fails on an argument it
-// does not recognize); treating a capable shard as incapable only costs the
-// performance the feature would have bought.
+// The version-to-capability mapping is the only thing that varies per feature:
+// every capability is decided from the same single piece of state (the `search`
+// module version a node advertises over HELLO, see MRConnPool's moduleVersion in
+// conn.h), so the enum plus RediSearchCaps_Supports is the whole per-feature
+// surface. Everything else (learning the version, invalidating it, sticky
+// demotion) is generic and lives once in conn.c/conn.h.
+
+// One entry per internal coordinator<->shard protocol feature gated by rolling
+// upgrade. RS_CAP__COUNT is not a real capability; it is the table size and the
+// bound for `demoted` bitmask shifts (see MRConnPool in conn.h).
+typedef enum {
+  RS_CAP_ROW_BLOCK = 0,  // compact binary aggregation rows, RESP2 reply path
+  RS_CAP__COUNT
+} RSCapability;
+
+// Human-readable name for `cap`, used only for diagnostics (FT.DEBUG
+// SHARD_CONNECTION_STATES). Returns a placeholder for an out-of-range value so a
+// missing table entry shows up in the debug output instead of crashing it.
+const char *RSCapability_Name(RSCapability cap);
 
 // Returns whether a shard advertising `moduleVersion` — encoded the same way as
 // REDISEARCH_MODULE_VERSION in version.h (major*10000 + minor*100 + patch) — is
-// known to support the row-block reply format (src/aggregate/row_block.h) for
-// internal coordinator<->shard aggregation.
+// known to support `cap`.
 //
-// Ranges are expressed per minor line rather than as a single `>=` threshold: a
-// single threshold cannot express a later backport of the format to an older minor
-// line without wrongly excluding it, or without wrongly widening every version
-// above it. Add a new line's range instead of extending an existing one.
-bool RediSearchCaps_HasRowBlock(int moduleVersion);
+// Every capability must fail closed: an unrecognized, unparseable, or absent
+// version resolves to `false`, and so does a capability with no registered
+// predicate (see redisearch_caps.c). Treating an incapable shard as capable is the
+// only failure mode that breaks a query outright (the shard hard-fails on an
+// argument it does not recognize); treating a capable shard as incapable only
+// costs the performance the feature would have bought.
+bool RediSearchCaps_Supports(RSCapability cap, int moduleVersion);
 
 #ifdef __cplusplus
 }

--- a/src/redisearch_caps.h
+++ b/src/redisearch_caps.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Rolling-upgrade capability predicates for internal coordinator<->shard protocol
+// features. A single source of truth, shared by the coordinator (which decides
+// whether to ask a shard for a feature) and, potentially, a shard-side consumer,
+// so the version-to-capability mapping cannot drift between the two sides.
+//
+// Every predicate here must fail closed: an unrecognized, unparseable, or absent
+// version resolves to `false`. Treating an incapable shard as capable is the only
+// failure mode that breaks a query outright (the shard hard-fails on an argument it
+// does not recognize); treating a capable shard as incapable only costs the
+// performance the feature would have bought.
+
+// Returns whether a shard advertising `moduleVersion` — encoded the same way as
+// REDISEARCH_MODULE_VERSION in version.h (major*10000 + minor*100 + patch) — is
+// known to support the row-block reply format (src/aggregate/row_block.h) for
+// internal coordinator<->shard aggregation.
+//
+// Ranges are expressed per minor line rather than as a single `>=` threshold: a
+// single threshold cannot express a later backport of the format to an older minor
+// line without wrongly excluding it, or without wrongly widening every version
+// above it. Add a new line's range instead of extending an existing one.
+bool RediSearchCaps_HasRowBlock(int moduleVersion);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/ctests/test_redisearch_caps.c
+++ b/tests/ctests/test_redisearch_caps.c
@@ -15,39 +15,48 @@
 // today: the row-block format has not shipped in a numbered release, so master is
 // the only build known to be capable. See redisearch_caps.c for where to add a
 // real release's minor line once one ships the format.
-int testHasRowBlock_devSentinel() {
-  ASSERT(RediSearchCaps_HasRowBlock(REDISEARCH_MODULE_VERSION));
+int testRowBlock_devSentinel() {
+  ASSERT(RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, REDISEARCH_MODULE_VERSION));
   return 0;
 }
 
 // A version one below the dev sentinel's minor line must not be treated as
 // capable: ranges are per minor line, not `>=`, so this also guards against a
 // future off-by-one when a real release line is added.
-int testHasRowBlock_belowSupportedLine() {
-  ASSERT(!RediSearchCaps_HasRowBlock(REDISEARCH_MODULE_VERSION - 1));
+int testRowBlock_belowSupportedLine() {
+  ASSERT(!RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, REDISEARCH_MODULE_VERSION - 1));
   return 0;
 }
 
 // Zero is the "no version was ever parsed" sentinel used by callers (e.g. a
 // malformed or absent HELLO `ver` field); it must fail closed.
-int testHasRowBlock_zero() {
-  ASSERT(!RediSearchCaps_HasRowBlock(0));
+int testRowBlock_zero() {
+  ASSERT(!RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, 0));
   return 0;
 }
 
 // Garbage (negative, and a large value with no meaningful major/minor/patch
 // decomposition) must fail closed rather than being silently accepted by
 // integer-range arithmetic.
-int testHasRowBlock_garbage() {
-  ASSERT(!RediSearchCaps_HasRowBlock(-1));
-  ASSERT(!RediSearchCaps_HasRowBlock(-999999));
-  ASSERT(!RediSearchCaps_HasRowBlock(123456789));
+int testRowBlock_garbage() {
+  ASSERT(!RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, -1));
+  ASSERT(!RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, -999999));
+  ASSERT(!RediSearchCaps_Supports(RS_CAP_ROW_BLOCK, 123456789));
+  return 0;
+}
+
+// A capability with no registered predicate must fail closed rather than crash -
+// RS_CAP__COUNT is guaranteed to have no table entry since it is the table size,
+// not a real capability.
+int testSupports_unregisteredCapabilityFailsClosed() {
+  ASSERT(!RediSearchCaps_Supports((RSCapability)RS_CAP__COUNT, REDISEARCH_MODULE_VERSION));
   return 0;
 }
 
 TEST_MAIN({
-  TESTFUNC(testHasRowBlock_devSentinel);
-  TESTFUNC(testHasRowBlock_belowSupportedLine);
-  TESTFUNC(testHasRowBlock_zero);
-  TESTFUNC(testHasRowBlock_garbage);
+  TESTFUNC(testRowBlock_devSentinel);
+  TESTFUNC(testRowBlock_belowSupportedLine);
+  TESTFUNC(testRowBlock_zero);
+  TESTFUNC(testRowBlock_garbage);
+  TESTFUNC(testSupports_unregisteredCapabilityFailsClosed);
 })

--- a/tests/ctests/test_redisearch_caps.c
+++ b/tests/ctests/test_redisearch_caps.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "redisearch_caps.h"
+#include "version.h"
+#include "test_util.h"
+
+// The dev sentinel (99.99.99) is the only version range this predicate can verify
+// today: the row-block format has not shipped in a numbered release, so master is
+// the only build known to be capable. See redisearch_caps.c for where to add a
+// real release's minor line once one ships the format.
+int testHasRowBlock_devSentinel() {
+  ASSERT(RediSearchCaps_HasRowBlock(REDISEARCH_MODULE_VERSION));
+  return 0;
+}
+
+// A version one below the dev sentinel's minor line must not be treated as
+// capable: ranges are per minor line, not `>=`, so this also guards against a
+// future off-by-one when a real release line is added.
+int testHasRowBlock_belowSupportedLine() {
+  ASSERT(!RediSearchCaps_HasRowBlock(REDISEARCH_MODULE_VERSION - 1));
+  return 0;
+}
+
+// Zero is the "no version was ever parsed" sentinel used by callers (e.g. a
+// malformed or absent HELLO `ver` field); it must fail closed.
+int testHasRowBlock_zero() {
+  ASSERT(!RediSearchCaps_HasRowBlock(0));
+  return 0;
+}
+
+// Garbage (negative, and a large value with no meaningful major/minor/patch
+// decomposition) must fail closed rather than being silently accepted by
+// integer-range arithmetic.
+int testHasRowBlock_garbage() {
+  ASSERT(!RediSearchCaps_HasRowBlock(-1));
+  ASSERT(!RediSearchCaps_HasRowBlock(-999999));
+  ASSERT(!RediSearchCaps_HasRowBlock(123456789));
+  return 0;
+}
+
+TEST_MAIN({
+  TESTFUNC(testHasRowBlock_devSentinel);
+  TESTFUNC(testHasRowBlock_belowSupportedLine);
+  TESTFUNC(testHasRowBlock_zero);
+  TESTFUNC(testHasRowBlock_garbage);
+})

--- a/tests/pytests/test_rowblock_capability.py
+++ b/tests/pytests/test_rowblock_capability.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+# Rolling-upgrade capability negotiation for the internal coordinator<->shard
+# row-block reply format (src/aggregate/row_block.h). All tests here run in
+# cluster mode only: the format, and the negotiation that gates it, only fire on
+# the internal coordinator<->shard path (useRowBlock in aggregate_exec.c requires
+# IsInternal(req)), which a standalone server never takes.
+#
+# RLTest starts every shard in a cluster from the same modulePath, so a genuinely
+# mixed-build fleet cannot be started by the harness. `search-_simulate-legacy-shard`
+# (RSConfig.simulateLegacyShard) is the test-only knob that stands in for an older
+# build - but only halfway: it makes a shard's *argument parser* reject `_ROW_BLOCK`
+# exactly as a pre-row-block build would, but a module's version, as advertised over
+# HELLO, is fixed at RedisModule_Init and cannot be faked by a runtime config. So
+# every shard in this test fleet, simulated-legacy or not, still reports this build's
+# real (capable) version, and the coordinator's HELLO-derived belief always resolves
+# to Yes for it. That makes this knob, by construction, exercise
+# MRConnManager_DemoteRowBlockCap's defence-in-depth path (a shard believed capable
+# that rejects the token anyway - a hole in the version mapping) rather than the
+# primary version-based mechanism (RediSearchCaps_HasRowBlock correctly saying "no"
+# for a genuinely old version) - that primary mechanism has no way to be driven end
+# to end without a real older binary.
+#
+# Concretely, every "legacy" shard in this file must be asked-and-rejected, and so
+# every query's *first* encounter with a freshly-simulated shard fails (see
+# aggregate_request.c's parseAggPlan terminal `else` - an unrecognized argument
+# fails the whole query, not just that shard's share). _warm_up_demotion runs the
+# query until every simulated shard has been individually demoted, then the actual
+# test assertions run against demoted (i.e. RESP-using) shards. In production, a
+# real older shard would skip this bootstrap failure entirely: its HELLO already
+# says "no", so the coordinator never asks it in the first place. That gap between
+# what this harness can drive and what production actually does is the reason
+# test_demotion_after_unrecognized_arg exists as its own test: it is the one
+# scenario where "the first query fails, then it stops happening" is the actual
+# documented behavior, not a test-harness workaround.
+
+from common import *
+
+ROW_BLOCK_CONFIG = 'search-internal-row-block-format'
+LEGACY_SHARD_CONFIG = 'search-_simulate-legacy-shard'
+
+
+def _create_and_populate(env, n=30):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'cat', 'TAG', 'n', 'NUMERIC').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(n):
+        conn.execute_command('HSET', f'doc:{i}', 'cat', f'cat{i % 3}', 'n', i)
+    waitForIndex(env, 'idx')
+
+
+def _aggregate_grouped(env):
+    """A GROUPBY aggregation, distributed across shards and merged on the
+    coordinator - the path that carries row-block-encoded rows when the format is
+    used. SORTBY makes the row order (and so the result) deterministic regardless
+    of which shards replied in blocks vs. RESP."""
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                   'GROUPBY', '1', '@cat',
+                   'REDUCE', 'COUNT', '0', 'AS', 'count',
+                   'REDUCE', 'SUM', '1', '@n', 'AS', 'total',
+                   'SORTBY', '2', '@cat', 'ASC')
+    return [to_dict(row) for row in res[1:]]
+
+
+def _set_all_shards(env, config, value):
+    verify_command_OK_on_all_shards(env, 'CONFIG', 'SET', config, value)
+
+
+def _warm_up_demotion(env):
+    """Run the query until it stops erroring, so every shard with
+    search-_simulate-legacy-shard on has been asked-and-rejected at least once and
+    demoted (MRConnManager_DemoteRowBlockCap) - see the module docstring for why
+    this bootstrap round is unavoidable in this harness. Bounded by shardsCount:
+    each round can newly demote at most the shards that replied and errored in it,
+    so at most one round per shard should ever be needed. The final call is made
+    outside the try/except so a real regression (e.g. demotion silently not taking
+    effect) surfaces as a normal test failure instead of being swallowed here."""
+    for _ in range(env.shardsCount):
+        try:
+            _aggregate_grouped(env)
+            return
+        except Exception:
+            continue
+    _aggregate_grouped(env)
+
+
+# cat0/cat1/cat2, each holding every third doc out of 30 (n=0..29). Every test in
+# this file that reaches a result asserts it equals this same ground truth -
+# together they are scenario (6): the result is identical whether every shard
+# replied in blocks, every shard fell back to RESP, or the fleet was mixed.
+def _expected_rows():
+    return [
+        {'cat': 'cat0', 'count': '10', 'total': '135'},
+        {'cat': 'cat1', 'count': '10', 'total': '145'},
+        {'cat': 'cat2', 'count': '10', 'total': '155'},
+    ]
+
+
+@skip(cluster=False)
+def test_all_shards_capable():
+    """Scenario (1): every shard is on this build (the only one that can decode
+    row-block today) and the format is on, so the coordinator's belief resolves to
+    Yes for every shard and every shard is asked."""
+    env = Env(shardsCount=3)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+
+    # Every shard's connection pool should have resolved a Yes belief by now.
+    # Uses env's own (non-cluster-routing) connection: SHARD_CONNECTION_STATES is
+    # keyless, and the cluster-aware client can't route a keyless command on its own.
+    state = str(env.cmd(debug_cmd(), 'SHARD_CONNECTION_STATES'))
+    env.assertEqual(state.count('RowBlockCapability=Yes'), env.shardsCount,
+                     message=f"debug state: {state}")
+
+
+@skip(cluster=False)
+def test_all_shards_legacy():
+    """Scenario (2): every shard rejects `_ROW_BLOCK`. Once every shard has been
+    demoted (see module docstring), the coordinator falls back to RESP for all of
+    them and still returns correct results with no error - the fleet-wide
+    pre-upgrade case."""
+    env = Env(shardsCount=3)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+    _set_all_shards(env, LEGACY_SHARD_CONFIG, 'yes')
+
+    _warm_up_demotion(env)
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+
+
+@skip(cluster=False)
+def test_one_legacy_shard_among_many():
+    """Scenario (3): one shard out of N cannot decode the format; the rest can.
+    Once that one shard has been demoted (see module docstring), the coordinator
+    asks only the capable shards, the demoted one replies in RESP, and the merged
+    result is unaffected by the mix - the case that, without per-shard negotiation,
+    would fail the *entire* query on this one shard's unrecognized-argument error
+    (see aggregate_request.c's parseAggPlan terminal `else`), not just its own
+    share of it."""
+    env = Env(shardsCount=3)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+    env.getConnection(1).execute_command('CONFIG', 'SET', LEGACY_SHARD_CONFIG, 'yes')
+
+    _warm_up_demotion(env)
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+
+
+@skip(cluster=False)
+def test_first_query_on_fresh_connections_does_not_error():
+    """Scenario (4): a shard's capability is Unknown until its connection's HELLO
+    reply resolves it, which happens no earlier than the first command dispatched
+    on that connection. maybeAskRowBlock (rmr.c) treats Unknown exactly like No -
+    no token is sent - so this must succeed via RESP with no error, never wait for
+    or depend on the belief resolving first.
+
+    This cannot deterministically force the Unknown state from a black-box flow
+    test: RLTest establishes the coordinator's connections to every shard as part
+    of cluster setup, and some other internal command may already have resolved
+    the belief before this test's own query runs. What it does verify is that the
+    very first query issued against a fresh environment succeeds regardless of
+    the coordinator's connections' internal capability state at that point.
+    """
+    env = Env(shardsCount=3)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+
+
+@skip(cluster=False)
+def test_demotion_after_unrecognized_arg():
+    """Scenario (5): a shard that errors on `_ROW_BLOCK` despite being believed
+    capable (LEGACY_SHARD_CONFIG simulates a hole in the version mapping: this
+    shard's HELLO still advertises a capable version) is not asked again.
+
+    Unlike the other mixed-fleet tests, this one asserts the failing bootstrap
+    query directly instead of hiding it in _warm_up_demotion: "the first query
+    fails, then it stops happening" is the actual documented behavior for this
+    scenario (see MRConnManager_DemoteRowBlockCap's doc comment in conn.h), not a
+    test-harness workaround for an unfakeable HELLO version.
+    """
+    env = Env(shardsCount=2)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+    env.getConnection(1).execute_command('CONFIG', 'SET', LEGACY_SHARD_CONFIG, 'yes')
+
+    # First query: shard 1 is believed capable (its HELLO reports this build's real,
+    # capable version) but rejects the token - this query fails.
+    env.expect('FT.AGGREGATE', 'idx', '*',
+               'GROUPBY', '1', '@cat',
+               'REDUCE', 'COUNT', '0', 'AS', 'count').error()
+
+    # Subsequent queries: shard 1 has been demoted to No and is not asked again,
+    # so they succeed.
+    for _ in range(2):
+        rows = _aggregate_grouped(env)
+        env.assertEqual(rows, _expected_rows())

--- a/tests/pytests/test_rowblock_capability.py
+++ b/tests/pytests/test_rowblock_capability.py
@@ -20,9 +20,9 @@
 # every shard in this test fleet, simulated-legacy or not, still reports this build's
 # real (capable) version, and the coordinator's HELLO-derived belief always resolves
 # to Yes for it. That makes this knob, by construction, exercise
-# MRConnManager_DemoteRowBlockCap's defence-in-depth path (a shard believed capable
+# MRConnManager_DemoteCapability's defence-in-depth path (a shard believed capable
 # that rejects the token anyway - a hole in the version mapping) rather than the
-# primary version-based mechanism (RediSearchCaps_HasRowBlock correctly saying "no"
+# primary version-based mechanism (RediSearchCaps_Supports correctly saying "no"
 # for a genuinely old version) - that primary mechanism has no way to be driven end
 # to end without a real older binary.
 #
@@ -38,11 +38,19 @@
 # test_demotion_after_unrecognized_arg exists as its own test: it is the one
 # scenario where "the first query fails, then it stops happening" is the actual
 # documented behavior, not a test-harness workaround.
+#
+# That gap is closed by search-_force-shard-caps (RSConfig.forceShardCapsOverride),
+# a hidden coordinator-only config that forces MRConnManager_NodeSupports's decision
+# directly, without a HELLO round trip. test_hello_driven_capability_skips_the_ask
+# uses it to put every shard into "supports nothing" and observe the coordinator
+# skip asking them outright - the one path every other test in this file cannot
+# reach, by construction, as explained above.
 
 from common import *
 
 ROW_BLOCK_CONFIG = 'search-internal-row-block-format'
 LEGACY_SHARD_CONFIG = 'search-_simulate-legacy-shard'
+FORCE_SHARD_CAPS_CONFIG = 'search-_force-shard-caps'
 
 
 def _create_and_populate(env, n=30):
@@ -73,7 +81,7 @@ def _set_all_shards(env, config, value):
 def _warm_up_demotion(env):
     """Run the query until it stops erroring, so every shard with
     search-_simulate-legacy-shard on has been asked-and-rejected at least once and
-    demoted (MRConnManager_DemoteRowBlockCap) - see the module docstring for why
+    demoted (MRConnManager_DemoteCapability) - see the module docstring for why
     this bootstrap round is unavoidable in this harness. Bounded by shardsCount:
     each round can newly demote at most the shards that replied and errored in it,
     so at most one round per shard should ever be needed. The final call is made
@@ -116,7 +124,7 @@ def test_all_shards_capable():
     # Uses env's own (non-cluster-routing) connection: SHARD_CONNECTION_STATES is
     # keyless, and the cluster-aware client can't route a keyless command on its own.
     state = str(env.cmd(debug_cmd(), 'SHARD_CONNECTION_STATES'))
-    env.assertEqual(state.count('RowBlockCapability=Yes'), env.shardsCount,
+    env.assertEqual(state.count('ROW_BLOCK=Yes'), env.shardsCount,
                      message=f"debug state: {state}")
 
 
@@ -187,7 +195,7 @@ def test_demotion_after_unrecognized_arg():
     Unlike the other mixed-fleet tests, this one asserts the failing bootstrap
     query directly instead of hiding it in _warm_up_demotion: "the first query
     fails, then it stops happening" is the actual documented behavior for this
-    scenario (see MRConnManager_DemoteRowBlockCap's doc comment in conn.h), not a
+    scenario (see MRConnManager_DemoteCapability's doc comment in conn.h), not a
     test-harness workaround for an unfakeable HELLO version.
     """
     env = Env(shardsCount=2)
@@ -206,3 +214,64 @@ def test_demotion_after_unrecognized_arg():
     for _ in range(2):
         rows = _aggregate_grouped(env)
         env.assertEqual(rows, _expected_rows())
+
+
+@skip(cluster=False)
+def test_hello_driven_capability_skips_the_ask():
+    """Scenario (7): the coordinator's HELLO-derived belief - not just the
+    defence-in-depth demotion path exercised by every other test in this file - is
+    what decides whether to ask a shard for the row-block format at all.
+
+    Every "legacy" shard in the tests above still advertises this build's real,
+    capable version over HELLO (see the module docstring), so they can only prove
+    that a shard asked-and-rejected stops being asked again; none of them can show
+    the coordinator skipping a shard *without* asking it first.
+    search-_force-shard-caps (RSConfig.forceShardCapsOverride) closes that gap: it
+    forces the decision MRConnManager_NodeSupports makes directly, without a HELLO
+    round trip, so this test can put every genuinely capable shard into "supports
+    nothing" and observe the primary mechanism - not the fallback - decide not to
+    ask them.
+
+    The observable that tells "never asked" apart from "asked and rejected" is
+    FT.DEBUG SHARD_CONNECTION_STATES's `demoted` flag (see
+    MRConnManager_DemoteCapability): demoted is only ever set by an actual
+    asked-and-rejected round trip. ROW_BLOCK=No(demoted=false) is only reachable
+    via the config override tested here - MRConnManager_DemoteCapability always
+    sets demoted=true alongside its own No - so demoted=true anywhere in this
+    test's state would mean the override didn't stop the ask, and demoted=true
+    would mean the primary mechanism, not this test, is broken.
+    """
+    env = Env(shardsCount=3)
+    _create_and_populate(env)
+    _set_all_shards(env, ROW_BLOCK_CONFIG, 'yes')
+
+    # Resolve every shard's HELLO-derived belief first, so the override below is
+    # unambiguously *why* every shard reads No afterwards, not a coincidence with
+    # an unresolved (unknown module version) belief.
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+    state = str(env.cmd(debug_cmd(), 'SHARD_CONNECTION_STATES'))
+    env.assertEqual(state.count('ROW_BLOCK=Yes'), env.shardsCount,
+                     message=f"debug state: {state}")
+
+    _set_all_shards(env, FORCE_SHARD_CAPS_CONFIG, 'no')
+
+    # The coordinator must not ask any shard at all, so the query has to succeed
+    # entirely via RESP fan-out with no rejection anywhere.
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+
+    state = str(env.cmd(debug_cmd(), 'SHARD_CONNECTION_STATES'))
+    env.assertEqual(state.count('ROW_BLOCK=No(demoted=false)'), env.shardsCount,
+                     message=f"debug state: {state}")
+    env.assertNotContains('demoted=true', state, message=f"debug state: {state}")
+
+    # Clearing the override lets the real (capable) HELLO-derived belief show
+    # through again - the override does not permanently replace it.
+    _set_all_shards(env, FORCE_SHARD_CAPS_CONFIG, 'auto')
+    rows = _aggregate_grouped(env)
+    env.assertEqual(rows, _expected_rows())
+    state = str(env.cmd(debug_cmd(), 'SHARD_CONNECTION_STATES'))
+    env.assertEqual(state.count('ROW_BLOCK=Yes'), env.shardsCount,
+                     message=f"debug state: {state}")
+    env.assertNotContains('demoted=true', state, message=f"debug state: {state}")


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: #11292 lets a coordinator ask a shard for the compact row-block reply format with the internal `_ROW_BLOCK` argument. A shard on an older build does not know that argument and **hard-fails the whole distributed query** — one old shard out of N is enough. The only protection is that the config defaults off, with a comment telling operators not to enable it until the fleet is fully upgraded. Enabling it mid-upgrade, or rolling a single shard back while it is on, breaks every distributed `FT.AGGREGATE`.
2. Change: the coordinator learns each shard's module version and asks only shards that can answer, failing closed to the legacy reply in every unknown or degraded case. **No new command, no extra round trip, and not a single additional byte on the wire** — the version is read from the `HELLO` reply the coordinator already sends and currently discards.
3. Outcome: a mixed-version cluster degrades to the legacy format instead of failing queries, which is the prerequisite for ever enabling the format by default. No user-visible change.

#### Which additional issues this PR fixes

1. Related to MOD-17716. Makes the format safe to enable; does not close the ticket.

#### Main objects this PR modified

1. `src/redisearch_caps.{c,h}` — new: the `RSCapability` enum and `RediSearchCaps_Supports`, a pure version predicate per capability.
2. `src/coord/rmr/conn.{c,h}` — `HELLO` reply parsing, the per-node module version and demotion bitmask, invalidation on any connection dropping, and `MRConnManager_NodeSupports`.
3. `src/coord/rmr/rmr.{c,h}`, `src/coord/rmr/command.{c,h}` — the token moves to a per-shard fill at fan-out, so the decision can differ per shard.
4. `src/coord/dist_utils.c` — demotes a shard that rejects the token despite being believed capable.
5. `src/config.{c,h}` — `search-_force-shard-caps`, a hidden test-only config.
6. `tests/pytests/test_rowblock_capability.py`, `tests/ctests/test_redisearch_caps.c` — the flow and unit tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal negotiation for a default-off internal format; nothing user-visible changes. The note belongs on whichever PR enables the format.

### What a reviewer should look at first

**Why there is no probe.** The coordinator already sends `HELLO <proto>` once per connection, with a `NULL` callback — the reply is thrown away. That reply carries `modules → {name: "search", ver: <int>}`, and `ver` is `major*10000 + minor*100 + patch` (`src/version.h`). So capability detection is a matter of reading a message that is already on the wire. Verified end to end: a fresh connection starts at `MRConn_Protocol_Undetermined`, the aggregate command always carries a definite protocol (`dist_aggregate.c` sets it inline), so the condition that sends `HELLO` is always true on first use — and a reconnect resets the protocol, so a fresh `HELLO` re-learns the version. That last part is what makes invalidation work end to end rather than only in principle.

**Two things deliberately not done.**

- **`MRConn_Connected` is not gated on the capability read.** `rmr.c` validates that every shard connection is established before fan-out, so making connectivity depend on a capability read would turn a performance feature into an outage the moment that read were filtered, delayed or denied. The cost of not gating is that up to one query per connection runs on the legacy path, because `HELLO` is pipelined immediately before the first command and its reply lands after that command is dispatched. That trade is deliberate.
- **No probe is modelled on `AUTH`.** In `conn.c`, an error reply to `AUTH` moves the connection to `MRConn_ReAuth`, whose timer retries forever and never reaches `Connected`. Anything that could draw an error reply on that path would brick old shards permanently.

**Fail-closed comes from the invalidation trigger, not from where state is stored.** `MRConnManager_NodeSupports` evaluates in a fixed order — forced-off config, unknown node, `moduleVersion < 0`, capability demoted for this node, then the predicate. And `moduleVersion` is reset to `-1` whenever any connection in the pool leaves `Connected` (`MRConn_SwitchState`). A process cannot be replaced without dropping its connections, so a stale "supports blocks" belief cannot survive a rollback, a restore, a node rebuild or a failover onto an older build. The sticky demotion bitmask deliberately survives that reset, because a rejection over the wire is evidence about a hole in the version mapping rather than about the connection's liveness.

**The token is filled per shard at fan-out, not at build time.** One commit moves it with no behaviour change, before any negotiation code exists, because that was the riskiest assumption in the design — and it was right to isolate: doing it as a tail append silently broke `FT.DEBUG ... AGGREGATE ... DEBUG_PARAMS_COUNT`, which the shard parses by counting backwards from the end of the command. The token now has a remembered insertion index, tracked like the existing `slotsInfoArgIndex`.

### Adding a new negotiated capability

The layer is generic because **the version is the state, and capabilities are pure functions of it.** Per node the coordinator stores exactly two things:

```c
int      moduleVersion;   // -1 = not yet learned, from the HELLO reply
uint32_t demoted;         // bitmask: capabilities this node proved it lacks
```

`Unknown` is `moduleVersion < 0` rather than a per-feature tri-state, so two capabilities can never disagree about whether a node was re-probed. Demotion is a bitmask because a shard rejecting one token says nothing about another feature.

Adding a capability is three edits, with no new storage, accessor, invalidation path, debug field, or wire change. Taking RESP3 row blocks as the worked example:

**1.** The enum value:

```c
 typedef enum {
   RS_CAP_ROW_BLOCK = 0,      // compact binary aggregation rows, RESP2 reply path
+  RS_CAP_ROW_BLOCK_RESP3,    // ... on the RESP3 reply path
   RS_CAP__COUNT
 } RSCapability;
```

**2.** Its predicate, with its own explicit version ranges, registered in the designated-initialiser table:

```c
+static bool rowBlockResp3Predicate(int v) {
+  // Shipped in 8.12, not backported. Anything older or unknown is false.
+  return v >= MINOR_LINE_MIN(8, 12);
+}
```

Ranges stay per-capability on purpose: a backport lands in one release line and not another, so a single global threshold cannot express reality — and each predicate is unit-testable with no cluster (`tests/ctests/test_redisearch_caps.c`).

**3.** Ask at the decision site:

```c
-if (MRConnManager_NodeSupports(mgr, id, RS_CAP_ROW_BLOCK))
+RSCapability cap = resp3 ? RS_CAP_ROW_BLOCK_RESP3 : RS_CAP_ROW_BLOCK;
+if (MRConnManager_NodeSupports(mgr, id, cap))
```

That is the whole change. `NodeSupports` applies every fail-closed rule in one place, and `FT.DEBUG SHARD_CONNECTION_STATES` prints `Capabilities(version=N);ROW_BLOCK=Yes(demoted=false)` generically across `RS_CAP__COUNT`, so it needs no edit either. An unregistered or out-of-range capability returns false rather than crashing.

**Backwards compatibility is unconditional**: nothing new is sent in either direction. An older shard needs no awareness of the scheme, and an older coordinator simply never asks.

**The limit, stated so nobody is surprised by it.** A version answers "this build *can*", not "this shard *will*". That is fine for anything config-gated, since the coordinator asks and the shard decides. It would break for a **compile-time optional** capability, where a build with the feature omitted still advertises a supporting version. The extension point for that case is to have the shard advertise explicitly in a reply the coordinator already parses — the cursor-creation reply of the first `_FT.AGGREGATE` is the natural carrier, since an extra field there is ignored by an older coordinator and its absence is what an older shard produces for free. Also no new command and no extra round trip. Deliberately not built now.

### Testing

Unit tests cover each supported version line, a line below it, the unreleased-master sentinel, zero, and an unregistered capability (all fail closed).

The flow tests need a way to put the coordinator in the "this shard cannot" state, because a shard cannot be made to lie about its `HELLO` version at runtime — that is fixed at `RedisModule_Init`. Two knobs, both hidden and default-off:

- `search-_simulate-legacy-shard` makes a shard **reject** the token as an older build would, which exercises the demotion path.
- `search-_force-shard-caps=no` makes the coordinator treat shards as incapable, which exercises the primary path — the one that matters, since without it the tests would pass even with `HELLO` parsing entirely broken, as long as demotion worked.

`test_hello_driven_capability_skips_the_ask` distinguishes the two by the discriminator that separates them: demotion always sets a demoted marker, so a shard showing `ROW_BLOCK=No(demoted=false)` was **never asked** rather than asked and refused.

An earlier revision of this PR added an `FT.DEBUG ROW_BLOCK_CAPABILITY_OVERRIDE` subcommand for the same purpose. It has been reverted: a test-only need should not add command surface, and per-node addressing turned out to be unnecessary once the genuinely mixed case is covered end to end (below).

Verified in **real cluster mode** — note that `COORD=oss` selects the coordinator *build*, while `REDIS_STANDALONE=0` is what selects cluster mode, and a run with only the former is standalone and exercises none of this while still reporting a full pass:

    test_rowblock_capability.py   6/6    (REDIS_STANDALONE=0 SHARDS=3)
    test_debug_commands.py        47/47  cluster, 95/95 standalone
    C/C++ unit                    1032/1032

`test_aggregate.py::testErrorStatsResp2` fails on this branch while the droppable `BENCHMARK ONLY` commit from #11292 defaults the format on — pre-existing and documented there.

### End-to-end proof on a real mixed cluster

RediSearch's own harness cannot start a mixed-build cluster (single `modulePath` for every shard), so the real scenario is covered in Redis Enterprise by [RediSearchEnterprise#966](https://github.com/redislabsdev/RediSearchEnterprise/pull/966), pinned to this branch. Its green run shows a distributed `FT.AGGREGATE` served while the fleet was genuinely mixed, in **both** coordinator roles, which have different edge cases — a new coordinator must not ask an old shard, and an old coordinator must get a legacy reply from a new shard:

    14:09:36.021   coord=3  NEW   OK   capability: 1=old,3=new
    14:09:41.272   coord=1  OLD   OK   capability: 1=old,3=new

### Open question, not resolved here

Whether Redis Enterprise's proxy answers `HELLO` itself rather than passing it to the shard. If it does, the `modules` list could describe the proxy. The expected outcome is fail-safe — no `search` entry resolves to no capability, hence the legacy path — but this is **unverified** and needs the proxy owners. The code is written so that outcome holds; this PR does not claim Enterprise is covered.
