### PR TITLE
[MOD-18489] Skip the himport tests when the server lacks the HIMPORT command

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -783,9 +783,56 @@ def skipTestUntil(date_str, reason=None):
     """
     skip_until(date_str, reason)(lambda: None)()
 
+binary_commands = None
+def binary_has_command(name):
+    """True if `Defaults.binary` provides command `name`.
+
+    Version alone cannot answer this: a server may report a version that carries a
+    command and still be built without it, which is how the guarded test then fails.
+
+    Asks the binary the same way `server_version_is_at_least` asks it for a version,
+    so a @skip can be decided before any test env exists. `--version` cannot answer
+    this one, so this starts a throwaway server on a private unix socket — no port to
+    collide over — and asks it, caching the answer for the rest of the session.
+
+    Only the binary's own commands are visible; no module is loaded, so this cannot
+    speak for `FT.*`.
+    """
+    global binary_commands
+    if binary_commands is None:
+        import subprocess
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = os.path.join(directory, 'command-probe.sock')
+            server = subprocess.Popen(
+                [Defaults.binary, '--port', '0', '--unixsocket', socket_path,
+                 '--save', '', '--appendonly', 'no'],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            try:
+                conn = redis.Redis(unix_socket_path=socket_path, decode_responses=True)
+                # `COMMAND LIST` is a flat array of names, but redis-py parses every
+                # `COMMAND` reply as though it were `COMMAND INFO` and mangles it. This
+                # client is private to the probe, so the callback can just be dropped.
+                conn.set_response_callback('COMMAND', lambda reply: reply)
+                deadline = time.time() + 10
+                while True:
+                    try:
+                        conn.ping()
+                        break
+                    except redis.exceptions.RedisError:
+                        if time.time() > deadline or server.poll() is not None:
+                            raise
+                        time.sleep(0.05)
+                binary_commands = {str(c).lower()
+                                   for c in conn.execute_command('COMMAND', 'LIST')}
+            finally:
+                server.terminate()
+                server.wait()
+    return name.lower() in binary_commands
+
+
 def _any_skip_condition_set(*, cluster, macos, musl, asan, msan, redis_less_than,
                             redis_greater_equal, min_shards, arch, gc_no_fork,
-                            no_json, enterprise):
+                            no_json, enterprise, missing_redis_command):
     """True if the caller provided at least one skip condition.
 
     With no conditions, @skip's legacy behaviour is to always skip — used as a
@@ -793,10 +840,12 @@ def _any_skip_condition_set(*, cluster, macos, musl, asan, msan, redis_less_than
     """
     return ((cluster is not None) or macos or musl or asan or msan or redis_less_than
             or redis_greater_equal or min_shards or (arch is not None)
-            or gc_no_fork or no_json or (enterprise is not None))
+            or gc_no_fork or no_json or (enterprise is not None)
+            or (missing_redis_command is not None))
 
 
-def _skip_fires_statically(*, cluster, macos, musl, asan, msan, min_shards, arch, no_json, enterprise):
+def _skip_fires_statically(*, cluster, macos, musl, asan, msan, min_shards, arch, no_json, enterprise,
+                           missing_redis_command):
     """Evaluate the subset of @skip predicates that don't need a live Redis.
 
     Excludes redis_less_than/redis_greater_equal/gc_no_fork — those genuinely
@@ -820,6 +869,8 @@ def _skip_fires_statically(*, cluster, macos, musl, asan, msan, min_shards, arch
         return True
     if enterprise is not None and enterprise == RS_TEST_ENTERPRISE:
         return True
+    if missing_redis_command and not binary_has_command(missing_redis_command):
+        return True
     return False
 
 
@@ -838,9 +889,10 @@ def _skip_fires_at_runtime(*, redis_less_than, redis_greater_equal, gc_no_fork):
     return False
 
 
-def skip(cluster=None, macos=False, musl=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False, enterprise=None):
+def skip(cluster=None, macos=False, musl=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False, enterprise=None, missing_redis_command=None):
     static_kwargs = dict(cluster=cluster, macos=macos, musl=musl, asan=asan, msan=msan,
-                         min_shards=min_shards, arch=arch, no_json=no_json, enterprise=enterprise)
+                         min_shards=min_shards, arch=arch, no_json=no_json, enterprise=enterprise,
+                         missing_redis_command=missing_redis_command)
     runtime_kwargs = dict(redis_less_than=redis_less_than,
                           redis_greater_equal=redis_greater_equal,
                           gc_no_fork=gc_no_fork)

--- a/tests/pytests/test_himport.py
+++ b/tests/pytests/test_himport.py
@@ -46,7 +46,8 @@ def assert_document(env, index, key, title, category, price, extra):
         [1, ['title', title, 'extra', extra]])
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_indexing_and_loading(env):
     """HIMPORT notifications and module hash reads support both template encodings."""
     create_index(env)
