### PR TITLE
[MOD-18480] Use typed dictionary lookup for RAM missing-field queries

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1851,6 +1851,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "c_trie",
+ "dict",
  "ffi",
  "field",
  "geo",

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -15,6 +15,7 @@ build_utils.workspace = true
 
 [dependencies]
 c_trie.workspace = true
+dict.workspace = true
 ffi.workspace = true
 field.workspace = true
 hidden_string.workspace = true

--- a/src/redisearch_rs/query_eval/src/nodes/missing.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/missing.rs
@@ -11,6 +11,8 @@
 
 use std::ptr::NonNull;
 
+use dict::{Dict, MissingFieldDictType};
+use hidden_string::HiddenString;
 use rqe_iterators::inverted_index::new_missing_iterator;
 
 use crate::{EvalResult, QueryEvalContext};
@@ -22,21 +24,14 @@ pub(crate) fn eval<'index>(
 ) -> Option<EvalResult<'index>> {
     let spec = ctx.spec();
 
-    // SAFETY: `spec` is valid (`QueryEvalContext::new` invariant 2), and any
-    // queryable spec has its `missing.indexes` initialised by
-    // `IndexSpec_MakeKeyless`, so the pointer is a valid dict; `fs.fieldName`
-    // is a valid `HiddenString` key, matching the C `Query_EvalMissingNode`.
-    let ii_ptr = unsafe { ffi::RS_dictFetchValue(spec.missing.indexes, fs.fieldName as *mut _) };
-
-    if ii_ptr.is_null() {
-        // There are no missing values for this field.
-        return None;
-    }
-
-    let ii_ptr: *const inverted_index::opaque::InvertedIndex = ii_ptr.cast();
-    // SAFETY: `ii_ptr` is a valid `InvertedIndex` obtained from the
-    // missing-field dict (non-null checked above).
-    let ii_ref = unsafe { &*ii_ptr };
+    // SAFETY: the query's spec owns a live missing-field dictionary created
+    // with MissingFieldDictType. Indexing finishes its rehashing before readers
+    // can access it, and query evaluation holds the spec lock.
+    let missing = unsafe { Dict::<MissingFieldDictType>::from_raw(spec.missing.indexes) };
+    // SAFETY: the query node references a schema field whose name remains valid
+    // for the lookup; HiddenString is the dictionary's key type.
+    let field_name = unsafe { HiddenString::from_raw(fs.fieldName) };
+    let ii_ref = missing.fetch(field_name)?;
 
     // `ctx.sctx()` is a live reference, so the resulting pointer is never null.
     let sctx_nn = NonNull::from(ctx.sctx());
@@ -49,7 +44,7 @@ pub(crate) fn eval<'index>(
     //    bounds (mirrors the C `Query_EvalMissingNode` using `fs->index`).
     // 3. `spec.missing.indexes` is a non-null, valid dict — initialised by
     //    `IndexSpec_MakeKeyless` for every queryable spec; it is also the dict
-    //    we just fetched `ii_ptr` from above.
+    //    we just fetched `ii_ref` from above.
     // 4. `ii_ref` uses `DocIdsOnly`/`RawDocIdsOnly` encoding: the indexer only
     //    ever stores doc-ids-only inverted indexes in `missing.indexes`.
     Some(unsafe { new_missing_iterator(ii_ref, sctx_nn, fs.index) })


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: RAM missing-field query evaluation looks up inverted indexes through the raw C dictionary API.
2. Change: Use the existing typed `Dict<MissingFieldDictType>` wrapper for that lookup. Raw pointer conversion remains at the wrapper boundary with documented safety requirements.
3. Outcome: Internal-only refactor with unchanged query behavior, providing the base for the disk missing-field work in #11362. No new mocks or tests are introduced; the 222 existing query-evaluator tests pass.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. RAM missing-field query evaluation: typed dictionary lookup.
2. `MissingFieldDictType`: reuse the existing key/value contract.
3. Query-evaluator dependencies: declare the existing workspace `dict` crate.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