@@ -62,7 +63,8 @@ def test_himport_indexing_and_loading(env):
             assert_document(env, 'idx', key, title, 'books', 12, extra)
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_replacement(env):
     """Replacing a hash removes old postings, including fields absent from the new fieldset."""
     create_index(env)
@@ -86,7 +88,8 @@ def test_himport_replacement(env):
             conn.execute_command('DEL', key)
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_replacement_clears_ttl(env):
     """Replacing an expiring hash clears its key TTL and replaces its search postings."""
     create_index(env)
@@ -110,7 +113,8 @@ def test_himport_replacement_clears_ttl(env):
             conn.execute_command('DEL', key)
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_hash_mutations(env):
     """Ordinary hash writes and deletions reindex template-backed documents."""
     create_index(env)
@@ -132,7 +136,8 @@ def test_himport_hash_mutations(env):
             env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([0])
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_backfill_and_reload(env):
     """Background indexing and RDB loading can read persisted template hashes."""
     cases = template_cases(env)
@@ -154,7 +159,8 @@ def test_himport_backfill_and_reload(env):
                             'books', 12, extra)
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_hash_auto_template_conversion(env):
     """HSET's opt-in conversion preserves indexing and field loading without HIMPORT."""
     create_index(env)
@@ -180,7 +186,8 @@ def test_hash_auto_template_conversion(env):
         env.cmd('CONFIG SET', *[arg for item in config.items() for arg in item])
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_himport_restore(env):
     """RESTORE, also used by HIMPORT replication, indexes template hashes and replacements."""
     create_index(env)
@@ -197,7 +204,8 @@ def test_himport_restore(env):
             conn.execute_command('DEL', 'doc:restored')
 
 
-@skip(cluster=True, redis_less_than='8.10.0')
+@skip(cluster=True, redis_less_than='8.10.0',
+      missing_redis_command='HIMPORT')
 def test_hash_template_conversion_on_rdb_load(env):
     """Converting plain hashes while loading an RDB preserves Search results."""
     create_index(env)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** the eight `test_himport` tests are guarded `redis_less_than='8.10.0'`, on the assumption that any server clearing that bar carries Redis 8.10's hash-template feature. RediSearchEnterprise's RoR suite is a counterexample — it pins a `redislabsdev/Redis` runtime beta that self-reports `v=99.99.99 sha=1c26c132` and predates the feature, so all eight fail on `unknown command 'HIMPORT'`. Because 99.99.99 is not less than 8.10.0 the guard is inert: no version threshold can express this precondition, since the version claims to be ahead of every threshold while the build is behind the feature. This currently blocks RediSearchEnterprise's automated `deps/RediSearch` bump.
2. **Change:** add a `@skip(missing_redis_command=...)` predicate that asks `Defaults.binary` what commands it has, the same way `server_version_is_at_least` asks it for a version. `--version` cannot answer this, so `binary_has_command` starts a throwaway server on a private unix socket, reads `COMMAND LIST` once (~0.13s), and caches it. The version guard stays — it is the cheaper signal and still correct for servers that version themselves honestly.
3. **Outcome:** internal-only; no user-visible surface changes. Unblocks the RediSearchEnterprise bump, and gives the suite a feature-detection guard for any case where a server's reported version does not imply the feature. Because it asks the binary rather than a live env, the predicate is *static*: a skipped `test_himport` run reports `Test Took: 0 sec` where a runtime predicate spent 3 sec provisioning envs only to discard them, and unlike the runtime predicates it is allowed on a class.

#### Which additional issues this PR fixes

1. MOD-18489

#### Main objects this PR modified

1. `binary_has_command` (`tests/pytests/common.py`) — new; probes `Defaults.binary` for its command set, cached per session.
2. `skip()` — new `missing_redis_command=` kwarg, classified with the static predicates rather than the runtime ones.
3. `_skip_fires_statically` / `_skip_fires_at_runtime` — the predicate lives in the former, so it is decided before env provisioning; the class-decoration `TypeError` therefore no longer lists it.
4. `tests/pytests/test_himport.py` — all eight guards gain `missing_redis_command='HIMPORT'`.

Two details worth knowing for reuse, documented on the helper: redis-py dispatches its response callback on the `COMMAND` container and parses every reply as `COMMAND INFO`, so on an unknown command its parser indexes into the nil entry and raises `TypeError` instead of returning something falsy — the probe drops that callback on its own private client. And no module is loaded, so the probe sees the binary's own commands only and cannot speak for `FT.*`.

**Verification.** Against a local Redis 8.10.0, which does have the command: all eight tests pass and none skip, so the predicate does not over-skip where the feature is present. Pointed at a nonexistent command it skips all eight. A class guarded on an absent command is skipped without provisioning an env; one guarded on `HIMPORT` runs.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

